### PR TITLE
fix: 本番環境の白画面バグを修正する（vite.config.ts の base を './' に戻す）

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base: './',
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## 概要

本番環境（GCS）で白画面が発生していたバグの暫定対応。

## 原因

`vite.config.ts` の `base` 設定が `'./'` から `'/'` に変更されたことで、ビルド成果物のアセットパスが絶対パスになった。
GCS はバケット名を含むサブパスで配信しているため、絶対パス `/assets/...` がバケットルートを指して 404 → 白画面になっていた。

詳細は `doc/bug-white-screen-production.md` 参照。

## 変更内容

- `frontend/vite.config.ts`: `base: '/'` → `base: './'`

## 影響範囲

| | 変更後 |
|---|---|
| GCS でのアセット読み込み | ✅ 正常（白画面解消） |
| `window.location.pathname` の読み取り | ✅ 変わらず動作 |
| `/node/12345` への直接アクセス | ❌ 変わらず GCS が 404（変更前後で同じ） |
| ローカル開発環境 | ✅ 変わらず動作 |

URL 直リンクの直接アクセスは変更前も後も GCS では動かないため、退行なし。

## 恒久対応について

URL 直リンク（`/node/:osm_node_id` への直接アクセス）を正しく動かすには、別途サーバー側のフォールバック対応が必要（Firebase Hosting 等）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend build configuration to support serving assets and application routes from alternative subpaths, enabling more flexible deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->