### PR TITLE
chore: prevent auto-publish for internal PRs in release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,8 +28,37 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      # Check if the merged PR has 'internal' label
+      # If it does, don't publish the release (keep it as draft)
+      - name: Check merged PR labels
+        id: check-labels
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commit = context.sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: commit
+            });
+            
+            const mergedPR = prs.find(pr => pr.merged_at);
+            if (mergedPR) {
+              const hasInternal = mergedPR.labels.some(label => label.name === 'internal');
+              core.setOutput('should_publish', !hasInternal);
+              console.log(`PR #${mergedPR.number} has internal label: ${hasInternal}`);
+              console.log(`Will publish release: ${!hasInternal}`);
+            } else {
+              // No PR found, default to publishing
+              core.setOutput('should_publish', true);
+              console.log('No merged PR found, will publish release');
+            }
+      
       - uses: release-drafter/release-drafter@v6
         with:
-          publish: true
+          # Only publish if the merged PR doesn't have 'internal' label
+          # For pull_request events, always keep as draft (publish: false)
+          publish: ${{ github.event_name == 'push' && steps.check-labels.outputs.should_publish == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add conditional publishing logic to release-drafter workflow
- Check merged PR labels using GitHub API
- Skip auto-publishing if PR has 'internal' label (e.g., chore/* branches)
- Auto-publish releases only for feature/data PRs

## Problem
Currently, `publish: true` in release-drafter workflow causes releases to be auto-published for all PRs merged to main, including chore/* branches. This creates unintended releases like v0.2.1 when only internal changes were made.

## Solution
- Use `actions/github-script@v7` to query GitHub API for merged PR labels
- Check if PR has 'internal' label (automatically applied by autolabeler for chore/* branches)
- Conditionally set `publish` parameter based on label presence
- Maintain consistent boolean type usage in outputs

## Test Plan
- [ ] Merge this PR (chore branch with 'internal' label) → release should stay as draft
- [ ] Merge a data/* or feature/* PR → release should auto-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to selectively publish releases. Release publication is now conditional based on PR categorization, ensuring only relevant updates trigger automatic releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->