### PR TITLE
feat: Cloud Logging → BigQuery → Looker Studio ダッシュボード (Phase 1)

### DIFF
--- a/terraform/logging.tf
+++ b/terraform/logging.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "cloud_run_logs" {
   description   = "Logs from Cloud Run services for analytics"
   location      = var.region
 
-  default_table_expiration_ms = 90 * 24 * 60 * 60 * 1000
+  default_partition_expiration_ms = 90 * 24 * 60 * 60 * 1000
 }
 
 resource "google_logging_project_sink" "cloud_run_requests" {


### PR DESCRIPTION
## Summary

- `terraform/logging.tf` を新規追加
- Cloud Run の HTTP リクエストログを BigQuery に自動エクスポートするログシンクを Terraform で構築
- ヘルスチェック (`/health`) を除外するフィルター設定

## 構成

```
Cloud Run (y-junctions-api)
    ↓ ログシンク（自動エクスポート）
Cloud Logging
    ↓ Terraform
BigQuery (cloud_run_logs dataset)
    ↓ データソース接続
Looker Studio（手動設定・公開URL）
```

## Terraform リソース

| リソース | 内容 |
|---|---|
| `google_bigquery_dataset` | データセット作成（90日TTL、asia-northeast1） |
| `google_logging_project_sink` | HTTPリクエストログのみ・ヘルスチェック除外 |
| `google_bigquery_dataset_iam_member` | ログシンクSAに dataEditor 権限付与 |

## Looker Studio（手動作業・このPR外）

- BigQuery をデータソースとして接続
- 時間帯別・曜日別・日別グラフ設定
- レポートを公開設定

## Test plan

- [x] `terraform plan` でエラーなし・意図通りの3リソース追加を確認
- [ ] `terraform apply` 後、BigQuery にデータセットが作成されることを確認
- [ ] 数分後、Cloud Run へのリクエストがBigQueryに記録されることを確認

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud Run logs are now automatically exported to BigQuery for advanced analytics and ad-hoc querying.
  * Log data is retained for 90 days before automatic deletion.
  * Exported logs exclude health check requests to focus on relevant service traffic.
  * Logs are written into partitioned tables for more efficient querying and cost-effective analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->