### PR TITLE
perf: skip elevation import for junctions with existing data

### DIFF
--- a/backend/src/db/repository.rs
+++ b/backend/src/db/repository.rs
@@ -299,6 +299,20 @@ pub async fn find_all(pool: &PgPool) -> Result<Vec<Junction>, sqlx::Error> {
     Ok(rows.into_iter().map(Junction::from).collect())
 }
 
+pub async fn find_without_elevation(pool: &PgPool) -> Result<Vec<Junction>, sqlx::Error> {
+    let rows: Vec<JunctionRow> = sqlx::query_as(
+        "SELECT id, osm_node_id, \
+         ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, \
+         angle_1, angle_2, angle_3, bearings, created_at, \
+         elevation, min_elevation_diff, max_elevation_diff, min_angle_elevation_diff \
+         FROM y_junctions WHERE elevation IS NULL",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(Junction::from).collect())
+}
+
 pub async fn bulk_update_elevations(
     pool: &PgPool,
     updates: &[ElevationUpdate],

--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -35,11 +35,11 @@ pub async fn import_elevation_data(pool: &PgPool, elevation_dir: &str) -> Result
     // Initialize elevation provider
     let mut elevation_provider = elevation::ElevationProvider::new(elevation_dir)?;
 
-    // Fetch all junctions from database using repository
-    let junctions = crate::db::repository::find_all(pool).await?;
+    // Fetch junctions without elevation data from database using repository
+    let junctions = crate::db::repository::find_without_elevation(pool).await?;
 
     tracing::info!(
-        "Found {} Y-junctions to enrich with elevation",
+        "Found {} Y-junctions without elevation data to process",
         junctions.len()
     );
 


### PR DESCRIPTION
## Summary

標高インポート処理を最適化し、既に標高データが存在するY字路をスキップするようにしました。
これにより、2回目以降のインポート実行が大幅に高速化されます。

## Changes

- **`backend/src/db/repository.rs`**: `find_without_elevation()` 関数を追加
  - `WHERE elevation IS NULL` で標高データがないY字路のみを取得
- **`backend/src/importer/mod.rs`**: `find_all()` から `find_without_elevation()` に変更
  - 既存データを持つY字路をスキップ

## Impact

- **初回インポート**: 変更なし（全Y字路を処理）
- **2回目以降**: 既存データを持つY字路をスキップし、処理時間を大幅削減

## Test Plan

- [x] `cargo test` - 全53テストが成功
- [x] `cargo fmt --check` - フォーマットチェック合格
- [x] `cargo clippy -- -D warnings` - Lintチェック合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data processing to more efficiently handle geographic locations requiring elevation information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->