### PR TITLE
chore: enable auto-publish for release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,5 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
+        with:
+          publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

release-drafterの設定に `publish: true` を追加し、mainブランチへのマージ時にリリースノートを自動的に公開するようにしました。

## 変更内容

- `.github/workflows/release-drafter.yml` に `publish: true` パラメータを追加

## 効果

- **変更前**: PRマージ → ドラフトリリース作成 → 手動で公開が必要
- **変更後**: PRマージ → リリース自動公開

これにより、mainにマージされたPRのリリースノートが即座に公開されるようになります。

## 関連

- #117 のリリースノートがドラフト状態だった問題を解決
- v0.2.0 は手動で公開済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to enable automatic publishing of release drafts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->