### PR TITLE
feat: extend database schema for elevation data (Phase 4)

### DIFF
--- a/backend/migrations/003_add_elevation.sql
+++ b/backend/migrations/003_add_elevation.sql
@@ -1,0 +1,45 @@
+-- Add elevation data columns to y_junctions table
+-- 標高データ: GSI DEM5A（5メートルメッシュ標高データ）由来
+
+ALTER TABLE y_junctions
+ADD COLUMN elevation REAL,
+ADD COLUMN neighbor_elevation_1 REAL,
+ADD COLUMN neighbor_elevation_2 REAL,
+ADD COLUMN neighbor_elevation_3 REAL,
+ADD COLUMN elevation_diff_1 REAL CHECK (elevation_diff_1 >= 0),
+ADD COLUMN elevation_diff_2 REAL CHECK (elevation_diff_2 >= 0),
+ADD COLUMN elevation_diff_3 REAL CHECK (elevation_diff_3 >= 0),
+ADD COLUMN min_angle_index SMALLINT CHECK (min_angle_index BETWEEN 1 AND 3),
+ADD COLUMN min_elevation_diff REAL CHECK (min_elevation_diff >= 0),
+ADD COLUMN max_elevation_diff REAL CHECK (max_elevation_diff >= 0),
+ADD COLUMN min_angle_elevation_diff REAL GENERATED ALWAYS AS (
+    CASE min_angle_index
+        WHEN 1 THEN ABS(neighbor_elevation_1 - neighbor_elevation_2)
+        WHEN 2 THEN ABS(neighbor_elevation_2 - neighbor_elevation_3)
+        WHEN 3 THEN ABS(neighbor_elevation_3 - neighbor_elevation_1)
+    END
+) STORED;
+
+CREATE INDEX idx_y_junctions_elevation
+    ON y_junctions (elevation)
+    WHERE elevation IS NOT NULL;
+
+CREATE INDEX idx_y_junctions_min_elevation_diff
+    ON y_junctions (min_elevation_diff)
+    WHERE min_elevation_diff IS NOT NULL;
+
+CREATE INDEX idx_y_junctions_min_angle_elevation_diff
+    ON y_junctions (min_angle_elevation_diff)
+    WHERE min_angle_elevation_diff IS NOT NULL;
+
+COMMENT ON COLUMN y_junctions.elevation IS 'ジャンクションノードの標高（メートル、GSI DEM5Aデータ由来）';
+COMMENT ON COLUMN y_junctions.neighbor_elevation_1 IS '隣接ノード1の標高（メートル）';
+COMMENT ON COLUMN y_junctions.neighbor_elevation_2 IS '隣接ノード2の標高（メートル）';
+COMMENT ON COLUMN y_junctions.neighbor_elevation_3 IS '隣接ノード3の標高（メートル）';
+COMMENT ON COLUMN y_junctions.elevation_diff_1 IS 'ジャンクションノードと隣接ノード1の標高差（メートル）';
+COMMENT ON COLUMN y_junctions.elevation_diff_2 IS 'ジャンクションノードと隣接ノード2の標高差（メートル）';
+COMMENT ON COLUMN y_junctions.elevation_diff_3 IS 'ジャンクションノードと隣接ノード3の標高差（メートル）';
+COMMENT ON COLUMN y_junctions.min_angle_index IS '最小角のインデックス（1=angle_1, 2=angle_2, 3=angle_3）';
+COMMENT ON COLUMN y_junctions.min_elevation_diff IS '最小高低差（メートル）';
+COMMENT ON COLUMN y_junctions.max_elevation_diff IS '最大高低差（メートル）';
+COMMENT ON COLUMN y_junctions.min_angle_elevation_diff IS '最小角を構成する2本の道路間の標高差（メートル）';

