### PR TITLE
refactor: Baidu panoid 取り込みを chunked persistence にする

### DIFF
--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -173,8 +173,14 @@ pub async fn import_elevation_data(pool: &PgPool, elevation_dir: &str) -> Result
 /// will need bounded concurrency; deferred out of this PR. Out-of-China
 /// rows are skipped in-process without hitting Baidu. Transport failures
 /// abort immediately so operators can retry after fixing the underlying
-/// Baidu/network issue.
+/// Baidu/network issue; results buffered up to the previous chunk flush
+/// stay in DB so the retry skips already-fetched junctions.
 pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<usize> {
+    /// Flush every 100 fetches. Worst-case loss on transport error is
+    /// CHUNK_SIZE - 1 in-flight items; matches the existing progress-log
+    /// cadence so each "Progress" line corresponds to one flush boundary.
+    const CHUNK_SIZE: usize = 100;
+
     let junctions = if refresh {
         crate::db::baidu_repository::find_all_for_refresh(pool).await?
     } else {
@@ -192,8 +198,11 @@ pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<us
     );
 
     let client = baidu::build_client()?;
-    let mut updates: Vec<(i64, crate::domain::china::BaiduPanorama)> = Vec::new();
-    let mut missed_ids: Vec<i64> = Vec::new();
+    let mut updates: Vec<(i64, crate::domain::china::BaiduPanorama)> =
+        Vec::with_capacity(CHUNK_SIZE);
+    let mut missed_ids: Vec<i64> = Vec::with_capacity(CHUNK_SIZE);
+    let mut total_updated: usize = 0;
+    let mut total_tombstoned: usize = 0;
 
     for (idx, junction) in china_junctions.iter().enumerate() {
         if idx > 0 {
@@ -214,32 +223,68 @@ pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<us
             }
         }
 
-        if (idx + 1) % 100 == 0 {
+        if updates.len() + missed_ids.len() >= CHUNK_SIZE {
+            flush_baidu_chunk(
+                pool,
+                &mut updates,
+                &mut missed_ids,
+                &mut total_updated,
+                &mut total_tombstoned,
+            )
+            .await?;
+
             tracing::info!(
-                "Progress: {}/{} (ok={}, none={})",
+                "Progress: {}/{} (flushed: ok={}, none={})",
                 idx + 1,
                 china_junctions.len(),
-                updates.len(),
-                missed_ids.len()
+                total_updated,
+                total_tombstoned
             );
         }
     }
 
+    flush_baidu_chunk(
+        pool,
+        &mut updates,
+        &mut missed_ids,
+        &mut total_updated,
+        &mut total_tombstoned,
+    )
+    .await?;
+
     tracing::info!(
         "Baidu panoid fetch complete: total={}, ok={}, none={}",
         china_junctions.len(),
-        updates.len(),
-        missed_ids.len()
+        total_updated,
+        total_tombstoned
     );
 
-    let updated_count = crate::db::baidu_repository::bulk_update_baidu(pool, &updates).await?;
-    tracing::info!("Updated {} Y-junctions with Baidu panoid", updated_count);
+    Ok(total_updated)
+}
 
-    let tombstoned = crate::db::baidu_repository::bulk_mark_queried(pool, &missed_ids).await?;
-    tracing::info!(
-        "Tombstoned {} Y-junctions with no Baidu coverage",
-        tombstoned
-    );
+/// Persist the current buffer of fetched panoids and tombstones, then clear
+/// the buffers. Called every CHUNK_SIZE fetches and once more at the end of
+/// the loop for the trailing partial chunk. No-op when both buffers are
+/// empty (e.g. when the run length is an exact multiple of CHUNK_SIZE).
+async fn flush_baidu_chunk(
+    pool: &PgPool,
+    updates: &mut Vec<(i64, crate::domain::china::BaiduPanorama)>,
+    missed_ids: &mut Vec<i64>,
+    total_updated: &mut usize,
+    total_tombstoned: &mut usize,
+) -> Result<()> {
+    if updates.is_empty() && missed_ids.is_empty() {
+        return Ok(());
+    }
 
-    Ok(updated_count)
+    let updated = crate::db::baidu_repository::bulk_update_baidu(pool, updates).await?;
+    let tombstoned = crate::db::baidu_repository::bulk_mark_queried(pool, missed_ids).await?;
+
+    *total_updated += updated;
+    *total_tombstoned += tombstoned;
+
+    updates.clear();
+    missed_ids.clear();
+
+    Ok(())
 }


### PR DESCRIPTION
Closes #214

## Summary

- `import_baidu_panoid_data` を 100件ごとに DB flush する chunked persistence に変更
- transport error で abort しても flush 済み分は保持され、リトライ時に `find_without_baidu_panoid` が成功済みを除外して二重問い合わせを防ぐ
- 進捗ログを flush 単位の累積件数（`total_updated` / `total_tombstoned`）に変更

## 変更点

- `backend/src/importer/mod.rs::import_baidu_panoid_data`
  - `CHUNK_SIZE = 100` 導入
  - ループ中に `updates.len() + missed_ids.len() >= CHUNK_SIZE` で `flush_baidu_chunk` 呼び出し
  - ループ終了後に端数を flush
- 新規ヘルパ `flush_baidu_chunk` を追加（`bulk_update_baidu` / `bulk_mark_queried` を呼んで両バッファを clear、累積カウンタを更新）

`bulk_update_baidu` / `bulk_mark_queried` のシグネチャは変更なし。

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`（121 件 全 pass）
- [ ] 手動: 上海 bbox 等で実際にインポート途中で abort し、再実行で flush 済み junction を Baidu API に再問い合わせしないことを確認（issue 受け入れ条件 (b)）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Baidu map data imports have been optimized for improved efficiency and progress tracking. The import operation now provides cumulative metrics and enhanced logging throughout the process, giving users better visibility into import status and completion timeline. Large-scale data imports benefit from more efficient resource management through improved incremental processing techniques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->