### PR TITLE
フロントエンドの角度フィルターを10度からスタートに変更

### DIFF
--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -101,7 +101,7 @@ export const FilterPanel = memo(function FilterPanel({
             <label style={{ fontSize: 12, color: '#666' }}>最小値: {minValue}°</label>
             <input
               type="range"
-              min="0"
+              min="10"
               max="60"
               value={minValue}
               onChange={e => handleMinChange(Number(e.target.value))}
@@ -114,7 +114,7 @@ export const FilterPanel = memo(function FilterPanel({
             <label style={{ fontSize: 12, color: '#666' }}>最大値: {maxValue}°</label>
             <input
               type="range"
-              min="0"
+              min="10"
               max="60"
               value={maxValue}
               onChange={e => handleMaxChange(Number(e.target.value))}
@@ -123,7 +123,7 @@ export const FilterPanel = memo(function FilterPanel({
           </div>
 
           <button
-            onClick={() => onMinAngleRangeChange([0, 60])}
+            onClick={() => onMinAngleRangeChange([10, 60])}
             className="angle-range-clear-button"
           >
             リセット

--- a/frontend/src/hooks/useFilters.ts
+++ b/frontend/src/hooks/useFilters.ts
@@ -10,7 +10,7 @@ export interface FilterState {
 
 export function useFilters() {
   const [angleTypes, setAngleTypes] = useState<AngleType[]>(['verysharp', 'sharp', 'normal']);
-  const [minAngleRange, setMinAngleRange] = useState<[number, number]>([0, 60]);
+  const [minAngleRange, setMinAngleRange] = useState<[number, number]>([10, 60]);
   const [elevationDiffRange, setElevationDiffRange] = useState<[number, number]>([0, 10]);
   const [categories, setCategories] = useState<RoadCategory[]>([
     'highway',
@@ -22,7 +22,7 @@ export function useFilters() {
   // フィルタをリセット
   const resetFilters = useCallback(() => {
     setAngleTypes(['verysharp', 'sharp', 'normal']);
-    setMinAngleRange([0, 60]);
+    setMinAngleRange([10, 60]);
     setElevationDiffRange([0, 10]);
     setCategories(['highway', 'major', 'local', 'pedestrian']);
   }, []);
@@ -58,8 +58,8 @@ export function useFilters() {
       params.angle_type = angleTypes;
     }
 
-    // minAngleRangeが初期値(0, 60)でない場合のみ送信
-    if (minAngleRange[0] > 0) {
+    // minAngleRangeが初期値(10, 60)でない場合のみ送信
+    if (minAngleRange[0] > 10) {
       params.min_angle_gt = minAngleRange[0];
     }
 


### PR DESCRIPTION
## 概要
PR #147のバックエンド変更に対応し、フロントエンドの角度フィルターを10度からスタートするように変更

## 変更内容
- `frontend/src/hooks/useFilters.ts`: デフォルト値を `[10, 60]` に変更
- `frontend/src/components/FilterPanel.tsx`: スライダーの最小値を10度に設定

## 動作確認
- ✅ 型チェック通過
- ✅ Lint通過
- ✅ フォーマットチェック通過
- ✅ ローカルで動作確認済み

## 関連PR
- #147: 最小角度10度未満のY字路データを除外（バックエンド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified angle filter minimum bounds from 0° to 10°. Users can no longer select angle values below 10 degrees. Both the minimum and maximum angle sliders now enforce this lower boundary. The reset action now initializes the angle range to 10-60° instead of the previous 0-60° default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->