### PR TITLE
feat: Remove skewed (direct branch) angle type from filters

### DIFF
--- a/backend/src/api/handlers.rs
+++ b/backend/src/api/handlers.rs
@@ -89,7 +89,6 @@ impl JunctionsQuery {
                 .map(|s| match s.trim() {
                     "verysharp" => Ok(AngleType::VerySharp),
                     "sharp" => Ok(AngleType::Sharp),
-                    "skewed" => Ok(AngleType::Skewed),
                     "normal" => Ok(AngleType::Normal),
                     _ => Err(AppError::BadRequest("Invalid angle_type")),
                 })

--- a/backend/src/db/repository.rs
+++ b/backend/src/db/repository.rs
@@ -96,16 +96,13 @@ fn add_angle_type_filter(builder: &mut QueryBuilder<sqlx::Postgres>, angle_types
         }
         match angle_type {
             AngleType::VerySharp => {
-                builder.push("(angle_1 < 30 AND angle_3 <= 200)");
+                builder.push("angle_1 < 30");
             }
             AngleType::Sharp => {
-                builder.push("(angle_1 >= 30 AND angle_1 < 45 AND angle_3 <= 200)");
-            }
-            AngleType::Skewed => {
-                builder.push("angle_3 > 200");
+                builder.push("(angle_1 >= 30 AND angle_1 < 45)");
             }
             AngleType::Normal => {
-                builder.push("(angle_1 >= 45 AND angle_3 <= 200)");
+                builder.push("angle_1 >= 45");
             }
         }
     }
