### PR TITLE
ci: release-drafter を releaser と autolabeler に分離

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,0 +1,31 @@
+# Autolabeler Workflow (autolabeler only)
+#
+# Trigger:
+# - pull_request: Applies labels (feature / bug / data / internal etc.) based
+#   on branch name and title rules defined in .github/release-drafter.yml.
+#
+# Release drafting is handled by .github/workflows/release-drafter.yml.
+# See: https://github.com/release-drafter/release-drafter#usage
+
+name: Autolabeler
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+concurrency:
+  group: autolabeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  autolabel:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        with:
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,31 +1,22 @@
-# Autolabeler Workflow (autolabeler only)
-#
-# Trigger:
-# - pull_request: Applies labels (feature / bug / data / internal etc.) based
-#   on branch name and title rules defined in .github/release-drafter.yml.
-#
-# Release drafting is handled by .github/workflows/release-drafter.yml.
-# See: https://github.com/release-drafter/release-drafter#usage
-
-name: Autolabeler
+name: Auto Label
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
 
 concurrency:
   group: autolabeler-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  autolabel:
+  auto_label:
     permissions:
-      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
-        with:
-          disable-releaser: true
+      - uses: release-drafter/release-drafter/autolabeler@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,12 +1,10 @@
-# Release Drafter Workflow
+# Release Drafter Workflow (releaser only)
 #
-# Triggers:
-# - push to main: Updates release draft with merged PRs
-# - pull_request events: Applies automatic labels via autolabeler
+# Trigger:
+# - push to main: Updates the GitHub Release draft based on merged PRs
 #
-# Permissions:
-# - contents: write - Required to create/update GitHub Releases
-# - pull-requests: write - Required to apply labels via autolabeler
+# Autolabeling is handled by .github/workflows/autolabeler.yml.
+# See: https://github.com/release-drafter/release-drafter#usage
 
 name: Release Drafter
 
@@ -14,8 +12,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 concurrency:
   group: release-drafter
@@ -25,11 +21,12 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
-          publish: false  # Always create as draft, publish manually after review
+          publish: false
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,11 +1,3 @@
-# Release Drafter Workflow (releaser only)
-#
-# Trigger:
-# - push to main: Updates the GitHub Release draft based on merged PRs
-#
-# Autolabeling is handled by .github/workflows/autolabeler.yml.
-# See: https://github.com/release-drafter/release-drafter#usage
-
 name: Release Drafter
 
 on:
@@ -13,20 +5,20 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 concurrency:
   group: release-drafter
   cancel-in-progress: false
 
 jobs:
   update_release_draft:
-    permissions:
-      contents: write
-      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
           publish: false
-          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `pull_request` イベントで release-drafter が `target_commitish = refs/pull/N/merge` となり GitHub Release API のバリデーションに失敗していた問題を修正
- 公式 README の推奨構成に従い、releaser（`push: main`）と autolabeler（`pull_request`）を独立ワークフローに分割
- それぞれ `disable-autolabeler` / `disable-releaser` で片方のみ動作させ、permissions も最小化

### 参考
- エラー再現 Job: https://github.com/cozy-corner/y-junctions/actions/runs/24592009502/job/71914503480?pr=208
- 公式 Issue (既知の制限): https://github.com/release-drafter/release-drafter/issues/1125

### 変更内容
- `release-drafter.yml`: トリガーを `push: main` のみに絞り `disable-autolabeler: true` を追加
- `autolabeler.yml`（新規）: `pull_request` 専用、`disable-releaser: true`、PR 番号ごとの concurrency で古い実行をキャンセル
- autolabeler の types から `labeled, unlabeled` を除外（自己発火を回避）

## Test plan
- [ ] この PR で **Autolabeler** が成功し、`internal` ラベルが自動付与される
- [ ] この PR で **Release Drafter** ワークフローは走らない（push(main) トリガーに変わったため）
- [ ] マージ後、main への push で **Release Drafter** が成功し、Releases ページのドラフトが更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated PR labeling workflow to streamline label application on pull requests.
  * Restructured GitHub Actions workflows by separating labeling and release responsibilities into dedicated workflows, improving efficiency and reducing unnecessary job executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->