### PR TITLE
fix: Use cloudbuild.builds.builder role for comprehensive permissions

### DIFF
--- a/terraform/github-actions.tf
+++ b/terraform/github-actions.tf
@@ -54,7 +54,7 @@ resource "google_service_account" "github_actions_deployer" {
 locals {
   github_actions_roles = toset([
     "roles/run.admin",
-    "roles/cloudbuild.builds.editor",
+    "roles/cloudbuild.builds.builder",
     "roles/storage.objectAdmin",
   ])
 }


### PR DESCRIPTION
## 問題

バックエンドのデプロイが失敗していました：

```
ERROR: The user is forbidden from accessing the bucket [***_cloudbuild]
```

## 原因

`roles/cloudbuild.builds.editor` には Cloud Build staging bucket へのアクセスに必要な storage 権限が含まれていませんでした。

## 修正内容

IAM ロールを `roles/cloudbuild.builds.editor` から `roles/cloudbuild.builds.builder` に変更しました。

### `roles/cloudbuild.builds.builder` に含まれる権限

- **Cloud Build 操作**: builds.create, builds.get, builds.list, builds.update
- **Storage 権限**: objects.create, objects.delete, objects.get, objects.list, objects.update
- **Artifact Registry 権限**: uploadArtifacts, downloadArtifacts, その他 Docker イメージ操作

このロールは Cloud Build サービスアカウント用の標準的なロールで、`gcloud builds submit` に必要なすべての権限が含まれています。

## 変更ファイル

- `terraform/github-actions.tf` - IAM ロールを builds.builder に変更

## デプロイ

terraform apply により権限が適用済みです。

## テスト

バックエンドのビルドとデプロイが正常に完了することを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions service account permissions for improved access control and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->