### PR TITLE
feat: add category search filter UI (PR3)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -152,6 +152,31 @@ body {
   border: 2px solid rgba(0, 0, 0, 0.1);
 }
 
+/* 道路カテゴリフィルター */
+.category-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.category-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.category-label:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.category-checkbox {
+  cursor: pointer;
+}
+
 /* 角度範囲フィルター */
 .angle-range-control {
   margin-bottom: 16px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,9 +16,11 @@ function App() {
     angleTypes,
     minAngleRange,
     elevationDiffRange,
+    categories,
     toggleAngleType,
     setMinAngleRange,
     setElevationDiffRange,
+    toggleCategory,
     resetFilters,
     toFilterParams,
   } = useFilters();
@@ -65,9 +67,11 @@ function App() {
               angleTypes={angleTypes}
               minAngleRange={minAngleRange}
               elevationDiffRange={elevationDiffRange}
+              categories={categories}
               onToggleAngleType={toggleAngleType}
               onMinAngleRangeChange={setMinAngleRange}
               onElevationDiffRangeChange={setElevationDiffRange}
+              onToggleCategory={toggleCategory}
               onReset={resetFilters}
             />
           </div>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -41,6 +41,10 @@ export async function fetchJunctions(
     if (filters?.max_angle_elevation_diff !== undefined) {
       params.append('max_angle_elevation_diff', filters.max_angle_elevation_diff.toString());
     }
+    if (filters?.category && filters.category.length > 0) {
+      // 配列形式で送信（?category=highway&category=major）
+      filters.category.forEach(cat => params.append('category', cat));
+    }
 
     const url = `${BASE_URL}/junctions?${params.toString()}`;
     const response = await fetch(url);

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -1,13 +1,15 @@
 import { memo } from 'react';
-import type { AngleType } from '../types';
+import type { AngleType, RoadCategory } from '../types';
 
 interface FilterPanelProps {
   angleTypes: AngleType[];
   minAngleRange: [number, number];
   elevationDiffRange: [number, number]; // 変更
+  categories: RoadCategory[]; // 道路カテゴリ
   onToggleAngleType: (type: AngleType) => void;
   onMinAngleRangeChange: (range: [number, number]) => void;
   onElevationDiffRangeChange: (range: [number, number]) => void; // 変更
+  onToggleCategory: (category: RoadCategory) => void; // 道路カテゴリトグル
   onReset: () => void;
 }
 
@@ -23,13 +25,22 @@ const ANGLE_TYPE_COLORS: Record<AngleType, string> = {
   normal: '#F59E0B', // 濃い黄色（琥珀色） - 通常
 };
 
+const CATEGORY_LABELS: Record<RoadCategory, string> = {
+  highway: '高速道路級',
+  major: '主要道路',
+  local: '生活道路',
+  pedestrian: '歩道',
+};
+
 export const FilterPanel = memo(function FilterPanel({
   angleTypes,
   minAngleRange,
   elevationDiffRange,
+  categories,
   onToggleAngleType,
   onMinAngleRangeChange,
   onElevationDiffRangeChange,
+  onToggleCategory,
   onReset,
 }: FilterPanelProps) {
   const [minValue, maxValue] = minAngleRange;
@@ -175,6 +186,27 @@ export const FilterPanel = memo(function FilterPanel({
           >
             リセット
           </button>
+        </div>
+      </div>
+
+      {/* 道路カテゴリ */}
+      <div className="filter-section">
+        <h3>道路カテゴリ</h3>
+        <p style={{ fontSize: 12, color: '#666', marginBottom: 8 }}>
+          選択したカテゴリを1本でも含むY字路を表示
+        </p>
+        <div className="category-options">
+          {(['highway', 'major', 'local', 'pedestrian'] as RoadCategory[]).map(category => (
+            <label key={category} className="category-label">
+              <input
+                type="checkbox"
+                checked={categories.includes(category)}
+                onChange={() => onToggleCategory(category)}
+                className="category-checkbox"
+              />
+              <span>{CATEGORY_LABELS[category]}</span>
+            </label>
+          ))}
         </div>
       </div>
 

--- a/frontend/src/hooks/useFilters.ts
+++ b/frontend/src/hooks/useFilters.ts
@@ -1,22 +1,30 @@
 import { useState, useCallback } from 'react';
-import type { AngleType, FilterParams } from '../types';
+import type { AngleType, RoadCategory, FilterParams } from '../types';
 
 export interface FilterState {
   angleTypes: AngleType[];
   minAngleRange: [number, number];
   elevationDiffRange: [number, number]; // 変更: number | null → [number, number]
+  categories: RoadCategory[]; // 道路カテゴリ
 }
 
 export function useFilters() {
   const [angleTypes, setAngleTypes] = useState<AngleType[]>(['verysharp', 'sharp', 'normal']);
   const [minAngleRange, setMinAngleRange] = useState<[number, number]>([0, 60]);
   const [elevationDiffRange, setElevationDiffRange] = useState<[number, number]>([0, 10]);
+  const [categories, setCategories] = useState<RoadCategory[]>([
+    'highway',
+    'major',
+    'local',
+    'pedestrian',
+  ]);
 
   // フィルタをリセット
   const resetFilters = useCallback(() => {
     setAngleTypes(['verysharp', 'sharp', 'normal']);
     setMinAngleRange([0, 60]);
     setElevationDiffRange([0, 10]);
+    setCategories(['highway', 'major', 'local', 'pedestrian']);
   }, []);
 
   // angle_typeの切り替え
@@ -26,6 +34,17 @@ export function useFilters() {
         return prev.filter(t => t !== type);
       } else {
         return [...prev, type];
+      }
+    });
+  }, []);
+
+  // categoryの切り替え
+  const toggleCategory = useCallback((category: RoadCategory) => {
+    setCategories(prev => {
+      if (prev.includes(category)) {
+        return prev.filter(c => c !== category);
+      } else {
+        return [...prev, category];
       }
     });
   }, []);
@@ -56,20 +75,28 @@ export function useFilters() {
       params.max_angle_elevation_diff = elevationDiffRange[1];
     }
 
+    // categoryを配列として送る（0個または4個の場合は送らない＝全選択扱い）
+    if (categories.length > 0 && categories.length < 4) {
+      params.category = categories;
+    }
+
     return params;
-  }, [angleTypes, minAngleRange, elevationDiffRange]);
+  }, [angleTypes, minAngleRange, elevationDiffRange, categories]);
 
   return {
     // 状態
     angleTypes,
     minAngleRange,
     elevationDiffRange,
+    categories,
 
     // セッター
     setAngleTypes,
     setMinAngleRange,
     setElevationDiffRange,
+    setCategories,
     toggleAngleType,
+    toggleCategory,
 
     // アクション
     resetFilters,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,9 @@
 // AngleType
 export type AngleType = 'verysharp' | 'sharp' | 'normal';
 
+// RoadCategory
+export type RoadCategory = 'highway' | 'major' | 'local' | 'pedestrian';
+
 // Junction (単体取得時のレスポンス)
 export interface Junction {
   id: number;
@@ -61,6 +64,7 @@ export interface FilterParams {
   min_angle_gt?: number;
   min_angle_elevation_diff?: number;
   max_angle_elevation_diff?: number; // 範囲検索用
+  category?: RoadCategory[]; // 道路カテゴリ
   limit?: number;
 }
 


### PR DESCRIPTION
## Summary
- Add road category filter UI to FilterPanel
- Implement category state management in useFilters hook
- Send category parameters to backend API

## Changes
- Add `RoadCategory` type (highway/major/local/pedestrian)
- Implement category filter state management with `toggleCategory` function
- Add category filter UI with checkboxes (without color indicators)
- Send category parameters as array format to API (`?category=highway&category=major`)
- Update `FilterParams` type to include `category` field
- Add CSS styles for category filter section

## Test plan
- [x] TypeScript type check passed
- [x] ESLint passed
- [x] Prettier format check passed
- [x] Frontend tests passed (with no tests)
- [x] Manual testing: category filter works correctly in UI
- [x] Manual testing: API receives correct category parameters

## Screenshots
Category filter UI has been added to the left sidebar with 4 checkboxes:
- 高速道路級 (highway)
- 主要道路 (major)
- 生活道路 (local)
- 歩道 (pedestrian)

Color indicators were removed to avoid confusion with marker colors (which are based on angle type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced road category filtering allowing users to refine junction results by road type. Filter options include highway, major, local, and pedestrian roads. Multiple categories can be selected simultaneously for more granular search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->