### PR TITLE
Add copyright footer to frontend

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15,10 +15,9 @@ body {
 
 /* アプリケーション全体のレイアウト */
 .app {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 }
 
 /* ヘッダー */
@@ -55,6 +54,7 @@ body {
   display: flex;
   overflow: hidden;
   position: relative;
+  min-height: 0;
 }
 
 /* サイドバー */
@@ -256,6 +256,30 @@ body {
 
 .marker-warning-icon {
   font-size: 18px;
+}
+
+/* フッター */
+.app-footer {
+  padding: 8px 20px;
+  background: #f8f9fa;
+  color: #999;
+  text-align: center;
+  font-size: 11px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.app-footer p {
+  margin: 0;
+}
+
+.app-footer a {
+  color: #999;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.app-footer a:hover {
+  color: #666;
 }
 
 /* レスポンシブ対応 */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -79,6 +79,16 @@ function App() {
           />
         </div>
       </main>
+
+      {/* フッター */}
+      <footer className="app-footer">
+        <p>
+          © 2025 Y字路マップ | Created by{' '}
+          <a href="https://x.com/coozy_corner" target="_blank" rel="noopener noreferrer">
+            @coozy_corner
+          </a>
+        </p>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add copyright footer to the application
- Include link to @coozy_corner Twitter account
- Use subtle design with gray color scheme for minimal visual impact

## Changes
- Added footer component to App.tsx
- Added footer styles to App.css
- Adjusted app layout to accommodate footer (min-height instead of fixed height)

## Test plan
- ✅ All frontend checks passed (tests, typecheck, format, lint)
- ✅ Verified footer displays correctly on localhost
- ✅ Confirmed subtle, non-intrusive design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app footer displaying copyright information and attribution to the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->