### PR TITLE
ci: install cargo-audit in CI pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,6 +101,10 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Install cargo-audit
+        if: steps.cache-cargo-test.outputs.cache-hit != 'true'
+        run: cargo install cargo-audit --locked
+
       - name: Security audit
         run: |
           # Ignore RUSTSEC-2023-0071 (rsa crate via sqlx-mysql): PostgreSQL-only project, MySQL code not executed


### PR DESCRIPTION
## Summary
- Add cargo-audit installation step to CI pipeline
- Fix backend-test workflow failure due to missing cargo-audit command

## Problem
- Previous PR #59 was merged but CI failed because cargo-audit was not installed
- `cargo audit` command resulted in "no such command" error

## Solution
- Add installation step for cargo-audit in deploy.yml
- Use cache to avoid reinstalling on every run
- Install only when cache is not hit

## Changes
- `.github/workflows/deploy.yml`: Add "Install cargo-audit" step before "Security audit"

## Test plan
- [x] CI/CD pipeline passes (backend-test job)
- [x] cargo-audit successfully runs in CI
- [x] Security vulnerabilities are properly audited

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the backend testing pipeline with improved security audit tooling installation, ensuring the necessary dependencies are available during the build process when cache is not reused.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->