### PR TITLE
feat: add elevation data model (Phase 2)

### DIFF
--- a/backend/src/db/repository.rs
+++ b/backend/src/db/repository.rs
@@ -50,6 +50,10 @@ impl From<JunctionRow> for Junction {
             angle_3: row.angle_3,
             bearings: row.bearings,
             created_at: row.created_at,
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         }
     }
 }
@@ -66,6 +70,10 @@ impl From<JunctionRowWithCount> for Junction {
             angle_3: row.angle_3,
             bearings: row.bearings,
             created_at: row.created_at,
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         }
     }
 }

--- a/backend/src/domain/junction.rs
+++ b/backend/src/domain/junction.rs
@@ -36,6 +36,15 @@ pub struct Junction {
     pub bearings: Vec<f32>,
     #[serde(with = "chrono::serde::ts_seconds")]
     pub created_at: DateTime<Utc>,
+
+    #[allow(dead_code)]
+    pub elevation: Option<f64>,
+    #[allow(dead_code)]
+    pub min_elevation_diff: Option<f64>,
+    #[allow(dead_code)]
+    pub max_elevation_diff: Option<f64>,
+    #[allow(dead_code)]
+    pub min_angle_elevation_diff: Option<f64>,
 }
 
 impl Junction {
@@ -105,7 +114,11 @@ impl Junction {
                 "osm_node_id": self.osm_node_id,
                 "angles": self.angles(),
                 "angle_type": self.angle_type(),
-                "streetview_url": self.streetview_url()
+                "streetview_url": self.streetview_url(),
+                "elevation": self.elevation,
+                "min_elevation_diff": self.min_elevation_diff,
+                "max_elevation_diff": self.max_elevation_diff,
+                "min_angle_elevation_diff": self.min_angle_elevation_diff
             }
         })
     }
@@ -158,6 +171,10 @@ mod tests {
             angle_3: 180,
             bearings: vec![10.0, 40.0, 190.0],
             created_at: Utc::now(),
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         };
 
         assert_eq!(junction.angle_type(), AngleType::Sharp);
@@ -175,6 +192,10 @@ mod tests {
             angle_3: 180,
             bearings: vec![10.0, 40.0, 190.0],
             created_at: Utc::now(),
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         };
 
         assert_eq!(junction.angles(), [30, 150, 180]);
@@ -192,6 +213,10 @@ mod tests {
             angle_3: 180,
             bearings: vec![10.0, 40.0, 190.0],
             created_at: Utc::now(),
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         };
 
         let url = junction.streetview_url();
@@ -213,6 +238,10 @@ mod tests {
             angle_3: 180,
             bearings: vec![10.0, 40.0, 190.0],
             created_at: Utc::now(),
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         };
 
         let feature = junction.to_feature();
@@ -242,6 +271,10 @@ mod tests {
             angle_3: 180,
             bearings: vec![10.0, 40.0, 190.0],
             created_at: Utc::now(),
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         };
 
         let junction2 = Junction {
@@ -254,6 +287,10 @@ mod tests {
             angle_3: 130,
             bearings: vec![50.0, 160.0, 280.0],
             created_at: Utc::now(),
+            elevation: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            min_angle_elevation_diff: None,
         };
 
         let collection = Junction::to_feature_collection(vec![junction1, junction2], 2);

--- a/backend/src/importer/detector.rs
+++ b/backend/src/importer/detector.rs
@@ -29,6 +29,44 @@ pub struct JunctionForInsert {
     /// Each bearing is in degrees (0-360), where 0° is North, 90° is East
     /// Order corresponds to angle_1, angle_2, angle_3
     pub bearings: [f64; 3],
+
+    #[allow(dead_code)]
+    pub elevation: Option<f64>,
+    #[allow(dead_code)]
+    pub neighbor_elevations: Option<[f64; 3]>,
+    #[allow(dead_code)]
+    pub elevation_diffs: Option<[f64; 3]>,
+    #[allow(dead_code)]
+    pub min_angle_index: Option<i16>,
+    #[allow(dead_code)]
+    pub min_elevation_diff: Option<f64>,
+    #[allow(dead_code)]
+    pub max_elevation_diff: Option<f64>,
+}
+
+impl JunctionForInsert {
+    pub fn calculate_min_angle_index(angles: &[i16; 3]) -> i16 {
+        let (min_idx, _) = angles
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, &angle)| angle)
+            .unwrap();
+        (min_idx + 1) as i16
+    }
+
+    pub fn calculate_elevation_diffs(base: f64, neighbors: &[f64; 3]) -> [f64; 3] {
+        [
+            (base - neighbors[0]).abs(),
+            (base - neighbors[1]).abs(),
+            (base - neighbors[2]).abs(),
+        ]
+    }
+
+    pub fn calculate_min_max_diffs(diffs: &[f64; 3]) -> (f64, f64) {
+        let min = diffs.iter().copied().fold(f64::INFINITY, f64::min);
+        let max = diffs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        (min, max)
+    }
 }
 
 /// Node connection counter for Y-junction detection
