### PR TITLE
fix: Send angle_type as comma-separated string to match backend expectation

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -23,10 +23,8 @@ export async function fetchJunctions(
     const params = new URLSearchParams({ bbox });
 
     if (filters?.angle_type && filters.angle_type.length > 0) {
-      // 配列の各要素をクエリパラメータとして追加
-      filters.angle_type.forEach(type => {
-        params.append('angle_type', type);
-      });
+      // カンマ区切りの文字列として送信（バックエンドの期待形式）
+      params.append('angle_type', filters.angle_type.join(','));
     }
     if (filters?.min_angle_lt !== undefined) {
       params.append('min_angle_lt', filters.min_angle_lt.toString());


### PR DESCRIPTION
## Summary
- フロントエンドとバックエンドでangle_typeパラメータの形式が不一致だった問題を修正
- フロントエンドは複数のパラメータとして送信していたが、バックエンドはカンマ区切りの文字列を期待していた
- これにより、チェックボックスを外した時に他のマーカーも消えてしまう問題が発生していた

## 変更内容
- `frontend/src/api/client.ts`: angle_type配列をカンマ区切りの文字列に変換して送信するように修正

## Test plan
- [x] ローカルでフロントエンドのチェック（typecheck, lint, format:check, test）を実行し、全て成功することを確認
- [ ] 開発環境で3つの角度タイプを全てチェックした状態から1つずつチェックを外し、該当するマーカーだけが消えることを確認
- [ ] 2つのチェックボックスをチェックした状態で、残りのマーカーが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized how filter parameters are formatted in API requests for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->