### PR TITLE
Update cold start optimization documentation

### DIFF
--- a/doc/cold-start-optimization.md
+++ b/doc/cold-start-optimization.md
@@ -175,7 +175,7 @@ default_endpoint_settings {
 - **Neon有料プラン（Launch以上）へのアップグレード（必須）**
   - Freeプランではautosuspend設定が5分固定で変更不可
   - Launch/Scaleプランは使用量ベース課金（月額最低料金なし）
-  - 出典: [Neon Pricing](https://neon.com/pricing), [Neon Scale to Zero](https://neon.com/docs/guides/auto-suspend-compute)
+  - 出典: [Neon Pricing](https://neon.com/pricing), [Neon Scale to Zero](https://neon.com/docs/guides/scale-to-zero-guide)
 - **推定月額コスト（2026年1月時点の使用量ベース料金）:**
   - Launchプラン基本使用: 約5ドル/月〜（コンピュート時間次第）
   - Autosuspend延長による追加compute使用: 0-5ドル/月程度（アクセスパターン次第）


### PR DESCRIPTION
## 概要

Cold start最適化ドキュメント（`doc/cold-start-optimization.md`）を全面改訂し、技術的に正確で実用的な内容に更新しました。

## 主な変更

### 1. ドキュメント構造の改善
- 事実と推測を明確に区別（各項目内でマーク）
- 時系列に沿った構成に変更
- 重複情報を排除

### 2. コスト情報の修正
- **Phase 2（Autosuspend延長）**: 「0-5ドル/月」→「月19-24ドル」
  - Neon有料プラン（Neon Pro以上）へのアップグレードが必須であることを明記
- **Connection Pooler**: 無料プランでも利用可能（追加料金なし）と確認

### 3. 技術的正確性の向上
- **Phase 3-1（SSL最適化）**: 実施不可能なセクションに移動
  - SQLx 0.8が未サポート
  - PostgreSQL 16使用中（17以降が必要）
- **Connection Pooler**: 「効果不明」→「アクセス頻度依存」
  - 4つのシナリオ表を追加
  - アクセスパターン別の効果を明記
- **connect_lazy()**: 「効果なし」→「副次的メリットあり」
  - 可用性向上などのメリットを記載

### 4. Phase番号の削除
- 実施可能な対策と実施不可能な対策を明確に区別
- 「Phase 2以降の対策候補」→「追加対策候補」+「技術的制約により実施不可」

## 影響範囲

- ドキュメントのみの変更
- コードやインフラへの影響なし

## チェックリスト

- [x] ドキュメントの技術的正確性を確認
- [x] 外部資料（Neon公式ドキュメント等）で事実確認
- [x] 推測部分に明示的なマークを追加
- [x] 重複排除と構成改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the Cloud Run cold-start guide into a phased report (Summary, Phase 1/2/3) with clearer structure.
  * Added Phase 1 implementation details, measurable before/after performance metrics, and a small monthly cost estimate.
  * Added Phase 1–centric conclusion, proposed follow-ups (Autosuspend, Connection Pooler, connect_lazy()), SSL negotiation feasibility note, and external references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->