### PR TITLE
fix: add missing min_angle_elevation_diff parameter

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,6 +35,9 @@ export async function fetchJunctions(
     if (filters?.limit !== undefined) {
       params.append('limit', filters.limit.toString());
     }
+    if (filters?.min_angle_elevation_diff !== undefined) {
+      params.append('min_angle_elevation_diff', filters.min_angle_elevation_diff.toString());
+    }
 
     const url = `${BASE_URL}/junctions?${params.toString()}`;
     const response = await fetch(url);

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -134,8 +134,8 @@ export const FilterPanel = memo(function FilterPanel({
             <input
               type="range"
               min="0"
-              max="50"
-              step="1"
+              max="5"
+              step="0.5"
               value={minAngleElevationDiff ?? 0}
               onChange={e => {
                 const value = Number(e.target.value);


### PR DESCRIPTION
## Summary
- Add missing `min_angle_elevation_diff` parameter to API client
- Change max elevation diff from 50m to 5m for more practical range

## Problem
Elevation search filter was not working because the `min_angle_elevation_diff` parameter was not being sent to the backend API.

## Changes
- `frontend/src/api/client.ts`: Add `min_angle_elevation_diff` parameter to API request
- `frontend/src/components/FilterPanel.tsx`: Adjust max value from 50m to 5m and step from 1m to 0.5m

## Test plan
- [x] TypeScript type check passed
- [x] ESLint check passed
- [x] Prettier format check passed
- [x] Manually tested elevation search filter in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added elevation angle difference filter for junction queries with enhanced precision controls
  * Refined filter range settings for more granular elevation difference selections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->