### PR TITLE
feat: マーカーをY字路形状のSVGアイコンに変更する

### DIFF
--- a/backend/src/domain/junction.rs
+++ b/backend/src/domain/junction.rs
@@ -132,6 +132,7 @@ impl Junction {
                 "way_1_category": self.way_1_category,
                 "way_2_category": self.way_2_category,
                 "way_3_category": self.way_3_category,
+                "bearings": self.bearings,
             }
         })
     }

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -643,6 +643,30 @@ async fn test_get_junctions_response_includes_elevation_data() {
 
 #[tokio::test]
 #[serial]
+async fn test_get_junctions_response_includes_bearings() {
+    let pool = setup_test_db().await;
+
+    let id = insert_test_junction(&pool, TestJunctionData::sharp_type()).await;
+
+    let app = create_test_app(pool);
+
+    let (status, json) = send_request(app, &format!("/api/junctions/{}", id)).await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    // bearings がレスポンスに含まれ、挿入した値と一致することを確認
+    let bearings = &json["properties"]["bearings"];
+    assert!(bearings.is_array(), "bearings should be an array");
+    let arr = bearings.as_array().unwrap();
+    assert_eq!(arr.len(), 3, "bearings should have 3 elements");
+    // sharp_type のbearings: [10.0, 45.0, 190.0]
+    assert_eq!(arr[0].as_f64().unwrap(), 10.0_f64, "bearing[0] mismatch");
+    assert_eq!(arr[1].as_f64().unwrap(), 45.0_f64, "bearing[1] mismatch");
+    assert_eq!(arr[2].as_f64().unwrap(), 190.0_f64, "bearing[2] mismatch");
+}
+
+#[tokio::test]
+#[serial]
 async fn test_get_junctions_combined_filters_with_elevation() {
     let pool = setup_test_db().await;
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -22,31 +22,34 @@ const MARKER_COLORS: Record<AngleType, string> = {
   normal: '#F59E0B', // 濃い黄色（琥珀色） - 通常
 };
 
-// カスタムマーカーアイコンを作成（メモ化用に外部で定義）
-const markerIconCache: Partial<Record<AngleType, Icon>> = {};
-
-function getMarkerIcon(angleType: AngleType): Icon {
-  if (markerIconCache[angleType]) {
-    return markerIconCache[angleType]!;
-  }
-
+// Y字路形状のSVGマーカーアイコンを生成する
+function getMarkerIcon(angleType: AngleType, bearings: number[]): Icon {
   const color = MARKER_COLORS[angleType];
-  const svg = `
-    <svg width="25" height="41" viewBox="0 0 25 41" xmlns="http://www.w3.org/2000/svg">
-      <path d="M12.5 0C5.6 0 0 5.6 0 12.5c0 8.4 12.5 28.5 12.5 28.5S25 20.9 25 12.5C25 5.6 19.4 0 12.5 0z"
-            fill="${color}" stroke="#fff" stroke-width="1.5"/>
-      <circle cx="12.5" cy="12.5" r="6" fill="#fff"/>
-    </svg>
-  `;
+  const size = 38;
+  const center = size / 2;
+  const bgRadius = center - 1;
+  const lineLen = bgRadius - 5;
 
-  const icon = new Icon({
+  const lines = bearings
+    .map(bearing => {
+      const rad = (bearing * Math.PI) / 180;
+      const x = (center + lineLen * Math.sin(rad)).toFixed(1);
+      const y = (center - lineLen * Math.cos(rad)).toFixed(1);
+      return `<line x1="${center}" y1="${center}" x2="${x}" y2="${y}" stroke="white" stroke-width="3" stroke-linecap="round"/>`;
+    })
+    .join('');
+
+  const svg = `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="${center}" cy="${center}" r="${bgRadius}" fill="${color}" stroke="white" stroke-width="2"/>
+    ${lines}
+    <circle cx="${center}" cy="${center}" r="3" fill="white"/>
+  </svg>`;
+
+  return new Icon({
     iconUrl: `data:image/svg+xml;base64,${btoa(svg)}`,
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
+    iconSize: [size, size],
+    iconAnchor: [center, center],
   });
-
-  markerIconCache[angleType] = icon;
-  return icon;
 }
 
 // 地図のイベントハンドリング用コンポーネント（メモ化）
@@ -211,14 +214,14 @@ export const MapView = memo(function MapView({
   const markers = useMemo(() => {
     return data?.features.map(feature => {
       const [lon, lat] = feature.geometry.coordinates;
-      const { osm_node_id, angle_type } = feature.properties;
+      const { osm_node_id, angle_type, bearings = [] } = feature.properties;
       const isSelected = urlOsmNodeId !== null && String(osm_node_id) === urlOsmNodeId;
 
       return (
         <JunctionMarker
           key={osm_node_id}
           position={[lat, lon]}
-          icon={getMarkerIcon(angle_type)}
+          icon={getMarkerIcon(angle_type, bearings)}
           isSelected={isSelected}
         >
           <JunctionPopup properties={feature.properties} />


### PR DESCRIPTION
## Summary

- マーカーアイコンをピン形状からY字路の実際の形状を反映した円形SVGに変更
- `bearings`（方位角）を使って3本の道路方向を描画し、地図上で一目でY字路の形がわかるようにした
- バックエンドの `to_feature()` に `bearings` フィールドが含まれていなかったバグを修正
- `bearings` がAPIレスポンスに含まれることを検証する統合テストを追加

## Test plan

- [ ] `cargo test` (47 unit tests + 33 integration tests) が全て通過することを確認
- [ ] フロントエンドで地図を開き、各マーカーがY字路の形状（3本線）で表示されることを確認
- [ ] マーカーをクリックしてポップアップが正常に開くことを確認
- [ ] verysharp/sharp/normal の3種類で色が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Junction API responses now include bearing data providing directional information for each junction
  * Map junction markers now feature dynamic directional indicators that visualize bearing information, replacing static icons with bearing-aware visuals for improved clarity of junction orientations

* **Tests**
  * Added test validation to verify bearings data is properly included in junction API responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->