### PR TITLE
fix: handle null min_angle_elevation_diff in JunctionPopup

### DIFF
--- a/frontend/src/components/JunctionPopup.tsx
+++ b/frontend/src/components/JunctionPopup.tsx
@@ -25,7 +25,7 @@ export function JunctionPopup({ properties }: JunctionPopupProps) {
           <div style={{ marginBottom: 4 }}>
             <strong>角度:</strong> {angles[0]}°, {angles[1]}°, {angles[2]}°
           </div>
-          {min_angle_elevation_diff !== undefined && (
+          {min_angle_elevation_diff != null && (
             <div>
               <strong>標高差:</strong> {min_angle_elevation_diff.toFixed(1)}m
             </div>


### PR DESCRIPTION
## Summary
- Fixed TypeError when clicking junction popup with null `min_angle_elevation_diff`
- Changed null check from `!== undefined` to `!= null` to handle both null and undefined values

## Problem
JunctionPopup was throwing `Cannot read properties of null (reading 'toFixed')` error when `min_angle_elevation_diff` was `null`. The backend returns `null` for this field when elevation data is not available, but the frontend only checked for `undefined`.

## Solution
Updated the conditional check in JunctionPopup.tsx from:
```typescript
{min_angle_elevation_diff !== undefined && (
```
to:
```typescript
{min_angle_elevation_diff != null && (
```

This ensures both `null` and `undefined` values are properly handled.

## Test plan
- ✅ All frontend checks passed (test, typecheck, format, lint)
- ✅ Pre-commit hooks passed successfully
- ✅ Tested locally - popup opens without errors for junctions with null elevation data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of elevation difference values in the junction popup to display in additional scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->