### PR TITLE
fix: Complete deployment and cache fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo dependencies
+        id: cache-cargo-test
         uses: actions/cache@v4
         with:
           path: |
@@ -60,6 +61,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Install sqlx-cli
+        if: steps.cache-cargo-test.outputs.cache-hit != 'true'
         run: cargo install sqlx-cli --no-default-features --features postgres,rustls
 
       - name: Run database migrations


### PR DESCRIPTION
## 変更内容

`.github/workflows/deploy.yml` の `backend-test` ジョブで、sqlx-cliのキャッシュが有効な場合にインストールをスキップするよう修正。

## 変更ファイル

- `.github/workflows/deploy.yml` (2行追加)
  - 50行目: Cache Cargo dependencies ステップに `id: cache-cargo-test` を追加
  - 64行目: Install sqlx-cli ステップに `if: steps.cache-cargo-test.outputs.cache-hit != 'true'` を追加