### PR TITLE
feat: 合流して戻る分岐（バス湾・ランプ等）を取り込み時に除外 (#213)

### DIFF
--- a/backend/src/importer/detector.rs
+++ b/backend/src/importer/detector.rs
@@ -1,5 +1,5 @@
 use dashmap::DashMap;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 /// Way tag information (bridge, tunnel, highway_type, etc.)
 #[derive(Debug, Clone, Default)]
@@ -478,6 +478,97 @@ impl NodeConnectionCounter {
     pub fn get_way_tag(&self, way_id: i64) -> Option<WayTagInfo> {
         self.way_tags.get(&way_id).map(|tag| tag.clone())
     }
+
+    /// Check if any branch from this junction merges back with another branch
+    /// within `max_way_hops` way-hops.
+    ///
+    /// Detects patterns like bus bays, highway ramps, and right-turn shortcuts where
+    /// the "Y" is not a real fork but two branches that rejoin downstream.
+    ///
+    /// Works for both 2-way and 3-way junctions: starts BFS from the junction node,
+    /// constrained so the first hop uses `w_start` only, and subsequent hops cannot
+    /// re-enter the junction via another of its ways.
+    pub fn junction_has_merge_back(&self, junction_node_id: i64, max_way_hops: usize) -> bool {
+        let ways: Vec<i64> = match self.node_to_ways.get(&junction_node_id) {
+            Some(w) => w.value().iter().copied().collect(),
+            None => return false,
+        };
+
+        for &w_start in &ways {
+            // target_set = nodes in other junction ways, excluding the junction node itself
+            let mut target_set: HashSet<i64> = HashSet::new();
+            for &w in &ways {
+                if w == w_start {
+                    continue;
+                }
+                if let Some(nodes) = self.way_nodes.get(&w) {
+                    for &n in nodes.value() {
+                        if n != junction_node_id {
+                            target_set.insert(n);
+                        }
+                    }
+                }
+            }
+
+            // Prevent re-entering the junction via another of its ways.
+            let mut visited_ways: HashSet<i64> =
+                ways.iter().copied().filter(|&w| w != w_start).collect();
+
+            let mut frontier: VecDeque<(i64, usize)> = VecDeque::new();
+            frontier.push_back((junction_node_id, 0));
+
+            while let Some((node, hops)) = frontier.pop_front() {
+                if hops >= max_way_hops {
+                    continue;
+                }
+
+                let node_ways: Vec<i64> = match self.node_to_ways.get(&node) {
+                    Some(w) => w.value().iter().copied().collect(),
+                    None => continue,
+                };
+
+                for way_id in node_ways {
+                    if visited_ways.contains(&way_id) {
+                        continue;
+                    }
+                    // First hop must start with w_start only
+                    if hops == 0 && way_id != w_start {
+                        continue;
+                    }
+
+                    visited_ways.insert(way_id);
+
+                    let way_nodes_vec: Vec<i64> = match self.way_nodes.get(&way_id) {
+                        Some(nodes) => nodes.value().clone(),
+                        None => continue,
+                    };
+
+                    // Merge-back: any node on this way (other than our entry node) is in another branch
+                    for &n in &way_nodes_vec {
+                        if n != node && target_set.contains(&n) {
+                            return true;
+                        }
+                    }
+
+                    // Expand BFS from the way's endpoints
+                    let first = way_nodes_vec.first().copied();
+                    let last = way_nodes_vec.last().copied();
+                    if let Some(f) = first {
+                        if f != node {
+                            frontier.push_back((f, hops + 1));
+                        }
+                    }
+                    if let (Some(l), first_val) = (last, first) {
+                        if l != node && Some(l) != first_val {
+                            frontier.push_back((l, hops + 1));
+                        }
+                    }
+                }
+            }
+        }
+
+        false
+    }
 }
 
 impl Default for NodeConnectionCounter {
@@ -916,6 +1007,71 @@ mod tests {
             0,
             "Should reject 2-way junction without core highway"
         );
+    }
+
+    #[test]
+    fn test_merge_back_bus_bay_1hop() {
+        // Bus bay pattern (2-way junction at node 20):
+        //   passing way [10, 20, 30, 40]
+        //   bay way     [20, 50, 40]   ← returns to main road at node 40
+        let mut counter = NodeConnectionCounter::new();
+        counter.add_way(1, &[10, 20, 30, 40], "residential", false, false);
+        counter.add_way(2, &[20, 50, 40], "service", false, false);
+
+        // w_start = way 2 (the bay): target = way 1's nodes - {20} = {10, 30, 40}.
+        // Way 2 itself contains node 40 → merge-back detected at 1 hop.
+        assert!(counter.junction_has_merge_back(20, 1));
+        assert!(counter.junction_has_merge_back(20, 2));
+    }
+
+    #[test]
+    fn test_merge_back_ramp_2hop() {
+        // Ramp pattern: junction 20, connecting way exits to an intermediate way
+        // that rejoins the passing way at node 40.
+        //   passing way      [10, 20, 30, 40]
+        //   connecting way   [20, 50]
+        //   intermediate way [50, 60, 40]
+        let mut counter = NodeConnectionCounter::new();
+        counter.add_way(1, &[10, 20, 30, 40], "primary", false, false);
+        counter.add_way(2, &[20, 50], "service", false, false);
+        counter.add_way(3, &[50, 60, 40], "service", false, false);
+
+        // 1-hop is not enough (reachable only after traversing way 2 then way 3)
+        assert!(!counter.junction_has_merge_back(20, 1));
+        // 2-hop catches it
+        assert!(counter.junction_has_merge_back(20, 2));
+    }
+
+    #[test]
+    fn test_merge_back_independent_y() {
+        // Three branches radiating out from node 2 with no shared downstream nodes.
+        let mut counter = NodeConnectionCounter::new();
+        counter.add_way(1, &[2, 10, 11, 12], "residential", false, false);
+        counter.add_way(2, &[2, 20, 21, 22], "residential", false, false);
+        counter.add_way(3, &[2, 30, 31, 32], "residential", false, false);
+
+        assert!(!counter.junction_has_merge_back(2, 5));
+    }
+
+    #[test]
+    fn test_merge_back_loop_beyond_max_hops() {
+        // 3-way junction at node 2 with a long loop connecting branch 1 back to branch 2.
+        //   branch 1: way 1 = [2, 10, 11]
+        //   branch 2: way 2 = [2, 20, 21]
+        //   branch 3: way 3 = [2, 30]
+        //   loop:     [11] → way4 → 40 → way5 → 50 → way6 → 60 → way7 → [21]
+        let mut counter = NodeConnectionCounter::new();
+        counter.add_way(1, &[2, 10, 11], "residential", false, false);
+        counter.add_way(2, &[2, 20, 21], "residential", false, false);
+        counter.add_way(3, &[2, 30], "residential", false, false);
+        counter.add_way(4, &[11, 40], "residential", false, false);
+        counter.add_way(5, &[40, 50], "residential", false, false);
+        counter.add_way(6, &[50, 60], "residential", false, false);
+        counter.add_way(7, &[60, 21], "residential", false, false);
+
+        // Reaching 21 from way 1 requires 5 way-hops (way1 → way4 → way5 → way6 → way7).
+        assert!(!counter.junction_has_merge_back(2, 2));
+        assert!(counter.junction_has_merge_back(2, 5));
     }
 
     #[test]

--- a/backend/src/importer/parser.rs
+++ b/backend/src/importer/parser.rs
@@ -9,6 +9,10 @@ use super::calculator::calculate_junction_angles;
 use super::detector::{JunctionForInsert, NodeConnectionCounter, YJunctionWithCoords};
 use crate::domain::junction::AngleType;
 
+/// Max way-hops for merge-back detection.
+/// 2 hops catches bus bays (1-hop) and ramps / right-turn shortcuts (2-hop).
+const MERGE_BACK_MAX_WAY_HOPS: usize = 2;
+
 /// Way data collected during parallel parsing
 #[derive(Debug)]
 struct WayData {
@@ -238,6 +242,11 @@ pub fn parse_pbf_three_way(
                 return None;
             }
 
+            // Exclude junctions whose branches merge back downstream (bus bays, ramps, etc.)
+            if counter.junction_has_merge_back(junction.node_id, MERGE_BACK_MAX_WAY_HOPS) {
+                return None;
+            }
+
             // Extract bridge/tunnel flags from way tags (now guaranteed to be in same order as angles)
             let (way_1_bridge, way_1_tunnel) = (way_tags[0].bridge, way_tags[0].tunnel);
             let (way_2_bridge, way_2_tunnel) = (way_tags[1].bridge, way_tags[1].tunnel);
@@ -383,6 +392,11 @@ pub fn parse_pbf_two_way(
                     min_angle, candidate.node_id, junction_lat, junction_lon,
                     angles[0], angles[1], angles[2]
                 );
+                return None;
+            }
+
+            // Exclude junctions whose branches merge back downstream (bus bays, ramps, etc.)
+            if counter.junction_has_merge_back(candidate.node_id, MERGE_BACK_MAX_WAY_HOPS) {
                 return None;
             }
 

--- a/scripts/reimport-all-regions.sh
+++ b/scripts/reimport-all-regions.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Re-import all regions (Japan, Taiwan, Korea, Shanghai) into local y_junction DB
+# using freshly-built import binaries. Used for verifying the merge-back filter
+# on full-scale data.
+#
+# Prerequisites:
+#   - release binaries built: (cd backend && cargo build --release --bin import --bin import_two_way)
+#   - ~/y-junctions-data/osm/ contains the regional PBF files
+#   - Docker CockroachDB (y-junctions-cockroachdb) running
+#
+# Run from the repo root.
+
+set -euo pipefail
+
+DB_URL="${DATABASE_URL:-postgresql://root@localhost:26257/y_junction?sslmode=disable}"
+export DATABASE_URL="$DB_URL"
+
+PBF_DIR="${HOME}/y-junctions-data/osm"
+IMPORT_3WAY="./backend/target/release/import"
+IMPORT_2WAY="./backend/target/release/import_two_way"
+
+if [[ ! -x "$IMPORT_3WAY" || ! -x "$IMPORT_2WAY" ]]; then
+  echo "ERROR: release binaries not found. Run: (cd backend && cargo build --release --bin import --bin import_two_way)" >&2
+  exit 1
+fi
+
+# (region_name, pbf_filename, bbox)
+# Bboxes intentionally generous; ON CONFLICT (osm_node_id) DO NOTHING de-dupes
+# across overlapping Japan region PBFs.
+REGIONS=(
+  "hokkaido|hokkaido-latest.osm.pbf|139,40,146,46"
+  "tohoku|tohoku-latest.osm.pbf|139,36,143,42"
+  "kanto|kanto-latest.osm.pbf|138,34,141,38"
+  "chubu|chubu-latest.osm.pbf|135,33,140,38"
+  "kansai|kansai-latest.osm.pbf|134,33,137,36"
+  "chugoku|chugoku-latest.osm.pbf|130,33,135,36"
+  "shikoku|shikoku-latest.osm.pbf|132,32,135,35"
+  "kyushu|kyushu-latest.osm.pbf|127,24,132,34"
+  "taiwan|taiwan-latest.osm.pbf|119.9,21.9,122.1,25.4"
+  "korea|south-korea-latest.osm.pbf|124.6,33.1,130.9,38.6"
+  "shanghai|china-latest.osm.pbf|121.30,31.10,121.65,31.40"
+)
+
+echo "=== TRUNCATE y_junctions ==="
+docker exec y-junctions-cockroachdb ./cockroach sql --insecure \
+  --database=y_junction --execute "TRUNCATE TABLE y_junctions;"
+
+for entry in "${REGIONS[@]}"; do
+  IFS='|' read -r name pbf bbox <<<"$entry"
+  pbf_path="$PBF_DIR/$pbf"
+  if [[ ! -f "$pbf_path" ]]; then
+    echo "SKIP: $name (missing PBF: $pbf_path)"
+    continue
+  fi
+  echo
+  echo "=== $name: 3-way ==="
+  "$IMPORT_3WAY" --input "$pbf_path" --bbox "$bbox" 2>&1 \
+    | grep -E "Found|imported|Importing" | tail -5
+  echo "=== $name: 2-way ==="
+  "$IMPORT_2WAY" --input "$pbf_path" --bbox "$bbox" 2>&1 \
+    | grep -E "Found|imported|Importing" | tail -5
+done
+
+echo
+echo "=== Final totals ==="
+docker exec y-junctions-cockroachdb ./cockroach sql --insecure \
+  --database=y_junction --execute "
+SELECT
+  CASE
+    WHEN lon BETWEEN 121.30 AND 121.65 AND lat BETWEEN 31.10 AND 31.40 THEN 'shanghai'
+    WHEN lon BETWEEN 119.9 AND 122.1 AND lat BETWEEN 21.9 AND 25.4 THEN 'taiwan'
+    WHEN lon BETWEEN 124.6 AND 130.9 AND lat BETWEEN 33.1 AND 38.6 THEN 'korea'
+    ELSE 'japan'
+  END AS region,
+  COUNT(*) AS count
+FROM y_junctions
+GROUP BY region
+ORDER BY region;
+SELECT COUNT(*) AS grand_total FROM y_junctions;"


### PR DESCRIPTION
## Summary
- `NodeConnectionCounter::junction_has_merge_back` を追加し、Y字路の各分岐から最大 2 way-hop で他分岐のノードに到達できるものを除外
- 3-way / 2-way 双方の取り込みパイプラインに統合（角度・高速道路フィルタ通過後）
- 単体テスト 4 本を追加（バス湾 1-hop / ランプ 2-hop / 独立Y字 / 長ループはヒットしない）
- 全地域再インポート用の検証スクリプト `scripts/reimport-all-regions.sh` を追加

Closes #213

## 検証結果（ローカル）
- 上海 bbox: 4,350 → 2,476 件（-43.1%、issue #213 の予測 ~43% と一致）
- 全地域 (日本/台湾/韓国/上海) 再インポート: 958,218 → 641,046 件（-33.1%）

## Test plan
- [x] `cargo test --manifest-path backend/Cargo.toml` 全通過（importer 単体含む 78 件）
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過
- [x] 上海 bbox の手動再インポートで -43% を確認
- [x] バス湾サンプルノード (11505454295, 11505454292, 11802519741, 11802519744) が除外されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced junction detection with merge-back filtering to improve accuracy of road network analysis.
  * Added automated regional data import script for streamlined map updates.

* **Improvements**
  * Refined junction filtering logic to better handle complex road patterns and branch configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->