### PR TITLE
fix: use minimum angle across all three angles for filtering

### DIFF
--- a/backend/src/db/repository.rs
+++ b/backend/src/db/repository.rs
@@ -96,13 +96,13 @@ fn add_angle_type_filter(builder: &mut QueryBuilder<sqlx::Postgres>, angle_types
         }
         match angle_type {
             AngleType::VerySharp => {
-                builder.push("angle_1 < 30");
+                builder.push("LEAST(angle_1, angle_2, angle_3) < 30");
             }
             AngleType::Sharp => {
-                builder.push("(angle_1 >= 30 AND angle_1 < 45)");
+                builder.push("(LEAST(angle_1, angle_2, angle_3) >= 30 AND LEAST(angle_1, angle_2, angle_3) < 45)");
             }
             AngleType::Normal => {
-                builder.push("angle_1 >= 45");
+                builder.push("LEAST(angle_1, angle_2, angle_3) >= 45");
             }
         }
     }
@@ -116,12 +116,12 @@ fn add_min_angle_filters(
     min_angle_gt: Option<i16>,
 ) {
     if let Some(lt) = min_angle_lt {
-        builder.push(" AND angle_1 < ");
+        builder.push(" AND LEAST(angle_1, angle_2, angle_3) < ");
         builder.push_bind(lt);
     }
 
     if let Some(gt) = min_angle_gt {
-        builder.push(" AND angle_1 > ");
+        builder.push(" AND LEAST(angle_1, angle_2, angle_3) > ");
         builder.push_bind(gt);
     }
 }
@@ -189,8 +189,8 @@ pub async fn count_by_type(pool: &PgPool) -> Result<HashMap<String, i64>, sqlx::
     let rows: Vec<(String, i64)> = sqlx::query_as(
         "SELECT \
            CASE \
-             WHEN angle_1 < 30 THEN 'verysharp' \
-             WHEN angle_1 < 45 THEN 'sharp' \
+             WHEN LEAST(angle_1, angle_2, angle_3) < 30 THEN 'verysharp' \
+             WHEN LEAST(angle_1, angle_2, angle_3) < 45 THEN 'sharp' \
              ELSE 'normal' \
            END as angle_type, \
            COUNT(*) as count \


### PR DESCRIPTION
## Summary

Fix the mismatch between filter checkboxes and marker colors by ensuring consistent angle type determination logic.

Previously:
- **Filtering logic**: Used `angle_1` directly
- **Display logic**: Used `LEAST(angle_1, angle_2, angle_3)`

This caused incorrect filtering where a junction with `angle_1=50, angle_2=25, angle_3=285` would:
- Be filtered as "Normal" (angle_1=50 ≥ 45)
- Display as "VerySharp" purple marker (min=25 < 30)

## Changes

Modified `backend/src/db/repository.rs`:
- `add_angle_type_filter()`: Use `LEAST(angle_1, angle_2, angle_3)` for angle type filtering
- `add_min_angle_filters()`: Use `LEAST(angle_1, angle_2, angle_3)` for range filtering
- `count_by_type()`: Use `LEAST(angle_1, angle_2, angle_3)` for statistics

## Test Results

✅ All unit tests passed (17 passed)
✅ All integration tests passed (14 passed)
✅ Cargo fmt check passed
✅ Cargo clippy check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved angle-type classification to evaluate all angle measurements for more precise categorization.
  * Enhanced angle filtering to consider all measured angles instead of a single value for better accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->