@@ -192,7 +189,6 @@ pub async fn count_by_type(pool: &PgPool) -> Result<HashMap<String, i64>, sqlx::
     let rows: Vec<(String, i64)> = sqlx::query_as(
         "SELECT \
            CASE \
-             WHEN angle_3 > 200 THEN 'skewed' \
              WHEN angle_1 < 30 THEN 'verysharp' \
              WHEN angle_1 < 45 THEN 'sharp' \
              ELSE 'normal' \

--- a/backend/src/domain/junction.rs
+++ b/backend/src/domain/junction.rs
@@ -6,15 +6,12 @@ use serde::{Deserialize, Serialize};
 pub enum AngleType {
     VerySharp,
     Sharp,
-    Skewed,
     Normal,
 }
 
 impl AngleType {
-    pub fn from_angles(angle_1: i16, _angle_2: i16, angle_3: i16) -> Self {
-        if angle_3 > 200 {
-            Self::Skewed
-        } else if angle_1 < 30 {
+    pub fn from_angles(angle_1: i16, _angle_2: i16, _angle_3: i16) -> Self {
+        if angle_1 < 30 {
             Self::VerySharp
         } else if angle_1 < 45 {
             Self::Sharp
@@ -140,13 +137,6 @@ mod tests {
         // angle_1 < 30 AND angle_3 <= 200
         let angle_type = AngleType::from_angles(25, 120, 180);
         assert_eq!(angle_type, AngleType::VerySharp);
-    }
-
-    #[test]
-    fn test_angle_type_skewed() {
-        // angle_3 > 200
-        let angle_type = AngleType::from_angles(50, 100, 210);
-        assert_eq!(angle_type, AngleType::Skewed);
     }
 
     #[test]

--- a/doc/todo.md
+++ b/doc/todo.md
@@ -69,7 +69,7 @@
 **タスク**:
 - [x] geo crateで方位角（bearing）計算
 - [x] 3方向の角度を算出・昇順ソート
-- [x] angle_type分類ロジック（sharp/even/skewed/normal）
+- [x] angle_type分類ロジック（verysharp/sharp/normal）
 - [x] Junction構造体定義（osm_node_id, location, angles, road_types）
 
 **完了条件**:
@@ -374,8 +374,8 @@
 
 **タスク**:
 - [x] FilterPanel実装
-  - angle_typeチェックボックス（sharp/even/skewed/normal）
-  - min_angleスライダー（0-180°）
+  - angle_typeチェックボックス（verysharp/sharp/normal）
+  - min_angleスライダー（0-60°）
   - フィルタリセットボタン
 - [x] JunctionPopup実装
   - 角度表示
@@ -426,7 +426,7 @@
 **実装メモ**:
 - App.cssでスタイルを整理（インラインスタイルから移行）
 - モバイルでサイドバーをトグル可能に実装
-- 角度タイプラベルを直感的な名前に変更（鋭角、三叉路、直線分岐、中間）
+- 角度タイプラベルを直感的な名前に変更（超鋭角、鋭角、中間）
 - マーカー色を最小角度でグラデーション化（青→水色→黄緑→赤）
 - 最小角度フィルターをレンジスライダーに改善
 - Street View URLを新しいAPI形式に修正
@@ -464,6 +464,61 @@
 - JunctionPopupから道路タイプセクション全体を削除
 - useJunctionsフックのモックデータからもroad_typesを削除（3箇所）
 - CSS削除は不要（インラインスタイルのみ使用）
+
+---
+
+### Phase 6: 直線分岐（Skewed）の削除 ✅
+
+**ゴール**: フィルターから直線分岐（Skewed）タイプを削除し、シンプルな3分類に変更
+
+**背景**:
+- 直線分岐（`angle_3 > 200`）はわかりにくい
+- 需要があるか不明
+- UIをシンプルにするため削除
+
+**成果物**:
+- `backend/src/domain/junction.rs` - AngleType enumから`Skewed`を削除
+- `backend/src/api/handlers.rs` - パース処理から削除
+- `backend/src/db/repository.rs` - クエリロジックから削除
+- `frontend/src/types/index.ts` - AngleType型から削除
+- `frontend/src/components/FilterPanel.tsx` - UIから削除
+- `frontend/src/components/MapView.tsx` - マーカー色から削除
+- `frontend/src/components/JunctionPopup.tsx` - ラベルから削除
+- `frontend/src/hooks/useFilters.ts` - デフォルト値から削除
+- `frontend/src/hooks/useJunctions.ts` - モックデータを修正
+- `doc/mvp-requirements.md` - ドキュメント更新
+- `doc/todo.md` - ドキュメント更新
+
+**タスク**:
+- [x] Backend: AngleType enumから`Skewed`を削除し、分類ロジックを修正
+- [x] Backend: ユニットテストを修正
+- [x] Backend: API handlers、repositoryから`skewed`の参照を削除
+- [x] Backend: cargo test、cargo fmt、cargo clippyを実行
+- [x] Frontend: AngleType型から`'skewed'`を削除
+- [x] Frontend: FilterPanel、MapView、JunctionPopupから直線分岐のUIを削除
+- [x] Frontend: useFilters、useJunctionsから`skewed`の参照を削除
+- [x] Frontend: npm run typecheck、lint、formatを実行
+- [x] Docs: mvp-requirements.mdを現在の実装に合わせて更新
+- [x] Docs: todo.mdを更新
+
+**完了条件**:
+- ✅ Backend: AngleTypeが3つ（verysharp/sharp/normal）になった
+- ✅ Backend: 全ユニットテスト（17個）が成功
+- ✅ Backend: cargo fmt、clippyチェックが成功
+- ✅ Frontend: フィルターパネルに3つのチェックボックスのみ表示
+- ✅ Frontend: 型チェック、Lint、フォーマットが成功
+- ✅ Docs: 全ドキュメントが更新され、skewedの参照が0件
+
+**新しい分類ロジック**:
+- **verysharp**（超鋭角）: `angle_1 < 30°`
+- **sharp**（鋭角）: `30° ≤ angle_1 < 45°`
+- **normal**（中間）: `angle_1 ≥ 45°`
+
+**実装メモ**:
+- 以前のSkewed（`angle_3 > 200`）は最小角度に基づいて再分類される
+- `angle_3 > 200`の条件をSQLとRustコードから削除
+- フィルターのロジックを4→3に変更（`angleTypes.length < 4` → `angleTypes.length < 3`）
+- コードベース全体でskewedの参照が完全に削除された
 
 ---
 

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -12,7 +12,6 @@ interface FilterPanelProps {
 const ANGLE_TYPE_LABELS: Record<AngleType, string> = {
   verysharp: '超鋭角',
   sharp: '鋭角',
-  skewed: '直線分岐',
   normal: '中間',
 };
 
@@ -20,7 +19,6 @@ const ANGLE_TYPE_COLORS: Record<AngleType, string> = {
   verysharp: '#1E3A8A', // 暗い青（濃紺） - 最小角度が最も小さい
   sharp: '#3B82F6', // 明るい青
   normal: '#F59E0B', // 濃い黄色（琥珀色） - 通常
-  skewed: '#7C3AED', // 紫 - 直線分岐（特殊）
 };
 
 export const FilterPanel = memo(function FilterPanel({
@@ -53,7 +51,7 @@ export const FilterPanel = memo(function FilterPanel({
         <h3>角度タイプ</h3>
         <div className="angle-type-options">
           {/* 最小角度の小さい順に並べる */}
-          {(['verysharp', 'sharp', 'normal', 'skewed'] as AngleType[]).map(type => (
+          {(['verysharp', 'sharp', 'normal'] as AngleType[]).map(type => (
             <label key={type} className="angle-type-label">
               <input
                 type="checkbox"

--- a/frontend/src/components/JunctionPopup.tsx
+++ b/frontend/src/components/JunctionPopup.tsx
@@ -5,9 +5,8 @@ interface JunctionPopupProps {
 }
 
 const ANGLE_TYPE_LABELS: Record<string, string> = {
+  verysharp: '超鋭角',
   sharp: '鋭角',
-  even: '三叉路',
-  skewed: '直線分岐',
   normal: '中間',
 };
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -14,7 +14,6 @@ const MARKER_COLORS: Record<AngleType, string> = {
   verysharp: '#1E3A8A', // 暗い青（濃紺） - 最小角度が最も小さい
   sharp: '#3B82F6', // 明るい青
   normal: '#F59E0B', // 濃い黄色（琥珀色） - 通常
-  skewed: '#7C3AED', // 紫 - 直線分岐（特殊）
 };
 
 // カスタムマーカーアイコンを作成（メモ化用に外部で定義）

--- a/frontend/src/hooks/useFilters.ts
+++ b/frontend/src/hooks/useFilters.ts
@@ -7,17 +7,12 @@ export interface FilterState {
 }
 
 export function useFilters() {
-  const [angleTypes, setAngleTypes] = useState<AngleType[]>([
-    'verysharp',
-    'sharp',
-    'skewed',
-    'normal',
-  ]);
+  const [angleTypes, setAngleTypes] = useState<AngleType[]>(['verysharp', 'sharp', 'normal']);
   const [minAngleRange, setMinAngleRange] = useState<[number, number]>([0, 60]);
 
   // フィルタをリセット
   const resetFilters = useCallback(() => {
-    setAngleTypes(['verysharp', 'sharp', 'skewed', 'normal']);
+    setAngleTypes(['verysharp', 'sharp', 'normal']);
     setMinAngleRange([0, 60]);
   }, []);
 
@@ -36,8 +31,8 @@ export function useFilters() {
   const toFilterParams = useCallback((): Omit<FilterParams, 'bbox'> => {
     const params: Omit<FilterParams, 'bbox'> = {};
 
-    // angle_typeを配列として送る（0個または4個の場合は送らない＝全選択扱い）
-    if (angleTypes.length > 0 && angleTypes.length < 4) {
+    // angle_typeを配列として送る（0個または3個の場合は送らない＝全選択扱い）
+    if (angleTypes.length > 0 && angleTypes.length < 3) {
       params.angle_type = angleTypes;
     }
 

--- a/frontend/src/hooks/useJunctions.ts
+++ b/frontend/src/hooks/useJunctions.ts
@@ -47,11 +47,11 @@ const MOCK_DATA: JunctionFeatureCollection = {
       properties: {
         id: 3,
         osm_node_id: 1003,
-        angles: [30, 100, 230],
-        angle_type: 'skewed',
+        angles: [60, 120, 180],
+        angle_type: 'normal',
         streetview_url:
           'https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=35.680,139.765',
-        bearings: [20, 50, 150],
+        bearings: [30, 90, 210],
       },
     },
   ],

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
 // AngleType
-export type AngleType = 'verysharp' | 'sharp' | 'skewed' | 'normal';
+export type AngleType = 'verysharp' | 'sharp' | 'normal';
 
 // Junction (単体取得時のレスポンス)
 export interface Junction {
@@ -48,7 +48,6 @@ export interface Stats {
   by_type: {
     verysharp: number;
     sharp: number;
-    skewed: number;
     normal: number;
   };
 }


### PR DESCRIPTION
## Summary

フィルターから直線分岐（Skewed）タイプを削除し、シンプルな3分類に変更しました。

### 変更内容

**Backend:**
- `AngleType` enumから`Skewed`バリアントを削除
- 分類ロジックを簡略化（`angle_3 > 200`の条件を削除）
- API handlers、repository queries、テストを更新
- 全ユニットテスト（17個）が成功

**Frontend:**
- `AngleType`と`Stats`インターフェースから`'skewed'`を削除
- FilterPanelのUIを更新（4つ→3つのチェックボックス）
- MapViewのマーカー色とJunctionPopupのラベルを更新
- フィルターロジックを3タイプ用に修正
- 全チェック（typecheck、lint、format）が成功

**Documentation:**
- mvp-requirements.mdを現在の実装に合わせて更新
- todo.mdにPhase 6の完了を記録

### 新しい分類ロジック

- **verysharp**（超鋭角）: `angle_1 < 30°`
- **sharp**（鋭角）: `30° ≤ angle_1 < 45°`
- **normal**（中間）: `angle_1 ≥ 45°`

以前のSkewed（`angle_3 > 200`）に分類されていたY字路は、最小角度に基づいて上記3つのいずれかに再分類されます。

### 理由

- 直線分岐（`angle_3 > 200`）はわかりにくい
- 需要があるか不明
- UIをシンプルにするため

## Test plan

- [x] Backend: cargo test（17個の全ユニットテストが成功）
- [x] Backend: cargo fmt --check、cargo clippy（警告なし）
- [x] Frontend: npm run typecheck（エラーなし）
- [x] Frontend: npm run lint（警告なし）
- [x] Frontend: npm run format:check（フォーマット済み）
- [x] コードベース全体でskewedの参照が0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified angle type classification system from four categories to three: "Very Sharp," "Sharp," and "Normal."
  * Updated angle filtering logic to use angle values for more accurate categorization.
  * Removed "Skewed" angle type from all application components.

* **Documentation**
  * Updated API specifications, database schema, and frontend types to reflect the new three-category angle system.
  * Revised sample responses and configuration documentation accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->