### PR TITLE
fix: GCS上でのマーカーURL直リンクバグを修正する

### DIFF
--- a/frontend/src/components/JunctionPopup.tsx
+++ b/frontend/src/components/JunctionPopup.tsx
@@ -17,7 +17,7 @@ export function JunctionPopup({ properties }: JunctionPopupProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopyUrl = useCallback(() => {
-    const url = `${window.location.origin}/node/${osm_node_id}`;
+    const url = `${window.location.origin}${window.location.pathname}#node=${osm_node_id}`;
     navigator.clipboard.writeText(url).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -162,7 +162,7 @@ export const MapView = memo(function MapView({
 }: MapViewProps) {
   // URLから osm_node_id を取得（文字列のまま扱う）
   const urlOsmNodeId = useMemo(() => {
-    const match = window.location.pathname.match(/^\/node\/(\d+)$/);
+    const match = window.location.hash.match(/^#node=(\d+)$/);
     return match?.[1] ?? null;
   }, []);
 


### PR DESCRIPTION
## Summary

- `JunctionPopup.tsx`: URLコピー時の生成URLをパスベース（`/node/{id}`）からハッシュベース（`#node={id}`）に変更
- `MapView.tsx`: URLパースを `window.location.pathname` から `window.location.hash` に変更

## Background

GCSホスティング環境でマーカーポップアップの「URLをコピー」ボタンが不正なURLを生成していた。

- **原因1**: `window.location.origin` のみ使用 → バケット名（パスの第1セグメント）が欠落
- **原因2**: パスベースURLはGCSがオブジェクトとして解釈するため、直アクセスするとXMLエラーになる

ハッシュはブラウザ内のみで処理されGCSへのリクエストは常に `index.html` に向くため、アセット解決も壊れない。詳細: `doc/bug-gcs-spa-routing.md`

## Test plan

- [ ] `http://localhost:3001/#node=581715516` に直接アクセスしてマーカーにフォーカスされることを確認
- [ ] マーカークリック → URLコピーボタン → コピーされたURLがハッシュ形式（`#node=...`）であることを確認
- [ ] コピーしたURLに直接アクセスして正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated junction link URL format from dedicated paths to hash-based fragments, enabling links to work consistently across different page contexts while preserving functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->