### PR TITLE
chore: リリースノート生成の改善

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,7 @@ categories:
       - 'bug'
 exclude-labels:
   - 'internal'
+  - 'dependencies'
 change-template: '- $TITLE (#$NUMBER)'
 template: |
   ## 変更内容
@@ -63,5 +64,7 @@ autolabeler:
       - '/^chore\/.*/'
       - '/^perf\/.*/'
       - '/^style\/.*/'
+      - '/^docs\/.*/'
+      - '/^dependabot\/.*/'
     title:
-      - '/refactor|chore|perf|style|リファクタ|チューニング|最適化/'
+      - '/refactor|chore|perf|style|docs|リファクタ|チューニング|最適化/'

--- a/README.md
+++ b/README.md
@@ -447,7 +447,8 @@ PRのマージ時にGitHub Releasesのドラフトが自動生成されます。
 - `data/*` - データ追加・更新 → `data` ラベル
 - `feature/*` - 新機能 → `feature` ラベル
 - `fix/*` または `bugfix/*` - バグ修正 → `bug` ラベル
-- `refactor/*`, `chore/*`, `perf/*`, `style/*` - 内部改善 → `internal` ラベル（リリースノートに含まれない）
+- `refactor/*`, `chore/*`, `perf/*`, `style/*`, `docs/*` - 内部改善・ドキュメント → `internal` ラベル（リリースノートに含まれない）
+- `dependabot/*` または dependabot作成のPR - 依存関係の自動更新 → `internal` ラベル（リリースノートに含まれない）
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要

release-drafter の設定を改善し、v0.1.0 のリリースノートを整理しました。

## 変更内容

### release-drafter.yml
- `dependencies` ラベルを除外リストに追加
- `docs/` と `dependabot/` ブランチを `internal` ラベルに自動分類
- 今後は dependabot やドキュメント変更が自動的にリリースノートから除外されます

### README.md
- ブランチ命名規則に `docs/*` と `dependabot/*` を追加

### v0.1.0 リリースノート
- 公開済み（https://github.com/cozy-corner/y-junctions/releases/tag/v0.1.0）
- 94件 → 6件に絞り込み、ユーザー視点で価値のある変更のみを記載
- 全国6地域のデータ（約201,400箇所）を正しく記載

## 今後の改善

次回以降のリリースでは、以下が自動的に除外されます：
- dependabot の PR
- chore/refactor/perf/style/docs の内部改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR labeling guidelines to clarify categorization of internal changes.

* **Chores**
  * Improved release process configuration to better handle categorization and exclusion of certain PR types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->