### PR TITLE
Frontend Phase 5: Remove road_types from UI

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -424,6 +424,39 @@
 
 ---
 
+### Phase 5: road_typesの削除 ✅
+
+**ゴール**: フロントエンドからroad_types（道路タイプ）の表示・処理を削除
+
+**背景**:
+- 現在の実装ではJunctionPopupでroad_typesを表示しているが、この情報が不要であることが判明
+- データの簡素化とUIの見やすさを向上させるため、road_types関連の機能を削除する
+
+**成果物**:
+- `frontend/src/types/index.ts` - 型定義修正
+- `frontend/src/components/JunctionPopup.tsx` - road_types表示削除
+- `frontend/src/hooks/useJunctions.ts` - モックデータ修正
+
+**タスク**:
+- [x] Junction型からroad_typesフィールドを削除
+- [x] JunctionPopupコンポーネントからroad_types表示を削除
+- [x] 関連するCSSスタイルの削除（該当する場合）
+- [x] 型エラーがないことを確認（`npm run typecheck`）
+
+**完了条件**:
+- ✅ Junction型にroad_typesが含まれていない（types/index.ts:14, 28）
+- ✅ ポップアップにroad_typesが表示されない（JunctionPopup.tsx:32-42削除済み）
+- ✅ TypeScriptの型チェックが通る（`npm run typecheck`成功）
+- ⚠️ 実際にブラウザで表示して動作確認（次のステップ）
+
+**実装メモ**:
+- JunctionとJunctionProperties両方の型定義からroad_typesを削除
+- JunctionPopupから道路タイプセクション全体を削除
+- useJunctionsフックのモックデータからもroad_typesを削除（3箇所）
+- CSS削除は不要（インラインスタイルのみ使用）
+
+---
+
 ## 🔗 統合・テスト・デプロイ
 
 ### Phase: エンドツーエンド動作確認

--- a/frontend/src/components/JunctionPopup.tsx
+++ b/frontend/src/components/JunctionPopup.tsx
@@ -12,7 +12,7 @@ const ANGLE_TYPE_LABELS: Record<string, string> = {
 };
 
 export function JunctionPopup({ properties }: JunctionPopupProps) {
-  const { angles, angle_type, road_types, streetview_url } = properties;
+  const { angles, angle_type, streetview_url } = properties;
 
   return (
     <div style={{ minWidth: 200 }}>
@@ -26,18 +26,6 @@ export function JunctionPopup({ properties }: JunctionPopupProps) {
           <div>
             <strong>角度:</strong> {angles[0]}°, {angles[1]}°, {angles[2]}°
           </div>
-        </div>
-      </div>
-
-      {/* 道路タイプ */}
-      <div style={{ marginBottom: 12 }}>
-        <h4 style={{ margin: 0, marginBottom: 8, fontSize: 14, fontWeight: 600 }}>道路タイプ</h4>
-        <div style={{ fontSize: 13 }}>
-          {road_types.map((type, i) => (
-            <div key={i}>
-              {i + 1}. {type}
-            </div>
-          ))}
         </div>
       </div>
 

--- a/frontend/src/hooks/useJunctions.ts
+++ b/frontend/src/hooks/useJunctions.ts
@@ -17,7 +17,6 @@ const MOCK_DATA: JunctionFeatureCollection = {
         osm_node_id: 1001,
         angles: [45, 135, 180],
         angle_type: 'sharp',
-        road_types: ['residential', 'residential', 'tertiary'],
         streetview_url:
           'https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=35.6812,139.7671',
       },
@@ -33,7 +32,6 @@ const MOCK_DATA: JunctionFeatureCollection = {
         osm_node_id: 1002,
         angles: [110, 120, 130],
         angle_type: 'even',
-        road_types: ['primary', 'secondary', 'tertiary'],
         streetview_url:
           'https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=35.682,139.770',
       },
@@ -49,7 +47,6 @@ const MOCK_DATA: JunctionFeatureCollection = {
         osm_node_id: 1003,
         angles: [30, 100, 230],
         angle_type: 'skewed',
-        road_types: ['residential', 'unclassified', 'living_street'],
         streetview_url:
           'https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=35.680,139.765',
       },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,7 +11,6 @@ export interface Junction {
   };
   angles: [number, number, number];
   angle_type: AngleType;
-  road_types: string[];
   streetview_url: string;
 }
 
@@ -26,7 +25,6 @@ export interface JunctionProperties {
   osm_node_id: number;
   angles: [number, number, number];
   angle_type: AngleType;
-  road_types: string[];
   streetview_url: string;
 }
 


### PR DESCRIPTION
## Summary

- Remove `road_types` field from frontend type definitions (`Junction` and `JunctionProperties`)
- Remove road types display section from `JunctionPopup` component
- Update mock data in `useJunctions` hook to remove `road_types`

This simplifies the UI and focuses on the essential Y-junction information (angles and type).

## Test plan

- [x] TypeScript type checking passes (`npm run typecheck`)
- [x] ESLint and Prettier checks pass (pre-commit hook)
- [ ] Verify popup displays correctly without road types section
- [ ] Check that map markers and filtering still work as expected
- [ ] Test with both mock data and real API data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 5 planning documentation with detailed implementation roadmap and completion criteria.

* **Refactor**
  * Removed road_types property from junction data models and interface definitions.
  * Removed road_types display from junction details popup.
  * Updated mock data to reflect structural changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->