### PR TITLE
fix: カテゴリフィルタのラベルを「歩道」から「歩行者系」に修正

### DIFF
--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -29,7 +29,7 @@ const CATEGORY_LABELS: Record<RoadCategory, string> = {
   highway: '高速道路級',
   major: '主要道路',
   local: '生活道路',
-  pedestrian: '歩道',
+  pedestrian: '歩行者系',
 };
 
 export const FilterPanel = memo(function FilterPanel({


### PR DESCRIPTION
## Summary
カテゴリフィルタのラベルを「歩道」から「歩行者系」に修正しました。

## 変更内容
- `frontend/src/components/FilterPanel.tsx` の `CATEGORY_LABELS` で `pedestrian` カテゴリのラベルを変更

## 背景
`pedestrian` カテゴリは以下を含みます：
- `steps`（階段）
- `pedestrian`（歩行者専用道路）
- `path`（小径・遊歩道）

これらは道路法や道路交通法で定義される「歩道」（車道の脇に縁石で区切られた部分）とは異なるため、より正確な「歩行者系」というラベルに変更しました。

## Test plan
- [x] 型チェック（npm run typecheck）
- [x] フォーマットチェック（npm run format:check）
- [x] Lintチェック（npm run lint）
- [x] テスト（npm test）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the pedestrian road category label in the filter panel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->