### PR TITLE
高低差フィルタを0.1m単位で調整可能に改善

### DIFF
--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -151,10 +151,10 @@ export const FilterPanel = memo(function FilterPanel({
               type="range"
               min="0"
               max="10"
-              step="0.5"
+              step="0.1"
               value={elevationDiffRange[0]}
               onChange={e => {
-                const newMin = Math.min(Number(e.target.value), elevationDiffRange[1] - 0.5);
+                const newMin = Math.min(Number(e.target.value), elevationDiffRange[1] - 0.1);
                 onElevationDiffRangeChange([newMin, elevationDiffRange[1]]);
               }}
               className="angle-range-slider"
@@ -170,10 +170,10 @@ export const FilterPanel = memo(function FilterPanel({
               type="range"
               min="0"
               max="10"
-              step="0.5"
+              step="0.1"
               value={elevationDiffRange[1]}
               onChange={e => {
-                const newMax = Math.max(Number(e.target.value), elevationDiffRange[0] + 0.5);
+                const newMax = Math.max(Number(e.target.value), elevationDiffRange[0] + 0.1);
                 onElevationDiffRangeChange([elevationDiffRange[0], newMax]);
               }}
               className="angle-range-slider"


### PR DESCRIPTION
## Summary
高低差フィルタの精度を向上させ、0.5m単位から0.1m単位で調整できるように改善しました。

## Changes
- スライダーのstep値を0.5から0.1に変更
- 最小値と最大値の最小差を0.5から0.1に調整
- より細かい高低差フィルタリングが可能に

## Test plan
- [x] TypeScript型チェック成功
- [x] ESLint成功
- [x] Prettierフォーマットチェック成功
- [x] ローカル環境で動作確認完了

## UI Changes
フィルターパネルの「最小角度の標高差」スライダーが0.1m刻みで調整可能になりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Elevation difference range sliders now support finer precision adjustments (0.1 step increments) for more granular filtering control.
  * Updated elevation range boundary constraints for improved slider behavior and clearer filtering boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->