### PR TITLE
fix(frontend): Use osm_node_id as React key for Marker

### DIFF
--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -114,10 +114,10 @@ export const MapView = memo(function MapView({
   const markers = useMemo(() => {
     return data?.features.map(feature => {
       const [lon, lat] = feature.geometry.coordinates;
-      const { id, angle_type } = feature.properties;
+      const { osm_node_id, angle_type } = feature.properties;
 
       return (
-        <Marker key={id} position={[lat, lon]} icon={getMarkerIcon(angle_type)}>
+        <Marker key={osm_node_id} position={[lat, lon]} icon={getMarkerIcon(angle_type)}>
           <Popup>
             <JunctionPopup properties={feature.properties} />
           </Popup>


### PR DESCRIPTION
## Summary

- CockroachDB の `BIGSERIAL`（`unique_rowid()`）が生成する大きな64bit整数が `Number.MAX_SAFE_INTEGER` を超え、フロントエンドで精度が失われる
- 異なる `id` が同じ数値に丸められ、React の重複 key 警告が発生してマーカーのポップアップが空白になっていた
- `id` の代わりに `osm_node_id`（安全な整数範囲内・UNIQUE制約あり）を React の `key` として使用することで修正

## Test plan

- [ ] フロントエンドを起動し、マーカーをクリックしてポップアップが正しく表示されることを確認
- [ ] ブラウザのコンソールに重複 key 警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal marker identification mechanism in map view for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->