### PR TITLE
fix: Add rustls feature to sqlx-cli for TLS support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Install sqlx-cli
-        run: cargo install sqlx-cli --no-default-features --features postgres
+        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
 
       - name: Run database migrations
         run: sqlx migrate run
@@ -151,7 +151,7 @@ jobs:
           key: ${{ runner.os }}-sqlx-cli
 
       - name: Install SQLx CLI
-        run: cargo install sqlx-cli --no-default-features --features postgres
+        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
 
       - name: Run database migrations
         working-directory: backend


### PR DESCRIPTION
## 問題

バックエンドのデプロイが失敗していました：

```
error: TLS upgrade required by connect options but SQLx was built without TLS support enabled
```

## 原因

`sqlx-cli` のインストール時に TLS 機能が有効化されていませんでした。Neon Database は TLS 接続が必須ですが、現在のインストールコマンドは `--features postgres` のみで、TLS 機能が含まれていません。

## 修正内容

`sqlx-cli` のインストール時に `rustls` 機能を追加：

```bash
cargo install sqlx-cli --no-default-features --features postgres,rustls
```

### 変更箇所

- `.github/workflows/deploy.yml` の2箇所：
  - backend-test ジョブ（line 63）
  - backend-deploy ジョブ（line 154）

## テスト

マイグレーション実行とバックエンドデプロイが正常に完了することを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include rustls for enhanced TLS support during backend deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->