### PR TITLE
fix: Cloud Run deployment fixes (service account + cache)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,12 +145,14 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Cache SQLx CLI
+        id: cache-sqlx
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/sqlx
           key: ${{ runner.os }}-sqlx-cli
 
       - name: Install SQLx CLI
+        if: steps.cache-sqlx.outputs.cache-hit != 'true'
         run: cargo install sqlx-cli --no-default-features --features postgres,rustls
 
       - name: Run database migrations


### PR DESCRIPTION
## 修正内容

### 1. Cloud Run 専用サービスアカウント

**問題:**
- 無効な `--no-service-account` フラグ使用
- `iam.serviceaccounts.actAs` 権限不足

**修正:**
- Terraform で `cloud-run-runtime` SA 作成
- GitHub Actions に適切な IAM 権限付与
- ワークフローで正しい `--service-account` フラグ使用

### 2. SQLx CLI キャッシュ改善

**問題:**
```
error: binary already exists in destination
```

**修正:**
- キャッシュヒット時は install ステップをスキップ
- 公式 actions/cache の推奨パターン使用

### 3. Cargo.lock 追加

Rust アプリケーションの再現可能なビルドのため、Cargo.lock をバージョン管理に追加

## デプロイ状況

- ✅ terraform apply 完了
- ✅ サービスアカウント作成済み
- ✅ IAM 権限設定済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend deployment workflow efficiency by implementing optimized build dependency caching, reducing overall deployment time across deploy paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->