### PR TITLE
refactor(db): Replace && operator with ST_Intersects for CockroachDB compatibility

### DIFF
--- a/backend/src/db/repository.rs
+++ b/backend/src/db/repository.rs
@@ -85,7 +85,7 @@ impl From<JunctionRow> for Junction {
 
 // ヘルパー関数: bboxフィルタを追加
 fn add_bbox_filter(builder: &mut QueryBuilder<sqlx::Postgres>, bbox: (f64, f64, f64, f64)) {
-    builder.push("WHERE location && ST_MakeEnvelope(");
+    builder.push("WHERE ST_Intersects(location::geometry, ST_MakeEnvelope(");
     builder.push_bind(bbox.0);
     builder.push(", ");
     builder.push_bind(bbox.1);
@@ -93,7 +93,7 @@ fn add_bbox_filter(builder: &mut QueryBuilder<sqlx::Postgres>, bbox: (f64, f64, 
     builder.push_bind(bbox.2);
     builder.push(", ");
     builder.push_bind(bbox.3);
-    builder.push(", 4326)");
+    builder.push(", 4326))");
 }
 
 // ヘルパー関数: angle_typeフィルタを追加


### PR DESCRIPTION
## Summary

Replace PostgreSQL-specific `&&` operator with standard `ST_Intersects` function in bbox filter to enable seamless database switching between Neon PostgreSQL and CockroachDB Serverless.

## Changes

- **File**: `backend/src/db/repository.rs`
- **Function**: `add_bbox_filter()`
- **Before**: `WHERE location && ST_MakeEnvelope(...)`
- **After**: `WHERE ST_Intersects(location::geometry, ST_MakeEnvelope(...))`

## Technical Details

### Compatibility
- ✅ **PostGIS**: `ST_Intersects` uses `&&` internally for fast bbox check, then performs exact intersection test
- ✅ **CockroachDB**: `ST_Intersects` also leverages spatial indexes (GIN instead of GIST)
- ✅ **Performance**: Negligible difference in practice for this use case

### Testing
- ✅ All 75 tests passed (`cargo test`)
- ✅ Format check passed (`cargo fmt --check`)
- ✅ Clippy check passed (`cargo clippy -- -D warnings`)

## Related Documentation

- `doc/database-migration-strategy.md` - Database switching strategy (Neon ⇔ CockroachDB)
- This is the implementation of **PR #1** from the migration plan

## References

- [PostGIS Performance Tips](https://postgis.net/docs/manual-3.0/performance_tips.html)
- [CockroachDB ST_Intersects](https://www.cockroachlabs.com/docs/stable/st_intersects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spatial bounding box filtering accuracy to ensure correct results when filtering by geographic locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->