@@ -190,5 +228,50 @@ mod tests {
         assert!(!counter.is_valid_highway_type("footway"));
         assert!(!counter.is_valid_highway_type("cycleway"));
         assert!(!counter.is_valid_highway_type("path"));
+    }
+
+    #[test]
+    fn test_calculate_min_angle_index() {
+        assert_eq!(
+            JunctionForInsert::calculate_min_angle_index(&[30, 150, 180]),
+            1
+        );
+        assert_eq!(
+            JunctionForInsert::calculate_min_angle_index(&[150, 30, 180]),
+            2
+        );
+        assert_eq!(
+            JunctionForInsert::calculate_min_angle_index(&[150, 180, 30]),
+            3
+        );
+        assert_eq!(
+            JunctionForInsert::calculate_min_angle_index(&[120, 120, 120]),
+            1
+        );
+    }
+
+    #[test]
+    fn test_calculate_elevation_diffs() {
+        let base = 100.0;
+        let neighbors = [95.0, 105.0, 100.0];
+        let diffs = JunctionForInsert::calculate_elevation_diffs(base, &neighbors);
+        assert_eq!(diffs, [5.0, 5.0, 0.0]);
+
+        let neighbors2 = [110.0, 90.0, 85.0];
+        let diffs2 = JunctionForInsert::calculate_elevation_diffs(base, &neighbors2);
+        assert_eq!(diffs2, [10.0, 10.0, 15.0]);
+    }
+
+    #[test]
+    fn test_calculate_min_max_diffs() {
+        let diffs = [5.0, 10.0, 15.0];
+        let (min, max) = JunctionForInsert::calculate_min_max_diffs(&diffs);
+        assert_eq!(min, 5.0);
+        assert_eq!(max, 15.0);
+
+        let diffs2 = [0.0, 0.0, 0.0];
+        let (min2, max2) = JunctionForInsert::calculate_min_max_diffs(&diffs2);
+        assert_eq!(min2, 0.0);
+        assert_eq!(max2, 0.0);
     }
 }

