### PR TITLE
fix: add retry logic for revision URL retrieval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -254,15 +254,24 @@ jobs:
           fi
           echo "Latest revision: $LATEST_REVISION"
 
-          # Get the revision URL
-          REVISION_URL=$(gcloud run revisions describe $LATEST_REVISION \
-            --region=${{ secrets.GCP_REGION }} \
-            --format='value(status.url)')
+          # Get the revision URL with retry (wait for revision to be ready)
+          for retry in {1..30}; do
+            REVISION_URL=$(gcloud run revisions describe $LATEST_REVISION \
+              --region=${{ secrets.GCP_REGION }} \
+              --format='value(status.url)' 2>/dev/null || true)
 
-          if [ -z "$REVISION_URL" ]; then
-            echo "ERROR: Failed to get revision URL for $LATEST_REVISION" >&2
-            exit 1
-          fi
+            if [ -n "$REVISION_URL" ]; then
+              break
+            fi
+
+            if [ $retry -eq 30 ]; then
+              echo "ERROR: Timeout waiting for revision URL after 5 minutes" >&2
+              exit 1
+            fi
+
+            echo "Waiting for revision URL (attempt $retry/30)..."
+            sleep 10
+          done
           echo "Revision URL: $REVISION_URL"
 
           # Health check on the new revision


### PR DESCRIPTION
## Summary

デプロイ時にリビジョンURLが取得できずエラーになる問題を修正。

## Problem

PR #104 でデプロイワークフローを改善しましたが、リビジョンURLの検証を追加したことで新たな問題が発生:
- リビジョン作成直後はURLがまだ割り当てられていない
- 厳格な検証により即座にエラーで終了

## Changes

### `.github/workflows/deploy.yml`
- リビジョンURL取得時にリトライロジックを追加:
  - 最大30回リトライ (10秒間隔)
  - 合計タイムアウト: 5分
  - リトライ中は進捗を表示
  - エラー出力を抑制 (`2>/dev/null`)

```yaml
# Get the revision URL with retry (wait for revision to be ready)
for retry in {1..30}; do
  REVISION_URL=$(gcloud run revisions describe $LATEST_REVISION \
    --region=${{ secrets.GCP_REGION }} \
    --format='value(status.url)' 2>/dev/null || true)

  if [ -n "$REVISION_URL" ]; then
    break
  fi

  if [ $retry -eq 30 ]; then
    echo "ERROR: Timeout waiting for revision URL after 5 minutes" >&2
    exit 1
  fi

  echo "Waiting for revision URL (attempt $retry/30)..."
  sleep 10
done
```

## Test plan

- [ ] GitHub Actionsでbackend変更をデプロイ
- [ ] リビジョンURL取得のリトライログを確認
- [ ] デプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment process resilience to handle initialization timing variations and reduce deployment failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->