### PR TITLE
fix: モバイルでハンバーガーメニューが反応しない問題を修正

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -46,6 +46,8 @@ body {
   font-size: 24px;
   cursor: pointer;
   padding: 5px 10px;
+  position: relative;
+  z-index: 1001;
 }
 
 /* メインコンテンツ */
@@ -64,7 +66,7 @@ body {
   flex-direction: column;
   border-right: 1px solid #e0e0e0;
   background: white;
-  z-index: 100;
+  z-index: 1001;
   transition: transform 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary

iPhoneなどのモバイルデバイスで、ハンバーガーメニューボタンが反応せず、フィルターが表示されない問題を修正。

### 問題の原因
z-indexの設定不足により、ハンバーガーメニューボタンとサイドバーが他の要素（地図など）の下に隠れていた。

### 修正内容
- ハンバーガーメニューボタンに `position: relative` と `z-index: 1001` を追加
- サイドバーの `z-index` を `100` から `1001` に変更

### 調査プロセス
当初は `.app-main` の `overflow: hidden` が原因と推測したが、実際には z-index のみが問題だったことを確認。

## Test plan

- [x] ブラウザのデベロッパーツールでモバイルビュー（768px以下）を表示
- [x] ハンバーガーメニューボタンがクリック可能であることを確認
- [x] サイドバーが左から正しくスライド表示されることを確認
- [x] フィルターパネルが完全に表示されることを確認
- [x] フォーマットチェック、Lintチェック、型チェックが全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed element layering to ensure correct display order of interface components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->