### PR TITLE
fix: Add Cloud Build staging bucket access permission

### DIFF
--- a/terraform/github-actions.tf
+++ b/terraform/github-actions.tf
@@ -75,3 +75,10 @@ resource "google_service_account_iam_member" "workload_identity_binding" {
 
   depends_on = [google_project_service.iamcredentials]
 }
+
+# Grant access to Cloud Build staging bucket
+resource "google_storage_bucket_iam_member" "cloudbuild_bucket_access" {
+  bucket = "${var.project_id}_cloudbuild"
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.github_actions_deployer.email}"
+}


### PR DESCRIPTION
## 問題

バックエンドのデプロイが失敗していました：

```
ERROR: The user is forbidden from accessing the bucket [y-junctions-prod_cloudbuild]
```

## 原因

GitHub Actions サービスアカウントに Cloud Build staging bucket (`y-junctions-prod_cloudbuild`) へのアクセス権限がありませんでした。

`gcloud builds submit` コマンドは、ソースコードを Cloud Build staging bucket にアップロードしてからビルドを実行するため、このバケットへのアクセス権が必要です。

## 修正内容

terraform で Cloud Build staging bucket への IAM binding を追加：

```hcl
resource "google_storage_bucket_iam_member" "cloudbuild_bucket_access" {
  bucket = "${var.project_id}_cloudbuild"
  role   = "roles/storage.objectAdmin"
  member = "serviceAccount:${google_service_account.github_actions_deployer.email}"
}
```

この変更により、GitHub Actions サービスアカウントが Cloud Build staging bucket に対して読み書きできるようになります。

## 変更ファイル

- `terraform/github-actions.tf` - Cloud Build bucket IAM binding 追加

## デプロイ

terraform apply により権限が適用済みです。

## テスト

バックエンドのビルドとデプロイが正常に完了することを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions deployment permissions to enable proper access to Cloud Build resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->