### PR TITLE
fix: Add dedicated Cloud Run runtime service account

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,7 +182,7 @@ jobs:
             --region ${{ secrets.GCP_REGION }} \
             --platform managed \
             --allow-unauthenticated \
-            --no-service-account \
+            --service-account cloud-run-runtime@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --set-env-vars DATABASE_URL="${{ secrets.DATABASE_URL }}",RUST_LOG=info \
             --memory 512Mi \
             --cpu 1 \

--- a/terraform/github-actions.tf
+++ b/terraform/github-actions.tf
@@ -75,3 +75,22 @@ resource "google_service_account_iam_member" "workload_identity_binding" {
 
   depends_on = [google_project_service.iamcredentials]
 }
+
+# Cloud Run Runtime Service Account
+resource "google_service_account" "cloud_run_runtime" {
+  project      = var.project_id
+  account_id   = "cloud-run-runtime"
+  display_name = "Cloud Run Runtime"
+  description  = "Service account for Cloud Run services runtime"
+
+  depends_on = [google_project_service.iam]
+}
+
+# Allow GitHub Actions to use Cloud Run Runtime Service Account
+resource "google_service_account_iam_member" "github_actions_can_use_runtime_sa" {
+  service_account_id = google_service_account.cloud_run_runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_actions_deployer.email}"
+
+  depends_on = [google_project_service.iamcredentials]
+}


### PR DESCRIPTION
## 問題

Cloud Run デプロイ時の2つのエラーを修正：

1. **無効なフラグエラー**
   ```
   ERROR: unrecognized arguments: --no-service-account
   ```

2. **権限エラー**
   ```
   PERMISSION_DENIED: Permission 'iam.serviceaccounts.actAs' denied
   ```

## 修正内容

### Terraform
- Cloud Run 専用のサービスアカウント `cloud-run-runtime` を作成
- GitHub Actions SA に `roles/iam.serviceAccountUser` 権限を付与

### GitHub Actions Workflow  
- 無効な `--no-service-account` フラグを削除
- 正しい `--service-account` フラグで専用 SA を指定

## ベストプラクティス

Compute Engine デフォルト SA ではなく、専用 SA を使用することで：
- ✅ 最小権限の原則に従う
- ✅ セキュリティが向上
- ✅ GCP 推奨の構成

## デプロイ済み

- ✅ terraform apply 完了
- ✅ サービスアカウント作成済み
- ✅ IAM 権限設定済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure to use proper service account authentication for Cloud Run services, replacing the previous authentication method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->