### PR TITLE
fix: Add --no-service-account to Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,6 +182,7 @@ jobs:
             --region ${{ secrets.GCP_REGION }} \
             --platform managed \
             --allow-unauthenticated \
+            --no-service-account \
             --set-env-vars DATABASE_URL="${{ secrets.DATABASE_URL }}",RUST_LOG=info \
             --memory 512Mi \
             --cpu 1 \


### PR DESCRIPTION
## 問題

Cloud Runデプロイ時に以下のエラーが発生：
```
PERMISSION_DENIED: Permission 'iam.serviceaccounts.actAs' denied on service account 1046195691426-compute@developer.gserviceaccount.com
```

## 原因

`gcloud run deploy`コマンドでサービスアカウントを指定していなかったため、デフォルトのCompute Engineサービスアカウントを使おうとしていた。GitHub Actionsのサービスアカウントはそのサービスアカウントとして動作する権限を持っていない。

## 修正内容

Cloud Runデプロイコマンドに`--no-service-account`フラグを追加。

バックエンドアプリケーションは：
- Neon Database（外部）のみに接続（DATABASE_URL経由）
- GCPサービスへのアクセスが不要
- サービスアカウント認証は不要

## テスト

- [ ] GitHub Actions CI/CDが成功する
- [ ] Cloud Runサービスが正常にデプロイされる
- [ ] ヘルスチェックがパスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment configuration on Cloud Run.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->