### PR TITLE
fix: Remove unsupported execution_mode from Terraform Cloud config

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,9 +7,6 @@ terraform {
     workspaces {
       name = "y-junctions-prod"
     }
-
-    # Locally run operations with remote state
-    execution_mode = "local"
   }
 
   required_providers {


### PR DESCRIPTION
## Summary
Removes the unsupported `execution_mode` parameter from Terraform Cloud configuration.

## Changes
- Removed `execution_mode = "local"` from `terraform/versions.tf`

## Background
The `execution_mode` parameter is not supported in the Terraform Cloud block and was causing initialization errors.

## Related
- Updates GitHub Secret `BACKEND_URL` to correct value
- Enables proper frontend deployment with correct API endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Terraform Cloud configuration to align with default execution settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->