### PR TITLE
fix: rustls-webpki 脆弱性修正 & .env.example を CockroachDB に揃える

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
-# PostgreSQL (Neon or local PostGIS)
-DATABASE_URL=postgres://y_junction:y_junction@localhost:5432/y_junction
-TEST_DATABASE_URL=postgres://y_junction:y_junction@localhost:5432/y_junction_test
+# CockroachDB (local development via docker-compose)
+DATABASE_URL=postgresql://root@localhost:26257/y_junction?sslmode=disable
+TEST_DATABASE_URL=postgresql://root@localhost:26257/y_junction_test?sslmode=disable
 
-# CockroachDB (local development)
-# DATABASE_URL=postgres://root@localhost:26257/y_junction?sslmode=disable
-# TEST_DATABASE_URL=postgres://root@localhost:26257/y_junction_test?sslmode=disable
+# PostgreSQL (Neon or local PostGIS)
+# DATABASE_URL=postgres://y_junction:y_junction@localhost:5432/y_junction
+# TEST_DATABASE_URL=postgres://y_junction:y_junction@localhost:5432/y_junction_test

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1891,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- `rustls-webpki` を 0.103.8 → 0.103.12 にアップデート（CI の `cargo audit` で検出された 3 件の RUSTSEC アドバイザリを解消）
- `backend/.env.example` の既定値を CockroachDB（26257）に入れ替え（docker-compose / README / CLAUDE.md と揃える）

## 背景
CI の Security audit が以下で落ちていた：
- RUSTSEC-2026-0049 (CRLs not authoritative by DP)
- RUSTSEC-2026-0098 (URI name constraints)
- RUSTSEC-2026-0099 (wildcard name constraints)

いずれも `rustls-webpki >=0.103.12` で解消。`cargo update -p rustls-webpki` で Cargo.lock のみ更新。

調査中に `.env.example` の既定値が PostgreSQL 5432 のままで、docker-compose が起動する CockroachDB 26257 と食い違っている問題も発見したため併せて修正。

## Test plan
- [x] `cargo audit --ignore RUSTSEC-2023-0071` ローカルで通過
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過
- [x] `cargo test` 通過（67 + 43 tests）
- [ ] CI（Security audit ジョブ）が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)