--- a/backend/src/importer/parser.rs
+++ b/backend/src/importer/parser.rs
@@ -246,6 +246,12 @@ pub fn parse_pbf(
                 angle_2: angles[1],
                 angle_3: angles[2],
                 bearings,
+                elevation: None,
+                neighbor_elevations: None,
+                elevation_diffs: None,
+                min_angle_index: None,
+                min_elevation_diff: None,
+                max_elevation_diff: None,
             });
         } else {
             failed_calculations += 1;

--- a/doc/elevation-feature.md
+++ b/doc/elevation-feature.md
@@ -111,7 +111,7 @@ backend/data/gsi/
 
 ---
 
-## 🔧 Phase 2: データモデル拡張
+## 🔧 Phase 2: データモデル拡張 ✅
 
 **ゴール**: 標高データを扱うためのデータ構造を拡張
 
@@ -120,7 +120,7 @@ backend/data/gsi/
 - `backend/src/domain/junction.rs` - Junction構造体拡張
 
 **タスク**:
-- [ ] `JunctionForInsert`構造体に標高フィールド追加
+- [x] `JunctionForInsert`構造体に標高フィールド追加
   ```rust
   pub struct JunctionForInsert {
       // 既存フィールド...
@@ -128,13 +128,15 @@ backend/data/gsi/
       pub neighbor_elevations: Option<[f64; 3]>,
       pub elevation_diffs: Option<[f64; 3]>,
       pub min_angle_index: Option<i16>,
+      pub min_elevation_diff: Option<f64>,
+      pub max_elevation_diff: Option<f64>,
   }
   ```
-- [ ] ヘルパーメソッド実装
-  - [ ] `calculate_min_angle_index(angles: &[i16; 3]) -> i16`
-  - [ ] `calculate_elevation_diffs(base: f64, neighbors: &[f64; 3]) -> [f64; 3]`
-  - [ ] `calculate_min_max_diffs(diffs: &[f64; 3]) -> (f64, f64)`
-- [ ] `Junction`構造体に標高フィールド追加
+- [x] ヘルパーメソッド実装
+  - [x] `calculate_min_angle_index(angles: &[i16; 3]) -> i16` - 1-based (1,2,3)を返すよう実装
+  - [x] `calculate_elevation_diffs(base: f64, neighbors: &[f64; 3]) -> [f64; 3]`
+  - [x] `calculate_min_max_diffs(diffs: &[f64; 3]) -> (f64, f64)`
+- [x] `Junction`構造体に標高フィールド追加
   ```rust
   pub struct Junction {
       // 既存フィールド...
@@ -144,15 +146,25 @@ backend/data/gsi/
       pub min_angle_elevation_diff: Option<f64>,
   }
   ```
-- [ ] ユニットテスト
-  - [ ] 最小角インデックス計算のテスト
-  - [ ] 高低差計算のテスト
+- [x] ユニットテスト
+  - [x] 最小角インデックス計算のテスト (1,2,3を期待)
+  - [x] 高低差計算のテスト
+- [x] `to_feature()` メソッド更新（標高データをGeoJSON propertiesに追加）
+- [x] 既存の初期化箇所の修正（None値で初期化）
 
 **完了条件**:
-- [ ] `cargo test` でドメインモデルのテスト合格
-- [ ] 標高データがOptionalで扱える（XMLファイルがない場合もエラーにならない）
+- ✅ `cargo test` でドメインモデルのテスト合格（26テスト全て成功）
+- ✅ 標高データがOptionalで扱える（XMLファイルがない場合もエラーにならない）
+- ✅ `cargo fmt` と `cargo clippy` チェック成功
+- ✅ Phase 7の検索要件を満たすデータ構造（elevation, min_elevation_diff, min_angle_elevation_diff）
 
 **工数**: 小（半日程度）
+
+**実装メモ**:
+- `calculate_min_angle_index` は1-based (1,2,3) を返す（PostgreSQL CHECK制約とCASE文に対応）
+- 全フィールドに `#[allow(dead_code)]` 属性を付与（Phase 3以降で使用）
+- `elevation_diffs` はジャンクションノードと隣接ノードの高低差を計算（junction-to-neighbor）
+- `min_angle_elevation_diff` はPostgreSQLのGenerated Columnで自動計算（neighbor-to-neighbor）
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 2の実装完了：標高データを扱うためのデータ構造を拡張

## Changes

### JunctionForInsert構造体の拡張
- `elevation: Option<f64>` - ジャンクションノードの標高
- `neighbor_elevations: Option<[f64; 3]>` - 3つの隣接ノードの標高
- `elevation_diffs: Option<[f64; 3]>` - 高低差（junction-to-neighbor）
- `min_angle_index: Option<i16>` - 最小角のインデックス（1-based: 1,2,3）
- `min_elevation_diff: Option<f64>` - 最小高低差
- `max_elevation_diff: Option<f64>` - 最大高低差

### ヘルパーメソッド実装
- `calculate_min_angle_index(angles: &[i16; 3]) -> i16`
  - 1-based（1,2,3）を返す（PostgreSQL CHECK制約対応）
- `calculate_elevation_diffs(base: f64, neighbors: &[f64; 3]) -> [f64; 3]`
  - ジャンクションと隣接ノード間の高低差を計算
- `calculate_min_max_diffs(diffs: &[f64; 3]) -> (f64, f64)`
  - 高低差の最小値・最大値を計算

### Junction構造体の拡張
- `elevation: Option<f64>` - ジャンクションノードの標高
- `min_elevation_diff: Option<f64>` - 最小高低差
- `max_elevation_diff: Option<f64>` - 最大高低差
- `min_angle_elevation_diff: Option<f64>` - 最小角高低差（Phase 7検索用）

### その他
- `to_feature()` メソッドを更新してGeoJSON propertiesに標高データを追加
- 既存の初期化箇所をNone値で修正（5箇所）
- ユニットテスト追加（3テスト）

## Testing

- ✅ ユニットテスト: 26テスト全て成功
- ✅ cargo fmt チェック成功
- ✅ cargo clippy チェック成功

## Notes

- 全フィールドに `#[allow(dead_code)]` 属性を付与（Phase 3以降で使用）
- Phase 7の検索要件を満たすデータ構造
- `min_angle_index`の1-based実装により、Phase 4のCHECK制約とPhase 3のCASE文が正しく動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added elevation data support for junctions, including elevation values and elevation difference metrics.
  * Elevation information is now included in API responses and GeoJSON exports.

* **Updates**
  * Enhanced data model to capture and store elevation-related properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->