### PR TITLE
fix: ドラッグ後スナップバックバグを修正（AbortControllerでレースコンディション解消）

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,7 +17,8 @@ export class ApiError extends Error {
 // Y字路一覧を取得
 export async function fetchJunctions(
   bbox: string,
-  filters?: Omit<FilterParams, 'bbox'>
+  filters?: Omit<FilterParams, 'bbox'>,
+  signal?: AbortSignal
 ): Promise<JunctionFeatureCollection> {
   try {
     const params = new URLSearchParams({ bbox });
@@ -47,7 +48,7 @@ export async function fetchJunctions(
     }
 
     const url = `${BASE_URL}/junctions?${params.toString()}`;
-    const response = await fetch(url);
+    const response = await fetch(url, { signal });
 
     if (!response.ok) {
       throw new ApiError(`Failed to fetch junctions: ${response.statusText}`, response.status);

--- a/frontend/src/hooks/useJunctions.ts
+++ b/frontend/src/hooks/useJunctions.ts
@@ -75,6 +75,7 @@ export function useJunctions({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const timeoutRef = useRef<number | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     // boundsがない場合は何もしない
@@ -89,6 +90,13 @@ export function useJunctions({
 
     // デバウンス処理
     timeoutRef.current = window.setTimeout(async () => {
+      // 古いフェッチをキャンセル
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
       setIsLoading(true);
       setError(null);
 
@@ -100,10 +108,13 @@ export function useJunctions({
         } else {
           // 実際のAPIを呼び出し
           const bbox = `${bounds.west},${bounds.south},${bounds.east},${bounds.north}`;
-          const result = await fetchJunctions(bbox, filters);
+          const result = await fetchJunctions(bbox, filters, controller.signal);
           setData(result);
         }
       } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          return; // キャンセルされた場合は何もしない
+        }
         console.error('Failed to fetch junctions:', err);
         setError(err instanceof Error ? err : new Error('Unknown error'));
         // エラー時はモックデータにフォールバック
@@ -120,6 +131,9 @@ export function useJunctions({
     return () => {
       if (timeoutRef.current !== null) {
         clearTimeout(timeoutRef.current);
+      }
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
       }
     };
   }, [bounds, filters, debounceMs, useMockData]);


### PR DESCRIPTION
## Summary

- `useJunctions.ts` に `AbortController` を導入し、新しいフェッチ開始時に進行中の古いリクエストをキャンセルするよう修正
- `fetchJunctions` に `signal?: AbortSignal` 引数を追加し、`fetch()` に渡すよう修正
- `AbortError` をキャッチして状態更新をスキップすることで、キャンセル済みリクエストが UI を上書きしないよう対処

## 背景

地図パン・スライダー操作後に「元の場所に戻される」ように見えるスナップバックバグの修正。

デバウンス処理がタイマーのみキャンセルし、進行中の HTTP リクエストをキャンセルしないため、古いリクエストが後から返ってきて新しい結果を上書きするレースコンディションが発生していた。

## Test plan

- [ ] 地図を素早くパンし、スナップバックが発生しないことを確認
- [ ] スライダーを素早く操作し、古い結果に戻らないことを確認
- [ ] ネットワークスロットリング（低速）でも正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Enhanced request handling to cancel outdated requests when new ones are initiated, ensuring faster response times and preventing stale data from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->