### PR TITLE
feat: add bridge/tunnel way tags to Y-junctions

### DIFF
--- a/backend/migrations/004_add_way_tags.sql
+++ b/backend/migrations/004_add_way_tags.sql
@@ -1,0 +1,17 @@
+-- Add bridge and tunnel tags for connected ways
+-- Migration 004: Add way tag information to identify bridges and tunnels
+
+ALTER TABLE y_junctions
+ADD COLUMN way_1_bridge BOOLEAN DEFAULT FALSE,
+ADD COLUMN way_1_tunnel BOOLEAN DEFAULT FALSE,
+ADD COLUMN way_2_bridge BOOLEAN DEFAULT FALSE,
+ADD COLUMN way_2_tunnel BOOLEAN DEFAULT FALSE,
+ADD COLUMN way_3_bridge BOOLEAN DEFAULT FALSE,
+ADD COLUMN way_3_tunnel BOOLEAN DEFAULT FALSE;
+
+-- Add index for filtering by bridge/tunnel
+CREATE INDEX idx_y_junctions_way_tags ON y_junctions (
+    way_1_bridge, way_1_tunnel,
+    way_2_bridge, way_2_tunnel,
+    way_3_bridge, way_3_tunnel
+);

--- a/backend/src/importer/inserter.rs
+++ b/backend/src/importer/inserter.rs
@@ -51,11 +51,13 @@ async fn insert_batch(
         "INSERT INTO y_junctions (osm_node_id, location, angle_1, angle_2, angle_3, bearings, \
          elevation, neighbor_elevation_1, neighbor_elevation_2, neighbor_elevation_3, \
          elevation_diff_1, elevation_diff_2, elevation_diff_3, \
-         min_angle_index, min_elevation_diff, max_elevation_diff) VALUES ",
+         min_angle_index, min_elevation_diff, max_elevation_diff, \
+         way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel, way_3_bridge, way_3_tunnel) VALUES ",
     );
 
-    const PARAMS_PER_ROW: usize = 19; // osm_node_id, lon, lat, angle_1, angle_2, angle_3, bearing_1, bearing_2, bearing_3,
-                                      // elevation, neighbor_elevation_1~3, elevation_diff_1~3, min_angle_index, min/max_elevation_diff
+    const PARAMS_PER_ROW: usize = 25; // osm_node_id, lon, lat, angle_1, angle_2, angle_3, bearing_1, bearing_2, bearing_3,
+                                      // elevation, neighbor_elevation_1~3, elevation_diff_1~3, min_angle_index, min/max_elevation_diff,
+                                      // way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel, way_3_bridge, way_3_tunnel
 
     for (i, _) in junctions.iter().enumerate() {
         if i > 0 {
@@ -64,7 +66,7 @@ async fn insert_batch(
         let base = i * PARAMS_PER_ROW + 1;
         query.push_str(&format!(
             "(${}, ST_SetSRID(ST_MakePoint(${}, ${}), 4326)::geography, ${}, ${}, ${}, ARRAY[${}, ${}, ${}], \
-             ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
+             ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${}, ${})",
             base,        // osm_node_id
             base + 1,    // lon
             base + 2,    // lat
@@ -83,7 +85,13 @@ async fn insert_batch(
             base + 15,   // elevation_diff_3
             base + 16,   // min_angle_index
             base + 17,   // min_elevation_diff
-            base + 18    // max_elevation_diff
+            base + 18,   // max_elevation_diff
+            base + 19,   // way_1_bridge
+            base + 20,   // way_1_tunnel
+            base + 21,   // way_2_bridge
+            base + 22,   // way_2_tunnel
+            base + 23,   // way_3_bridge
+            base + 24    // way_3_tunnel
         ));
     }
 
@@ -111,7 +119,13 @@ async fn insert_batch(
             .bind(junction.elevation_diffs.map(|e| e[2]))
             .bind(junction.min_angle_index)
             .bind(junction.min_elevation_diff)
-            .bind(junction.max_elevation_diff);
+            .bind(junction.max_elevation_diff)
+            .bind(junction.way_1_bridge)
+            .bind(junction.way_1_tunnel)
+            .bind(junction.way_2_bridge)
+            .bind(junction.way_2_tunnel)
+            .bind(junction.way_3_bridge)
+            .bind(junction.way_3_tunnel);
     }
 
     q.execute(&mut **tx).await?;


### PR DESCRIPTION
## Summary

- Add bridge/tunnel boolean flags for the three connected ways at each Y-junction
- Filter out junctions on bridges and tunnels when using elevation filters
- Migration 004 adds 6 columns: `way_1_bridge`, `way_1_tunnel`, `way_2_bridge`, `way_2_tunnel`, `way_3_bridge`, `way_3_tunnel`

## Changes

### Database
- **Migration 004**: Added 6 boolean columns to track bridge/tunnel status of each connected way
- Added composite index on all 6 columns for efficient filtering

### Importer
- Extract `bridge=yes` and `tunnel=yes` tags from OSM ways during PBF parsing
- Store bridge/tunnel information in `NodeConnectionCounter` 
- Populate the new columns during junction insertion

### API
- Filter out junctions with any bridge/tunnel tags when `min_angle_elevation_diff` or `max_angle_elevation_diff` parameters are used
- Junctions without elevation filter parameters include all junctions (no filtering)

### Tests
- Added test for bridge/tunnel tag storage in importer
- Added test for retrieval of connected way tags
- Added integration tests for filtering behavior with/without elevation filters

## Data Analysis

全データ（34,101地点）での除外状況:
- **除外されている地点**: 1,213地点（3.6%）
- 除外地点の高低差分布:
  - < 0.5m: 604件（49.8%）- 標高データは正確
  - ≥ 5m: 108件（8.9%）- 標高データに問題がある可能性

## Test Plan

- [x] Unit tests pass (29/29)
- [x] Code formatting check passes
- [x] Clippy check passes
- [ ] Integration tests require separate test database setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bridges and tunnels are now automatically filtered out when applying elevation-based search criteria, providing more relevant results for users seeking significant elevation changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->