--- a/doc/elevation-feature.md
+++ b/doc/elevation-feature.md
@@ -271,7 +271,7 @@ for junction in &y_junctions {
 
 ---
 
-## 🗄️ Phase 4: データベーススキーマ拡張
+## 🗄️ Phase 4: データベーススキーマ拡張 ✅
 
 **ゴール**: 標高データを保存するためのDBスキーマ変更
 
@@ -279,27 +279,33 @@ for junction in &y_junctions {
 - `backend/migrations/003_add_elevation.sql` - マイグレーションSQL
 
 **タスク**:
-- [ ] マイグレーションSQL作成
-  - [ ] 標高カラム追加（elevation, neighbor_elevation_1~3）
-  - [ ] 高低差カラム追加（elevation_diff_1~3）
-  - [ ] 最小角インデックス追加（min_angle_index）
-  - [ ] 計算済みカラム追加（min_elevation_diff, max_elevation_diff）
-  - [ ] Generated Column追加（min_angle_elevation_diff）
-- [ ] インデックス作成
-  - [ ] `CREATE INDEX idx_y_junctions_elevation ON y_junctions (elevation)`
-  - [ ] `CREATE INDEX idx_y_junctions_min_elevation_diff ON y_junctions (min_elevation_diff)`
-  - [ ] `CREATE INDEX idx_y_junctions_min_angle_elevation_diff ON y_junctions (min_angle_elevation_diff)`
-- [ ] コメント追加（各カラムの説明）
-- [ ] マイグレーション実行テスト
+- [x] マイグレーションSQL作成
+  - [x] 標高カラム追加（elevation, neighbor_elevation_1~3）
+  - [x] 高低差カラム追加（elevation_diff_1~3）
+  - [x] 最小角インデックス追加（min_angle_index）
+  - [x] 計算済みカラム追加（min_elevation_diff, max_elevation_diff）
+  - [x] Generated Column追加（min_angle_elevation_diff）
+- [x] インデックス作成
+  - [x] `CREATE INDEX idx_y_junctions_elevation ON y_junctions (elevation)`
+  - [x] `CREATE INDEX idx_y_junctions_min_elevation_diff ON y_junctions (min_elevation_diff)`
+  - [x] `CREATE INDEX idx_y_junctions_min_angle_elevation_diff ON y_junctions (min_angle_elevation_diff)`
+- [x] コメント追加（各カラムの説明）
+- [x] マイグレーション実行テスト
 
 **完了条件**:
-- [ ] `sqlx migrate run` でマイグレーション成功
-- [ ] `\d y_junctions` で新しいカラムが表示される
-- [ ] Generated Columnが正しく動作する
+- ✅ `sqlx migrate run` でマイグレーション成功
+- ✅ `\d y_junctions` で新しいカラムが表示される（11カラム追加）
+- ✅ Generated Columnが正しく動作する（min_angle_elevation_diffの自動計算を確認）
 
 **工数**: 小（半日程度）
 
 **依存**: Phase 3完了（実装確定後）
+
+**実装メモ**:
+- マイグレーション003_add_elevation.sqlを作成し、全ての標高関連カラムを追加
+- 3つのインデックスを作成（WHERE句でNULL値を除外）
+- 全カラムにコメントを追加（高低差のコメントは「何と何の差」か明示）
+- Generated Column (min_angle_elevation_diff) はmin_angle_indexに基づいて自動計算される
 
 **マイグレーションSQL例**:
 ```sql


### PR DESCRIPTION
## Summary

Phase 4: データベーススキーマ拡張を完了しました。

- マイグレーション `003_add_elevation.sql` を作成し、標高関連の11カラムを追加
- 検索最適化のため3つのインデックスを作成
- Generated Columnで最小角の標高差を自動計算

## Changes

### Database Schema
- **elevation**: ジャンクションノードの標高（メートル）
- **neighbor_elevation_1/2/3**: 隣接ノードの標高
- **elevation_diff_1/2/3**: ジャンクションノードと隣接ノード間の標高差
- **min_angle_index**: 最小角のインデックス (1-3)
- **min_elevation_diff**: 3つの高低差の最小値
- **max_elevation_diff**: 3つの高低差の最大値
- **min_angle_elevation_diff**: Generated Column（最小角を構成する2本の道路間の標高差）

### Indexes
- `idx_y_junctions_elevation` - 標高でのフィルタリング用
- `idx_y_junctions_min_elevation_diff` - 最小高低差でのフィルタリング用
- `idx_y_junctions_min_angle_elevation_diff` - 最小角高低差でのフィルタリング用

### Documentation
- `doc/elevation-feature.md` にPhase 4完了マークを追加
- 実装メモを記録

## Test plan

- [x] マイグレーション実行成功（`sqlx migrate run`）
- [x] 全カラムが正しく追加されたことを確認（`\d y_junctions`）
- [x] Generated Columnが正しく動作することを確認
- [x] 全カラムコメントが追加されたことを確認
- [x] Backend tests合格（43 tests passed）
- [x] Format check合格（`cargo fmt --check`）
- [x] Clippy check合格（`cargo clippy -- -D warnings`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)