### PR TITLE
docs: Add mise trust to worktree setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,15 @@ cd y-junctions
 # worktree作成時の自動セットアップを有効化
 git gtr config add gtr.hook.postCreate "npm install"
 git gtr config add gtr.hook.postCreate "cd frontend && npm install"
+git gtr config add gtr.hook.postCreate "mise trust"
 
 # 設定確認
 git config --get-all gtr.hook.postCreate
 ```
 
-この設定により、`git gtr new <branch>` で新しいworktreeを作成すると、自動的に必要な依存関係（husky, lint-staged, フロントエンド開発ツール）がインストールされます。
+この設定により、`git gtr new <branch>` で新しいworktreeを作成すると、自動的に以下が実行されます：
+- 必要な依存関係（husky, lint-staged, フロントエンド開発ツール）のインストール
+- mise設定ファイル（.mise.toml）の自動trust（worktree間のcd移動時のエラー回避）
 
 #### 3. 環境変数の設定
 


### PR DESCRIPTION
## Summary

- Git worktree作成時に自動的に`mise trust`を実行するよう設定を追加
- READMEに設定手順を記載

## 背景

worktreeディレクトリにcdすると、`.mise.toml`が信頼されていないためエラーが発生していた：

```
mise ERROR error parsing config file: ~/code/y-junctions-worktrees/street-view/.mise.toml
mise ERROR Config files in ~/code/y-junctions-worktrees/street-view/.mise.toml are not trusted.
```

## 変更内容

1. `git gtr config add gtr.hook.postCreate "mise trust"` をgit設定に追加
2. READMEのworktree設定セクションに以下を追加：
   - `mise trust`コマンドの追加
   - 自動trustの説明

## Test plan

- [x] git configに`gtr.hook.postcreate`が正しく設定されている
- [x] READMEの記載が明確である

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic mise configuration file trust is now performed when creating new branches, preventing errors and friction during worktree transitions.

* **Documentation**
  * Updated README to document the automatic dependency installation and mise configuration file trust process that now runs during new branch creation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->