### PR TITLE
インポート時にmotorway/motorway_linkを除外

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ COPY (
 " > ~/y-junctions-data/export.csv
 
 # 3. 本番DBから全データを削除
-docker run --rm postgres:15-alpine psql "$PROD_DB_URL" -c "DELETE FROM y_junctions;"
+docker run --rm postgres:15-alpine psql "$PROD_DB_URL" -c "TRUNCATE TABLE y_junctions RESTART IDENTITY;"
 
 # 4. 本番DBに新データをCOPYでインポート
 cat ~/y-junctions-data/export.csv | docker run --rm -i postgres:15-alpine psql "$PROD_DB_URL" -c "

--- a/backend/src/importer/detector.rs
+++ b/backend/src/importer/detector.rs
@@ -124,8 +124,7 @@ impl NodeConnectionCounter {
         let mut valid_highway_types = HashSet::new();
 
         // Add common road types for Y-junction detection
-        // Primary roads
-        valid_highway_types.insert("motorway".to_string());
+        // Primary roads (excluding motorway - filtered out)
         valid_highway_types.insert("trunk".to_string());
         valid_highway_types.insert("primary".to_string());
         valid_highway_types.insert("secondary".to_string());
@@ -136,8 +135,7 @@ impl NodeConnectionCounter {
         valid_highway_types.insert("unclassified".to_string());
         valid_highway_types.insert("service".to_string());
 
-        // Links
-        valid_highway_types.insert("motorway_link".to_string());
+        // Links (excluding motorway_link - filtered out)
         valid_highway_types.insert("trunk_link".to_string());
         valid_highway_types.insert("primary_link".to_string());
         valid_highway_types.insert("secondary_link".to_string());
@@ -151,7 +149,6 @@ impl NodeConnectionCounter {
         // Core highway types (traditional roads, not pedestrian ways)
         // At least one core highway is required to avoid pure hiking trails
         let mut core_highway_types = HashSet::new();
-        core_highway_types.insert("motorway".to_string());
         core_highway_types.insert("trunk".to_string());
         core_highway_types.insert("primary".to_string());
         core_highway_types.insert("secondary".to_string());
@@ -159,7 +156,6 @@ impl NodeConnectionCounter {
         core_highway_types.insert("residential".to_string());
         core_highway_types.insert("unclassified".to_string());
         core_highway_types.insert("service".to_string());
-        core_highway_types.insert("motorway_link".to_string());
         core_highway_types.insert("trunk_link".to_string());
         core_highway_types.insert("primary_link".to_string());
         core_highway_types.insert("secondary_link".to_string());
@@ -526,8 +522,9 @@ mod tests {
         assert!(counter.is_valid_highway_type("residential"));
         assert!(counter.is_valid_highway_type("tertiary"));
         assert!(counter.is_valid_highway_type("primary"));
-        assert!(counter.is_valid_highway_type("motorway"));
 
+        assert!(!counter.is_valid_highway_type("motorway"));
+        assert!(!counter.is_valid_highway_type("motorway_link"));
         assert!(!counter.is_valid_highway_type("footway"));
         assert!(!counter.is_valid_highway_type("cycleway"));
 


### PR DESCRIPTION
## 変更内容

- `detector.rs`の`valid_highway_types`から`motorway`と`motorway_link`を削除
- `detector.rs`の`core_highway_types`から`motorway`と`motorway_link`を削除
- `motorway`と`motorway_link`が無効な道路タイプであることを検証するテストケースを追加
- `README.md`の本番DB削除コマンドを`DELETE`から`TRUNCATE TABLE ... RESTART IDENTITY`に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Y-junction detection to exclude motorways and motorway links from analysis. This improves the accuracy and relevance of detected junctions when analyzing road networks and geographic data.

* **Improvements**
  * Optimized the data import-export workflow with an enhanced database clearing operation. This improved method reduces processing time while ensuring proper data consistency during all imports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->