### PR TITLE
perf: STORED lat/lon + B-tree インデックスで大bboxクエリを13x高速化

### DIFF
--- a/backend/migrations/006_add_lon_lat_stored.sql
+++ b/backend/migrations/006_add_lon_lat_stored.sql
@@ -1,0 +1,9 @@
+-- Add STORED lat/lon columns to avoid ST_Y/ST_X per-row computation
+-- and enable efficient B-tree range scan instead of spatial index full scan
+ALTER TABLE y_junctions
+  ADD COLUMN lat FLOAT8 GENERATED ALWAYS AS (ST_Y(location::geometry)) STORED,
+  ADD COLUMN lon FLOAT8 GENERATED ALWAYS AS (ST_X(location::geometry)) STORED;
+
+-- B-tree index on (lon, lat) for efficient bbox range queries
+-- Replaces ST_Intersects + spatial inverted index with simple BETWEEN scan
+CREATE INDEX idx_y_junctions_lon_lat ON y_junctions (lon, lat);

--- a/backend/src/db/repository.rs
+++ b/backend/src/db/repository.rs
@@ -85,15 +85,14 @@ impl From<JunctionRow> for Junction {
 
 // ヘルパー関数: bboxフィルタを追加
 fn add_bbox_filter(builder: &mut QueryBuilder<sqlx::Postgres>, bbox: (f64, f64, f64, f64)) {
-    builder.push("WHERE ST_Intersects(location, ST_MakeEnvelope(");
-    builder.push_bind(bbox.0);
-    builder.push(", ");
-    builder.push_bind(bbox.1);
-    builder.push(", ");
-    builder.push_bind(bbox.2);
-    builder.push(", ");
-    builder.push_bind(bbox.3);
-    builder.push(", 4326)::geography)");
+    builder.push("WHERE lon BETWEEN ");
+    builder.push_bind(bbox.0); // min_lon
+    builder.push(" AND ");
+    builder.push_bind(bbox.2); // max_lon
+    builder.push(" AND lat BETWEEN ");
+    builder.push_bind(bbox.1); // min_lat
+    builder.push(" AND ");
+    builder.push_bind(bbox.3); // max_lat
 }
 
 // ヘルパー関数: angle_typeフィルタを追加
@@ -195,7 +194,7 @@ pub async fn find_by_bbox(
 
     let mut query_builder = QueryBuilder::new(
         "SELECT id, osm_node_id, \
-         ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, \
+         lat, lon, \
          angle_1, angle_2, angle_3, bearings, created_at, \
          elevation, min_elevation_diff, max_elevation_diff, min_angle_elevation_diff, \
          way_1_highway_type, way_2_highway_type, way_3_highway_type, \
@@ -249,7 +248,7 @@ pub async fn find_by_bbox(
 pub async fn find_by_id(pool: &PgPool, id: i64) -> Result<Option<Junction>, sqlx::Error> {
     let row: Option<JunctionRow> = sqlx::query_as(
         "SELECT id, osm_node_id, \
-         ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, \
+         lat, lon, \
          angle_1, angle_2, angle_3, bearings, created_at, \
          elevation, min_elevation_diff, max_elevation_diff, min_angle_elevation_diff, \
          way_1_highway_type, way_2_highway_type, way_3_highway_type, \
@@ -298,7 +297,7 @@ pub async fn count_total(pool: &PgPool) -> Result<i64, sqlx::Error> {
 pub async fn find_all(pool: &PgPool) -> Result<Vec<Junction>, sqlx::Error> {
     let rows: Vec<JunctionRow> = sqlx::query_as(
         "SELECT id, osm_node_id, \
-         ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, \
+         lat, lon, \
          angle_1, angle_2, angle_3, bearings, created_at, \
          elevation, min_elevation_diff, max_elevation_diff, min_angle_elevation_diff, \
          way_1_highway_type, way_2_highway_type, way_3_highway_type, \
@@ -314,7 +313,7 @@ pub async fn find_all(pool: &PgPool) -> Result<Vec<Junction>, sqlx::Error> {
 pub async fn find_without_elevation(pool: &PgPool) -> Result<Vec<Junction>, sqlx::Error> {
     let rows: Vec<JunctionRow> = sqlx::query_as(
         "SELECT id, osm_node_id, \
-         ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, \
+         lat, lon, \
          angle_1, angle_2, angle_3, bearings, created_at, \
          elevation, min_elevation_diff, max_elevation_diff, min_angle_elevation_diff, \
          way_1_highway_type, way_2_highway_type, way_3_highway_type, \

--- a/doc/archive/explain-analyze-after.md
+++ b/doc/archive/explain-analyze-after.md
@@ -1,0 +1,186 @@
+# EXPLAIN ANALYZE アフター（STORED lat/lon + B-tree インデックス適用後）
+
+**計測日**: 2026-02-23
+**データ件数**: 743,318件
+**計測条件**: コールドキャッシュ（docker restart 後の初回実行）
+**クエリ**: カテゴリフィルタあり（local OR pedestrian）、LIMIT 500
+**適用変更**:
+- `migration 006_add_lon_lat_stored.sql`: `lat`, `lon` を STORED 生成カラムとして追加
+- `idx_y_junctions_lon_lat` (lon, lat) B-tree インデックス作成
+- `add_bbox_filter`: ST_Intersects → lon/lat BETWEEN に変更
+
+---
+
+## 小bbox（約2km × 2km）
+
+**座標**: `lon BETWEEN 134.04 AND 134.06 AND lat BETWEEN 34.33 AND 34.35`
+
+```
+planning time: 5ms
+execution time: 13ms
+distribution: local
+vectorized: true
+plan type: custom
+rows decoded from KV: 576 (49 KiB, 576 KVs, 5 gRPC calls)
+cumulative time spent in KV: 11ms
+maximum memory usage: 5.0 MiB
+sql cpu time: <1ms
+
+• limit (count: 500)
+└── • filter
+    │ actual row count: 51
+    │ execution time: 175µs
+    │ estimated row count: 27
+    │ filter: (category conditions)
+    └── • index join (streamer)
+        │ actual row count: 55
+        │ KV time: 10ms
+        │ KV rows decoded: 55
+        │ KV gRPC calls: 4
+        │ table: y_junctions@y_junctions_pkey
+        └── • filter
+            │ actual row count: 55
+            │ filter: (lat >= 34.33) AND (lat <= 34.35)
+            └── • scan
+                  actual row count: 56
+                  KV time: 1ms
+                  KV gRPC calls: 1
+                  table: y_junctions@idx_y_junctions_lon_lat
+                  spans: [/134.04/34.33 - /134.06/34.35]
+```
+
+**コスト内訳**:
+| ステップ | 行数 | 時間 |
+|---------|------|------|
+| B-tree index scan (lon, lat) | 56行 | KV 1ms |
+| lat filter | → 55行 | <1ms |
+| index join (pkey fetch) | 55行 | KV 10ms |
+| category filter | → 51行 | <1ms |
+
+---
+
+## 中bbox（約8km × 11km）
+
+**座標**: `lon BETWEEN 134.00 AND 134.08 AND lat BETWEEN 34.30 AND 34.40`
+
+```
+planning time: 4ms
+execution time: 23ms
+distribution: local
+vectorized: true
+plan type: custom
+rows decoded from KV: 1,748 (152 KiB, 1,748 KVs, 5 gRPC calls)
+cumulative time spent in KV: 19ms
+maximum memory usage: 5.0 MiB
+sql cpu time: 1ms
+
+• limit (count: 500)
+└── • filter
+    │ actual row count: 500
+    │ execution time: 271µs
+    │ estimated row count: 313
+    │ filter: (category conditions)
+    └── • index join (streamer)
+        │ actual row count: 780
+        │ KV time: 18ms
+        │ KV rows decoded: 780
+        │ KV gRPC calls: 4
+        │ table: y_junctions@y_junctions_pkey
+        └── • filter
+            │ actual row count: 780
+            │ filter: (lat >= 34.30) AND (lat <= 34.40)
+            └── • scan
+                  actual row count: 802
+                  KV time: 1ms
+                  KV gRPC calls: 1
+                  table: y_junctions@idx_y_junctions_lon_lat
+                  spans: [/134.00/34.30 - /134.08/34.40]
+```
+
+**コスト内訳**:
+| ステップ | 行数 | 時間 |
+|---------|------|------|
+| B-tree index scan (lon, lat) | 802行 | KV 1ms |
+| lat filter | → 780行 | <1ms |
+| index join (pkey fetch) | 780行 | KV 18ms |
+| category filter | → 500行 | <1ms |
+
+---
+
+## 大bbox（約28km × 44km）
+
+**座標**: `lon BETWEEN 133.90 AND 134.20 AND lat BETWEEN 34.20 AND 34.60`
+
+```
+planning time: 5ms
+execution time: 94ms
+distribution: local
+vectorized: true
+plan type: custom
+rows decoded from KV: 11,257 (981 KiB, 11,749 KVs, 5 gRPC calls)
+cumulative time spent in KV: 79ms
+maximum memory usage: 5.0 MiB
+sql cpu time: 6ms
+
+• limit (count: 500)
+└── • filter
+    │ actual row count: 500
+    │ execution time: 163µs
+    │ estimated row count: 575
+    │ filter: (category conditions)
+    └── • index join (streamer)
+        │ actual row count: 1,534
+        │ KV time: 73ms
+        │ KV rows decoded: 1,534
+        │ KV bytes read: 478 KiB
+        │ KV gRPC calls: 3
+        │ table: y_junctions@y_junctions_pkey
+        └── • filter
+            │ actual row count: 4,288
+            │ filter: (lat >= 34.2) AND (lat <= 34.6)
+            └── • scan
+                  actual row count: 9,723
+                  KV time: 6ms
+                  KV rows decoded: 9,723
+                  KV bytes read: 503 KiB
+                  KV gRPC calls: 2
+                  estimated row count: 8,051 - 9,256 (1.2% of the table)
+                  table: y_junctions@idx_y_junctions_lon_lat
+                  spans: [/133.9/34.2 - /134.2/34.6]
+```
+
+**コスト内訳**:
+| ステップ | 行数 | 時間 |
+|---------|------|------|
+| B-tree index scan (lon, lat) | 9,723行 | KV 6ms |
+| lat filter | → 4,288行 | <1ms |
+| index join (pkey fetch) | 1,534行 | KV 73ms |
+| category filter | → 500行 | <1ms |
+
+---
+
+## ベースラインとの比較
+
+| bbox | ベースライン | アフター | 改善率 | プラン変化 |
+|------|------------|---------|-------|-----------|
+| 小（2km） | 12ms | 13ms | ≒同等 | 空間インデックス → B-tree (lon, lat) |
+| 中（10km） | 24ms | 23ms | ≒同等 | 空間インデックス → B-tree (lon, lat) |
+| **大（30km）** | **1,200ms** | **94ms** | **13x 高速化** | **FULL SCAN → B-tree (lon, lat)** |
+
+### 改善の要点
+
+**大bbox**:
+- ベースライン: 266,732行をディスクから読み取り（primary key の ID 順フルスキャン）
+- アフター: 9,723行のみ読み取り（lon 範囲でインデックスをポイントスキャン）
+- 読み取り量: 81 MiB → 981 KiB（約85分の1）
+
+**小〜中bbox**:
+- ベースラインでも空間インデックスが使用されており大きな差はなし
+- index join ボトルネックは引き続き存在（pkey 2段目ルックアップ）
+
+### 残課題
+
+- index join による2段目ルックアップが小〜中bboxのボトルネック
+  - `(lon, lat)` インデックスは座標しか持たないため、他カラム取得に primary key lookup が必要
+  - COVERING INDEX（全カラムをインデックスに含める）で解消可能だが、インデックスサイズが大幅増加
+- 大bboxではカテゴリフィルタ後に 1,534行 → 500行なので、さらなる絞り込みは困難

--- a/doc/archive/explain-analyze-baseline.md
+++ b/doc/archive/explain-analyze-baseline.md
@@ -1,0 +1,160 @@
+# EXPLAIN ANALYZE ベースライン（改善前）
+
+**計測日**: 2026-02-23
+**データ件数**: 743,318件
+**計測条件**: コールドキャッシュ（docker restart 後の初回実行）
+**クエリ**: カテゴリフィルタあり（local OR pedestrian）、LIMIT 500
+
+---
+
+## 小bbox（約2km × 2km）
+
+**座標**: `ST_MakeEnvelope(134.04, 34.33, 134.06, 34.35, 4326)`
+
+```
+planning time: 91ms
+execution time: 12ms
+distribution: local
+vectorized: true
+plan type: custom
+rows decoded from KV: 435 (39 KiB, 435 KVs, 6 gRPC calls)
+cumulative time spent in KV: 10ms
+maximum memory usage: 230 KiB
+sql cpu time: 1ms
+
+• render
+└── • limit (count: 500)
+    └── • filter
+        │ actual row count: 51
+        │ execution time: 675µs
+        │ estimated row count: 81,022  ← 統計が古く見積もりが大幅にずれ
+        │ filter: st_intersects(...) AND (category conditions)
+        └── • index join (streamer)
+            │ actual row count: 55
+            │ KV time: 9ms
+            │ KV rows decoded: 55
+            │ KV gRPC calls: 5
+            │ table: y_junctions@y_junctions_pkey
+            └── • inverted filter
+                │ actual row count: 55
+                └── • scan
+                      actual row count: 380
+                      KV time: 2ms
+                      KV gRPC calls: 1
+                      table: y_junctions@idx_y_junctions_location
+                      WARNING: row count estimate is inaccurate, consider running ANALYZE
+```
+
+**コスト内訳**:
+| ステップ | 行数 | 時間 |
+|---------|------|------|
+| 空間インデックス scan | 380 S2セル | KV 2ms |
+| inverted filter | → 55行 | <1ms |
+| index join (pkey fetch) | 55行 | KV 9ms ← ボトルネック |
+| filter (ST_Intersects + category) | → 51行 | <1ms |
+
+---
+
+## 中bbox（約8km × 11km）
+
+**座標**: `ST_MakeEnvelope(134.00, 34.30, 134.08, 34.40, 4326)`
+
+```
+planning time: 4ms
+execution time: 24ms
+distribution: local
+vectorized: true
+plan type: custom
+rows decoded from KV: 1,782 (249 KiB, 1,782 KVs, 7 gRPC calls)
+cumulative time spent in KV: 15ms
+maximum memory usage: 1.1 MiB
+sql cpu time: 10ms
+
+• render
+└── • limit (count: 500)
+    └── • filter
+        │ actual row count: 500
+        │ execution time: 5ms
+        │ estimated row count: 81,022
+        │ filter: st_intersects(...) AND (category conditions)
+        └── • index join (streamer)
+            │ actual row count: 606
+            │ KV time: 14ms
+            │ KV rows decoded: 606
+            │ KV gRPC calls: 6
+            │ table: y_junctions@y_junctions_pkey
+            └── • inverted filter
+                │ actual row count: 606
+                └── • scan
+                      actual row count: 1,176
+                      KV time: 1ms
+                      KV gRPC calls: 1
+                      table: y_junctions@idx_y_junctions_location
+```
+
+**コスト内訳**:
+| ステップ | 行数 | 時間 |
+|---------|------|------|
+| 空間インデックス scan | 1,176 S2セル | KV 1ms |
+| inverted filter | → 606行 | 4ms |
+| index join (pkey fetch) | 606行 | KV 14ms ← ボトルネック |
+| filter (ST_Intersects + category) | → 500行 | 5ms |
+
+---
+
+## 大bbox（約28km × 44km）
+
+**座標**: `ST_MakeEnvelope(133.90, 34.20, 134.20, 34.60, 4326)`
+
+```
+planning time: 45ms
+execution time: 1.2s
+distribution: local
+vectorized: true
+plan type: custom
+rows decoded from KV: 266,732 (81 MiB, 270,365 KVs, 9 gRPC calls)
+cumulative time spent in KV: 917ms
+maximum memory usage: 11 MiB
+sql cpu time: 693ms
+
+• render
+└── • limit (count: 500)
+    └── • filter
+        │ actual row count: 500
+        │ execution time: 250ms
+        │ estimated row count: 81,022
+        │ filter: st_intersects(...) AND (category conditions)
+        └── • scan
+              actual row count: 266,732
+              KV time: 917ms  ← 支配的
+              KV rows decoded: 266,732
+              KV bytes read: 81 MiB
+              KV gRPC calls: 9
+              estimated row count: 4,588 - 743,318 (100% of the table)
+              table: y_junctions@y_junctions_pkey
+              spans: FULL SCAN (SOFT LIMIT)  ← 空間インデックス不使用
+```
+
+**コスト内訳**:
+| ステップ | 行数 | 時間 |
+|---------|------|------|
+| **フルスキャン (pkey)** | **266,732行** | **KV 917ms** |
+| filter (ST_Intersects + category) | → 500行 | 250ms |
+
+---
+
+## 総括
+
+| bbox | 実行時間 | プラン | 問題点 |
+|------|---------|-------|-------|
+| 小（2km） | 12ms | 空間インデックス → index join | index join (9ms) がボトルネック |
+| 中（10km） | 24ms | 空間インデックス → index join | index join (14ms) がボトルネック |
+| **大（30km）** | **1.2s** | **FULL SCAN** | S2 covering が広すぎて空間インデックス不使用、81MB読み取り |
+
+### 根本的な問題
+- **大bbox**: S2セルの covering がテーブル大半をカバーする規模になるとオプティマイザが空間インデックスを諦め、プライマリキーのフルスキャンに切り替える。266,732行を読んで500行を返す（533:1のオーバーヘッド）。
+- **小〜中bbox**: 空間インデックスは使われているが、inverted index が `(id, location_inverted_key)` しか持たないため、他のカラム取得に index join（プライマリキーへの2段目ルックアップ）が必要になる。
+
+### 統計の問題
+- `estimated row count: 81,022` は実際の 51〜606 行に対して大幅にずれている
+- `ANALYZE y_junctions` が推奨されている（stats collected 2 days ago）


### PR DESCRIPTION
## Summary

- `lat`/`lon` を STORED 生成カラムとして追加（`migration 006`）
- `(lon, lat)` B-tree インデックスを作成（`idx_y_junctions_lon_lat`）
- `add_bbox_filter` を `ST_Intersects` → `lon/lat BETWEEN` に変更
- SELECT の `ST_Y/ST_X(location::geometry)` → 直接 `lat`/`lon` に変更

## 背景

大bbox（〜30km）のクエリでは CockroachDB のオプティマイザが空間インデックスを諦め、primary key のフルスキャンに切り替えていた。その結果、266,732行（81MB）を読み取ってから500件を返す非効率な実行プランになっていた。

STORED カラムと B-tree インデックスにより、lon 範囲でポイントスキャンできるようになり、読み取り行数が地理的に一致するレコードのみに絞られる。

## 改善結果（コールドキャッシュ、743,318件）

| bbox | ベースライン | アフター | 改善率 |
|------|------------|---------|-------|
| 小（2km） | 12ms | 13ms | ≒同等 |
| 中（10km） | 24ms | 23ms | ≒同等 |
| **大（30km）** | **1,200ms** | **94ms** | **13x** |

大bboxの読み取り量: 81MB（266,732行）→ 981KB（9,723行）

詳細な実行計画は `doc/archive/` を参照。

## Test plan

- [x] `cargo test` 全75テスト通過
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized bounding box queries for location-based searches with significantly faster results, especially for large geographic areas.

* **Documentation**
  * Added performance analysis documentation capturing query optimization improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->