### PR TITLE
Frontend Phase 1: Type definitions and API client

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -188,12 +188,12 @@
 - `frontend/src/api/client.ts` - APIクライアント
 
 **タスク**:
-- [ ] Junction型、AngleType型、GeoJSON型定義
-- [ ] FilterParams型、AppState型定義
-- [ ] `fetchJunctions(bbox, filters)` 実装
-- [ ] `fetchJunctionById(id)` 実装
-- [ ] `fetchStats()` 実装
-- [ ] エラーハンドリング（try-catch + Error型）
+- [x] Junction型、AngleType型、GeoJSON型定義
+- [x] FilterParams型、AppState型定義
+- [x] `fetchJunctions(bbox, filters)` 実装
+- [x] `fetchJunctionById(id)` 実装
+- [x] `fetchStats()` 実装
+- [x] エラーハンドリング（try-catch + Error型）
 
 **完了条件**:
 - TypeScriptコンパイルエラーなし

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,113 @@
+import type {
+  Junction,
+  JunctionFeatureCollection,
+  Stats,
+  FilterParams,
+} from '../types';
+
+const BASE_URL = 'http://localhost:8080/api';
+
+// カスタムエラークラス
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public response?: unknown
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+// Y字路一覧を取得
+export async function fetchJunctions(
+  bbox: string,
+  filters?: Omit<FilterParams, 'bbox'>
+): Promise<JunctionFeatureCollection> {
+  try {
+    const params = new URLSearchParams({ bbox });
+
+    if (filters?.angle_type) {
+      params.append('angle_type', filters.angle_type);
+    }
+    if (filters?.min_angle_lt !== undefined) {
+      params.append('min_angle_lt', filters.min_angle_lt.toString());
+    }
+    if (filters?.min_angle_gt !== undefined) {
+      params.append('min_angle_gt', filters.min_angle_gt.toString());
+    }
+    if (filters?.limit !== undefined) {
+      params.append('limit', filters.limit.toString());
+    }
+
+    const url = `${BASE_URL}/junctions?${params.toString()}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new ApiError(
+        `Failed to fetch junctions: ${response.statusText}`,
+        response.status
+      );
+    }
+
+    const data: JunctionFeatureCollection = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    throw new ApiError(
+      `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+// 特定のY字路詳細を取得
+export async function fetchJunctionById(id: number): Promise<Junction> {
+  try {
+    const url = `${BASE_URL}/junctions/${id}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new ApiError(
+        `Failed to fetch junction: ${response.statusText}`,
+        response.status
+      );
+    }
+
+    const data: Junction = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    throw new ApiError(
+      `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+// 統計情報を取得
+export async function fetchStats(): Promise<Stats> {
+  try {
+    const url = `${BASE_URL}/stats`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new ApiError(
+        `Failed to fetch stats: ${response.statusText}`,
+        response.status
+      );
+    }
+
+    const data: Stats = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    throw new ApiError(
+      `Network error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,90 @@
+// AngleType
+export type AngleType = 'sharp' | 'even' | 'skewed' | 'normal';
+
+// Junction (単体取得時のレスポンス)
+export interface Junction {
+  id: number;
+  osm_node_id: number;
+  location: {
+    lat: number;
+    lon: number;
+  };
+  angles: [number, number, number];
+  angle_type: AngleType;
+  road_types: string[];
+  streetview_url: string;
+}
+
+// GeoJSON型定義
+export interface GeoJSONPoint {
+  type: 'Point';
+  coordinates: [number, number]; // [lon, lat]
+}
+
+export interface JunctionProperties {
+  id: number;
+  osm_node_id: number;
+  angles: [number, number, number];
+  angle_type: AngleType;
+  road_types: string[];
+  streetview_url: string;
+}
+
+export interface JunctionFeature {
+  type: 'Feature';
+  geometry: GeoJSONPoint;
+  properties: JunctionProperties;
+}
+
+export interface JunctionFeatureCollection {
+  type: 'FeatureCollection';
+  features: JunctionFeature[];
+  total_count: number;
+}
+
+// 統計情報
+export interface Stats {
+  total_count: number;
+  by_type: {
+    sharp: number;
+    even: number;
+    skewed: number;
+    normal: number;
+  };
+}
+
+// フィルタパラメータ
+export interface FilterParams {
+  bbox?: string; // "min_lon,min_lat,max_lon,max_lat"
+  angle_type?: AngleType;
+  min_angle_lt?: number;
+  min_angle_gt?: number;
+  limit?: number;
+}
+
+// 地図のbounds
+export interface LatLngBounds {
+  north: number;
+  south: number;
+  east: number;
+  west: number;
+}
+
+// アプリケーション状態
+export interface AppState {
+  // 地図状態
+  bounds: LatLngBounds | null;
+  zoom: number;
+
+  // フィルタ条件
+  filters: {
+    angleTypes: AngleType[];
+    minAngleLt: number | null;
+    minAngleGt: number | null;
+  };
+
+  // データ
+  junctions: Junction[];
+  isLoading: boolean;
+  totalCount: number;
+}


### PR DESCRIPTION
## Summary

Implements Frontend Phase 1 as defined in `doc/todo.md`:
- TypeScript type definitions for Y-junction data structures
- API client functions for backend communication
- Error handling with try-catch pattern

## Changes

### New Files
- `frontend/src/types/index.ts` - Core type definitions
  - `Junction`, `AngleType`, `GeoJSON` types
  - `FilterParams`, `AppState` types
- `frontend/src/api/client.ts` - API client implementation
  - `fetchJunctions(bbox, filters)` - Fetch Y-junctions list
  - `fetchJunctionById(id)` - Fetch single junction details
  - `fetchStats()` - Fetch statistics
  - `ApiError` class for error handling

### Updated Files
- `doc/todo.md` - Marked Frontend Phase 1 tasks as completed

## Test Plan
- [x] TypeScript compilation succeeds with no errors
- [x] All type definitions match API specification from `doc/mvp-requirements.md`
- [x] API client functions have proper error handling
- [x] Build completes successfully (`npm run build`)

## Completion Status
All Phase 1 tasks completed:
- [x] Junction型、AngleType型、GeoJSON型定義
- [x] FilterParams型、AppState型定義
- [x] `fetchJunctions(bbox, filters)` 実装
- [x] `fetchJunctionById(id)` 実装
- [x] `fetchStats()` 実装
- [x] エラーハンドリング（try-catch + Error型）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Established foundation for junction data fetching and management with support for querying by location, ID, and various filters (angle type, angle measurements).
  * Added statistics viewing capability to display junction data distribution.
  * Implemented error handling for API operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->