### PR TITLE
fix: ensure Cloud Run traffic switches to new revisions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,6 +238,8 @@ jobs:
 
       - name: Verify deployment
         run: |
+          set -euo pipefail
+
           # Get the latest revision name
           LATEST_REVISION=$(gcloud run revisions list \
             --service=y-junctions-api \
@@ -245,12 +247,22 @@ jobs:
             --format="value(name)" \
             --sort-by=~createdTime \
             --limit=1)
+
+          if [ -z "$LATEST_REVISION" ]; then
+            echo "ERROR: Failed to get latest revision" >&2
+            exit 1
+          fi
           echo "Latest revision: $LATEST_REVISION"
 
           # Get the revision URL
           REVISION_URL=$(gcloud run revisions describe $LATEST_REVISION \
             --region=${{ secrets.GCP_REGION }} \
             --format='value(status.url)')
+
+          if [ -z "$REVISION_URL" ]; then
+            echo "ERROR: Failed to get revision URL for $LATEST_REVISION" >&2
+            exit 1
+          fi
           echo "Revision URL: $REVISION_URL"
 
           # Health check on the new revision
@@ -262,11 +274,13 @@ jobs:
             echo "Health check attempt $i failed, retrying..."
             sleep 10
           done
-          echo "Health check failed after 5 attempts"
+          echo "ERROR: Health check failed after 5 attempts" >&2
           exit 1
 
       - name: Switch traffic to new revision
         run: |
+          set -euo pipefail
+
           echo "Switching traffic to latest revision..."
           gcloud run services update-traffic y-junctions-api \
             --to-latest \


### PR DESCRIPTION
## Summary

- デプロイワークフローでトラフィックが新リビジョンに切り替わらない問題を修正
- `--no-traffic` フラグを追加して新リビジョンを0%トラフィックで作成
- 新リビジョンのURLに対してヘルスチェックを実行
- ヘルスチェック成功後に明示的にトラフィックを切り替え

## Changes

### `.github/workflows/deploy.yml`
- `gcloud run deploy` に `--no-traffic` フラグを追加
- "Verify deployment" ステップを修正:
  - サービスURLではなく新リビジョンのURLをヘルスチェック
  - 最新リビジョン名とURLを取得して検証
- "Switch traffic to new revision" ステップを追加:
  - ヘルスチェック成功後に `gcloud run services update-traffic` を実行
  - `--to-latest` で最新リビジョンにトラフィックを切り替え

## Background

以前のワークフローは `gcloud run deploy` のデフォルト動作（自動トラフィック切り替え）に依存していましたが、実際には新リビジョンにトラフィックが切り替わっていませんでした。この変更により、トラフィック切り替えを明示的に制御し、確実に新リビジョンがトラフィックを受け取るようにします。

## Test plan

- [ ] GitHub Actionsでbackend変更をデプロイ
- [ ] 新リビジョンが作成されることを確認
- [ ] ヘルスチェックが新リビジョンURLに対して実行されることを確認
- [ ] トラフィックが新リビジョンに切り替わることを確認
- [ ] デプロイ後にAPIが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow to delay automatic traffic shifts and perform an explicit switch to the verified revision.
  * Cleanup of older revisions after successful deployments to reduce clutter.

* **Bug Fixes**
  * Health checks now verify the latest revision URL with clearer per-revision status messaging.
  * Added automatic rollback to the previous revision if a deployment fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->