### PR TITLE
feat: URLアクセス時に上空からズームインするフォーカスアニメーションを追加する

### DIFF
--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -11,6 +11,10 @@ import { JunctionPopup } from './JunctionPopup';
 const DEFAULT_CENTER: [number, number] = [35.6812, 139.7671];
 const INITIAL_ZOOM = 14;
 
+// URLアクセス時のフォーカスアニメーション設定
+const FOCUS_START_ZOOM = 5;
+const FOCUS_TARGET_ZOOM = 16;
+
 // angle_typeごとのマーカー色（Y字路書籍をイメージした紫、青、黄色のパレット）
 const MARKER_COLORS: Record<AngleType, string> = {
   verysharp: '#8B5CF6', // 紫（violet-500） - 最小角度が最も小さい
@@ -92,6 +96,24 @@ const InitialBounds = memo(function InitialBounds({
       west: bounds.getWest(),
     });
   }, [map, onBoundsChange]);
+
+  return null;
+});
+
+// URLアクセス時に上空からズームインするアニメーションコンポーネント
+interface FocusAnimationProps {
+  target: [number, number];
+}
+
+const FocusAnimation = memo(function FocusAnimation({ target }: FocusAnimationProps) {
+  const map = useMap();
+
+  useEffect(() => {
+    map.flyTo(target, FOCUS_TARGET_ZOOM, {
+      animate: true,
+      duration: 5,
+    });
+  }, [map, target]);
 
   return null;
 });
@@ -214,7 +236,7 @@ export const MapView = memo(function MapView({
     <div style={{ height: '100%', width: '100%' }}>
       <MapContainer
         center={initialCenter}
-        zoom={urlOsmNodeId ? 16 : INITIAL_ZOOM}
+        zoom={urlOsmNodeId ? FOCUS_START_ZOOM : INITIAL_ZOOM}
         style={{ height: '100%', width: '100%' }}
       >
         {/* OpenStreetMap タイル */}
@@ -222,6 +244,9 @@ export const MapView = memo(function MapView({
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
+
+        {/* URLアクセス時のフォーカスアニメーション */}
+        {urlOsmNodeId && initialCenter && <FocusAnimation target={initialCenter} />}
 
         {/* 初期bounds設定 */}
         <InitialBounds onBoundsChange={handleBoundsChange} />


### PR DESCRIPTION
## Summary

- `/node/:osm_node_id` のURLでアクセスした際、マーカー地点の上空（zoom=5）から5秒かけてzoom=16までズームインするアニメーションを追加
- `FocusAnimation` コンポーネントを新設し、Leafletの `flyTo` を使って実装
- 変更ファイルは `frontend/src/components/MapView.tsx` のみ

## Test plan

- [ ] `/node/:osm_node_id` でアクセスし、上空から降りてくるアニメーションが動作することを確認
- [ ] 通常アクセス（`/`）ではアニメーションが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Maps accessed via URL with a specific location now feature an animated zoom-in effect, smoothly transitioning from an overview perspective to the target location with a cinematic aerial animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->