### PR TITLE
Optimize backend test CI performance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,10 +83,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-deps-
 
-      - name: Install tools
-        uses: taiki-e/install-action@v2
+      - name: Cache tools
+        id: cache-tools
+        uses: actions/cache@v4
         with:
-          tool: sqlx-cli@0.8.6,cargo-audit@0.21.0
+          path: |
+            ~/.cargo/bin/sqlx
+            ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-tools-sqlx-0.8.6-audit-0.21.0
+
+      - name: Install tools
+        if: steps.cache-tools.outputs.cache-hit != 'true'
+        run: |
+          cargo install sqlx-cli --version 0.8.6 --no-default-features --features postgres,rustls
+          cargo install cargo-audit --version 0.21.0 --locked
 
       - name: Run database migrations
         run: sqlx migrate run


### PR DESCRIPTION
## Summary
- Optimize backend-test job execution time through better tool caching strategy
- Replace taiki-e/install-action with cargo install + manual cache
- Separate tool cache from dependency cache to prevent unnecessary reinstallation

## Problem
Backend tests were taking over 5 minutes, with tool installation being the main bottleneck:
- cargo-audit installation: 147.6s
- sqlx-cli installation: 64.3s
- Total: ~211s for tools alone

## Solution
Implemented cargo install with manual caching:
- Cache tool binaries separately with version-based key
- Skip installation on cache hit
- Use minimal features for sqlx-cli (`--no-default-features --features postgres,rustls`)

## Expected Results
- First run (cache miss): ~4-5 minutes (same as before)
- Subsequent runs (cache hit): ~1-2 minutes (major improvement)
- Cache invalidates only on tool version changes, not Cargo.lock changes

## Technical Details
- sqlx-cli@0.8.6 lacks prebuilt binaries, making cargo-binstall and taiki-e/install-action ineffective
- Manual cache approach provides better control and reliability
- Cache key: `${{ runner.os }}-tools-sqlx-0.8.6-audit-0.21.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow with caching mechanisms to improve build performance and reduce deployment times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->