### PR TITLE
Fix Dependabot configuration to consolidate PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       - "rust"
     groups:
       backend-dependencies:
-        applies-to: security-updates
         patterns:
           - "*"
 
@@ -33,7 +32,6 @@ updates:
       - "frontend"
     groups:
       frontend-dependencies:
-        applies-to: security-updates
         patterns:
           - "*"
 
@@ -51,7 +49,6 @@ updates:
       - "devtools"
     groups:
       devtools-dependencies:
-        applies-to: security-updates
         patterns:
           - "*"
 
@@ -69,6 +66,5 @@ updates:
       - "github-actions"
     groups:
       actions-dependencies:
-        applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Fix Dependabot configuration to properly consolidate dependency updates into single PRs per ecosystem.

## Problem

Despite having group configurations, Dependabot was creating multiple individual PRs:
- Frontend: separate PRs for linting, testing, react, vite groups
- Backend: individual PRs for each dependency (chrono, tower, serde_json, etc.)

**Root cause**: Group overlap between `security-updates` (using `update-types`) and `all-dependencies` (using `patterns: ["*"]`). Both groups matched the same updates, causing Dependabot to fall back to individual PRs.

## Changes

Removed overlapping groups and simplified to **one group per ecosystem**:

| Ecosystem | Group Name | Pattern | Expected PRs |
|-----------|------------|---------|--------------|
| Backend (Rust) | `backend-dependencies` | `*` | 1 per week |
| Frontend (npm) | `frontend-dependencies` | `*` | 1 per week |
| Devtools (npm) | `devtools-dependencies` | `*` | 1 per week |
| GitHub Actions | `actions-dependencies` | `*` | 1 per month |

Also adjusted `open-pull-requests-limit` from 5 to 3 (sufficient for grouped updates).

## Expected Behavior

**Before:**
```
PR #158: chore(deps-dev): Bump @types/react
PR #159: chore(deps-dev): Bump the linting group
PR #152: chore(deps): Bump chrono
PR #151: chore(deps): Bump tower
```

**After:**
```
PR: chore(deps): Update backend-dependencies (chrono, tower, serde_json, etc.)
PR: chore(deps-dev): Update frontend-dependencies (react, eslint, vitest, etc.)
```

## Trade-offs

- ✅ Significantly reduced PR count (from 10+ to ~4 per week)
- ✅ Easier review of related updates together
- ⚠️ Security updates bundled with regular updates (no separate urgent PRs)
- ℹ️ Dependabot still highlights security updates within grouped PRs

## Verification

Reviewed by git-workflow-manager agent:
- ✅ No group overlap or conflicts
- ✅ Valid YAML syntax
- ✅ Appropriate settings for consolidation
- ✅ Will function as intended

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced maximum concurrent dependency update pull requests from 5 to 3 across backend, frontend, development tools, and Actions scopes.
  * Reorganized dependency update groups into per-scope groups (backend, frontend, devtools, Actions) replacing the previous combined groupings.
  * Preserved existing match patterns for these new per-scope groups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->