### PR TITLE
fix(deps): Update bytes and flate2 to fix security audit

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -239,9 +239,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -542,9 +542,9 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",


### PR DESCRIPTION
## Summary
- Update `bytes` from 1.11.0 to 1.11.1 to fix RUSTSEC-2026-0007 (Integer overflow in `BytesMut::reserve`)
- Update `flate2` from 1.1.7 to 1.1.9 to resolve yanked version warning

## Test plan
- [x] Security audit passes (`cargo audit`)
- [x] All backend tests pass (75/75 tests)
- [x] Format check passes (`cargo fmt --check`)
- [x] Clippy check passes (`cargo clippy -- -D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)