### PR TITLE
Fix backend deployment trigger to exclude import tools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
+      backend-deploy: ${{ steps.filter.outputs.backend-deploy }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - name: Checkout code
@@ -26,9 +27,20 @@ jobs:
         id: filter
         with:
           filters: |
+            # backend: Triggers tests for any backend changes
             backend:
               - 'backend/**'
               - '.github/workflows/deploy.yml'
+            # backend-deploy: Triggers deployment, excluding CLI import tools
+            backend-deploy:
+              - 'backend/src/**'
+              - '!backend/src/bin/import*.rs'  # Import tools are CLI-only, not deployed
+              - 'backend/Cargo.toml'
+              - 'backend/Cargo.lock'
+              - 'backend/Dockerfile'
+              - 'backend/migrations/**'
+              - '.github/workflows/deploy.yml'
+            # frontend: Triggers tests and deployment for frontend changes
             frontend:
               - 'frontend/**'
               - '.github/workflows/deploy.yml'
@@ -158,7 +170,7 @@ jobs:
     needs: [changes, backend-test]
     if: |
       always() &&
-      needs.changes.outputs.backend == 'true' &&
+      needs.changes.outputs.backend-deploy == 'true' &&
       needs.backend-test.result == 'success'
 
     permissions:


### PR DESCRIPTION
## Summary
Import tools (import.rs, import_elevation.rs, import_two_way.rs) are CLI-only binaries that don't need to be deployed to Cloud Run. This PR prevents unnecessary API server deployments when only import tools are modified.

## Changes
- Add `backend-deploy` filter that excludes `backend/src/bin/import*.rs`
- Update `backend-deploy` job to use `backend-deploy` filter instead of `backend` filter
- `backend` filter still triggers tests for all backend changes (including import tools)
- Add documentation comments explaining filter purposes

## Behavior
| File Changed | backend-test | backend-deploy |
|--------------|--------------|----------------|
| `backend/src/bin/import*.rs` | ✅ Run | ⏭️ Skip |
| `backend/src/main.rs` (API) | ✅ Run | ✅ Run |
| `backend/Cargo.toml` | ✅ Run | ✅ Run |
| `backend/migrations/**` | ✅ Run | ✅ Run |

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test that import tool changes skip deployment
- [ ] Test that API code changes trigger deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized backend deployment workflow detection to trigger deployments based on relevant source code changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->