### PR TITLE
ci: cargo audit を PR CI へ移動し deploy から除去

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,6 +43,38 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  audit:
+    name: Backend - Security audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.90.0'
+
+      - name: Cache cargo-audit
+        id: cache-tools
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-tools-audit-0.22.0
+
+      - name: Install cargo-audit
+        if: steps.cache-tools.outputs.cache-hit != 'true'
+        run: cargo install cargo-audit --version 0.22.0 --locked
+
+      - name: Security audit
+        # Ignore RUSTSEC-2023-0071 (rsa crate via sqlx-mysql): PostgreSQL-only project, MySQL code not executed
+        run: cargo audit --ignore RUSTSEC-2023-0071
+
   test:
     name: Backend - Test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,19 +95,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-deps-
 
-      - name: Cache tools
-        id: cache-tools
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/cargo-audit
-          key: ${{ runner.os }}-tools-audit-0.22.0
-
-      - name: Install tools
-        if: steps.cache-tools.outputs.cache-hit != 'true'
-        run: |
-          cargo install cargo-audit --version 0.22.0 --locked
-
       - name: Create test database
         run: psql -h localhost -U y_junction -d y_junction -c "CREATE DATABASE y_junction_test;"
         env:
@@ -121,11 +108,6 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Security audit
-        run: |
-          # Ignore RUSTSEC-2023-0071 (rsa crate via sqlx-mysql): PostgreSQL-only project, MySQL code not executed
-          cargo audit --ignore RUSTSEC-2023-0071
 
   # Frontend Test Job
   frontend-test:


### PR DESCRIPTION
## Summary
- `backend-ci.yml` に `audit` job を新規追加（PR ごとに `cargo audit --ignore RUSTSEC-2023-0071` を実行）
- `deploy.yml` から Security audit / cargo-audit インストール関連を削除
- Refs #207

## 背景
PR #206 で `rustls-webpki` の RUSTSEC 3件が検出されたが、気付けたのは **main マージ後の `deploy.yml` で audit が失敗したタイミング**だった。main 側に直接 push できない運用では「deploy で詰まる → 修正用の別 PR を作る」コストが発生する。

PR CI 側に audit を置けば、**同じ branch で `cargo update` → 再 push** で解決でき、PR 作り直しが不要になる。

## 設計判断
- 当初 issue #207 の案A（pre-push hook）を検討したが、ローカル開発者の cargo-audit インストール事情や `--no-verify` による bypass の余地があり、CI 側で強制したほうが確実
- `cargo audit` は実測 ~1.5s（キャッシュあり）で PR CI への追加コストは無視できる
- `deploy.yml` 側に残すと「deploy で止まる PR 作り直し問題」が解消されないため同時に外す

## Test plan
- [ ] PR CI で `Backend - Security audit` job が通ること
- [ ] deploy.yml は `on: push branches: main` なので、マージ後の deploy が通ること（audit step が無くなったので失敗しないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized backend CI pipeline by introducing a dedicated security audit job with improved tool caching for faster execution. Updated deployment workflow accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->