### PR TITLE
feat: バス停ループ（パターンA）の Y字路を取り込み時に除外

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ npm install  # 初回のみ
 npm run dev
 ```
 
-フロントエンドは `http://localhost:5173` で起動します。
+フロントエンドは `http://localhost:3000` で起動します（ポートは `frontend/vite.config.ts` で指定）。
 
 ### Git Worktree Runnerの設定（追加worktree用）
 

--- a/backend/src/importer/detector.rs
+++ b/backend/src/importer/detector.rs
@@ -117,6 +117,8 @@ pub struct NodeConnectionCounter {
     valid_highway_types: HashSet<String>,
     /// Core highway types (roads, not pedestrian ways) - at least one required per junction
     core_highway_types: HashSet<String>,
+    /// Node ids tagged public_transport=stop_position
+    bus_stop_nodes: HashSet<i64>,
 }
 
 impl NodeConnectionCounter {
@@ -168,7 +170,18 @@ impl NodeConnectionCounter {
             way_highway_types: DashMap::new(),
             valid_highway_types,
             core_highway_types,
+            bus_stop_nodes: HashSet::new(),
         }
+    }
+
+    /// Register a node id as a bus stop (public_transport=stop_position)
+    pub fn add_bus_stop_node(&mut self, node_id: i64) {
+        self.bus_stop_nodes.insert(node_id);
+    }
+
+    /// Check if a node is a bus stop
+    pub fn is_bus_stop_node(&self, node_id: i64) -> bool {
+        self.bus_stop_nodes.contains(&node_id)
     }
 
     /// Check if highway type is valid for Y-junction detection
@@ -477,6 +490,115 @@ impl NodeConnectionCounter {
     /// Returns WayTagInfo if the way exists, None otherwise
     pub fn get_way_tag(&self, way_id: i64) -> Option<WayTagInfo> {
         self.way_tags.get(&way_id).map(|tag| tag.clone())
+    }
+
+    /// Check if a junction is part of a bus-stop loop (Pattern A bus pull-out).
+    ///
+    /// Detects the structure: J → service way → bus_stop → service way → N,
+    /// where N lies on another branch of J (the split main road), and the
+    /// bus_stop has exactly degree 2 (only the in/out service ways meet there).
+    ///
+    /// Both junctions of a paired pull-out match this condition symmetrically,
+    /// so calling this on either J1 or J2 returns true.
+    pub fn junction_has_bus_stop_loop(&self, junction_node_id: i64) -> bool {
+        let way_ids: Vec<i64> = match self.node_to_ways.get(&junction_node_id) {
+            Some(ws) => ws.value().iter().copied().collect(),
+            None => return false,
+        };
+
+        for &wid in &way_ids {
+            // Branch must be highway=service
+            let highway = match self.way_highway_types.get(&wid) {
+                Some(h) => h.value().clone(),
+                None => continue,
+            };
+            if highway != "service" {
+                continue;
+            }
+
+            // Find far endpoint of this service way (must be at endpoint, not middle)
+            let nodes: Vec<i64> = match self.way_nodes.get(&wid) {
+                Some(n) => n.value().clone(),
+                None => continue,
+            };
+            if nodes.len() < 2 {
+                continue;
+            }
+            let far_endpoint = if nodes[0] == junction_node_id {
+                nodes[nodes.len() - 1]
+            } else if nodes[nodes.len() - 1] == junction_node_id {
+                nodes[0]
+            } else {
+                continue;
+            };
+
+            // Far endpoint must be a bus stop
+            if !self.is_bus_stop_node(far_endpoint) {
+                continue;
+            }
+
+            // Bus stop must have exactly degree 2 (in + out, no extra branches)
+            let bus_stop_ways: Vec<i64> = match self.node_to_ways.get(&far_endpoint) {
+                Some(ws) => ws.value().iter().copied().collect(),
+                None => continue,
+            };
+            if bus_stop_ways.len() != 2 {
+                continue;
+            }
+
+            // The other way at the bus stop
+            let other_wid = match bus_stop_ways.iter().find(|&&w| w != wid).copied() {
+                Some(w) => w,
+                None => continue,
+            };
+
+            // Other way must also be highway=service
+            let other_highway = match self.way_highway_types.get(&other_wid) {
+                Some(h) => h.value().clone(),
+                None => continue,
+            };
+            if other_highway != "service" {
+                continue;
+            }
+
+            // Find far endpoint of the other service way (must be at endpoint)
+            let other_nodes: Vec<i64> = match self.way_nodes.get(&other_wid) {
+                Some(n) => n.value().clone(),
+                None => continue,
+            };
+            if other_nodes.len() < 2 {
+                continue;
+            }
+            let other_far = if other_nodes[0] == far_endpoint {
+                other_nodes[other_nodes.len() - 1]
+            } else if other_nodes[other_nodes.len() - 1] == far_endpoint {
+                other_nodes[0]
+            } else {
+                continue;
+            };
+
+            // Build target_set: nodes of J's OTHER branches (not the current service way),
+            // excluding J itself. This is what "loop comes back to another branch" means.
+            let mut target_set: HashSet<i64> = HashSet::new();
+            for &other_branch_wid in &way_ids {
+                if other_branch_wid == wid {
+                    continue;
+                }
+                if let Some(branch_nodes) = self.way_nodes.get(&other_branch_wid) {
+                    for &nid in branch_nodes.value() {
+                        if nid != junction_node_id {
+                            target_set.insert(nid);
+                        }
+                    }
+                }
+            }
+
+            if target_set.contains(&other_far) {
+                return true;
+            }
+        }
+
+        false
     }
 }
 
@@ -939,6 +1061,84 @@ mod tests {
             candidates.len(),
             1,
             "Should accept 2-way junction with one core highway"
+        );
+    }
+
+    /// Build a paired bus pull-out: J1 ↔ J2 connected by a main road segment
+    /// AND by a service loop through bus_stop B.
+    ///
+    ///   [10] ── main ── [J1=100] ── main ── [J2=200] ── main ── [20]
+    ///                     │                    ↑
+    ///                     │ service            │ service
+    ///                     └──→ [B=50] ─────────┘
+    fn build_paired_pullout_counter() -> NodeConnectionCounter {
+        let mut counter = NodeConnectionCounter::new();
+        counter.add_way(1, &[10, 100], "tertiary", false, false); // main_a
+        counter.add_way(2, &[100, 200], "tertiary", false, false); // main_b (J1↔J2)
+        counter.add_way(3, &[200, 20], "tertiary", false, false); // main_c
+        counter.add_way(4, &[100, 50], "service", false, false); // service J1→B
+        counter.add_way(5, &[50, 200], "service", false, false); // service B→J2
+        counter.add_bus_stop_node(50);
+        counter
+    }
+
+    #[test]
+    fn test_bus_stop_loop_excludes_j1() {
+        let counter = build_paired_pullout_counter();
+        assert!(
+            counter.junction_has_bus_stop_loop(100),
+            "J1 (entry of bus pull-out) should be detected"
+        );
+    }
+
+    #[test]
+    fn test_bus_stop_loop_excludes_j2() {
+        let counter = build_paired_pullout_counter();
+        assert!(
+            counter.junction_has_bus_stop_loop(200),
+            "J2 (exit of bus pull-out) should be detected"
+        );
+    }
+
+    #[test]
+    fn test_bus_stop_loop_independent_y_not_excluded() {
+        let mut counter = NodeConnectionCounter::new();
+        // 3 independent branches, no bus stop, no loop
+        counter.add_way(1, &[1, 100], "tertiary", false, false);
+        counter.add_way(2, &[100, 2], "tertiary", false, false);
+        counter.add_way(3, &[100, 3], "service", false, false);
+
+        assert!(
+            !counter.junction_has_bus_stop_loop(100),
+            "Independent Y-junction without bus stop must not match"
+        );
+    }
+
+    #[test]
+    fn test_bus_stop_loop_degree_three_bus_stop_not_excluded() {
+        // Same shape as paired pull-out, but bus_stop also has a 3rd way
+        // → bus_stop degree = 3 → must NOT match (terminal-like, not Pattern A)
+        let mut counter = NodeConnectionCounter::new();
+        counter.add_way(1, &[10, 100], "tertiary", false, false);
+        counter.add_way(2, &[100, 200], "tertiary", false, false);
+        counter.add_way(3, &[200, 20], "tertiary", false, false);
+        counter.add_way(4, &[100, 50], "service", false, false);
+        counter.add_way(5, &[50, 200], "service", false, false);
+        counter.add_way(6, &[50, 999], "service", false, false); // 3rd way at bus_stop
+        counter.add_bus_stop_node(50);
+
+        assert_eq!(
+            counter.get_connection_count(50),
+            3,
+            "Bus stop now has degree 3"
+        );
+        assert!(
+            !counter.junction_has_bus_stop_loop(100),
+            "Pattern A rule must not match when bus stop has extra branches"
+        );
+        assert!(
+            !counter.junction_has_bus_stop_loop(200),
+            "Pattern A rule must not match J2 either"
         );
     }
 }

--- a/backend/src/importer/parser.rs
+++ b/backend/src/importer/parser.rs
@@ -24,6 +24,7 @@ struct WayData {
 struct LocalState {
     ways: Vec<WayData>,
     nodes: Vec<(i64, (f64, f64))>,
+    bus_stop_node_ids: Vec<i64>,
 }
 
 impl LocalState {
@@ -34,6 +35,7 @@ impl LocalState {
     fn merge(mut self, other: Self) -> Self {
         self.ways.extend(other.ways);
         self.nodes.extend(other.nodes);
+        self.bus_stop_node_ids.extend(other.bus_stop_node_ids);
         self
     }
 }
@@ -86,10 +88,22 @@ fn build_cache_and_counter(input_path: &str) -> Result<CacheAndCounter> {
                 osmpbf::Element::Node(node) => {
                     // Cache all node coordinates
                     local.nodes.push((node.id(), (node.lat(), node.lon())));
+                    if node
+                        .tags()
+                        .any(|(k, v)| k == "public_transport" && v == "stop_position")
+                    {
+                        local.bus_stop_node_ids.push(node.id());
+                    }
                 }
                 osmpbf::Element::DenseNode(node) => {
                     // Cache all dense node coordinates
                     local.nodes.push((node.id(), (node.lat(), node.lon())));
+                    if node
+                        .tags()
+                        .any(|(k, v)| k == "public_transport" && v == "stop_position")
+                    {
+                        local.bus_stop_node_ids.push(node.id());
+                    }
                 }
                 _ => {}
             }
@@ -113,6 +127,9 @@ fn build_cache_and_counter(input_path: &str) -> Result<CacheAndCounter> {
             way.tunnel,
         );
     }
+    for &node_id in &local_state.bus_stop_node_ids {
+        counter.add_bus_stop_node(node_id);
+    }
 
     // Build node coordinates map
     let node_coords: DashMap<i64, (f64, f64)> = DashMap::new();
@@ -128,6 +145,10 @@ fn build_cache_and_counter(input_path: &str) -> Result<CacheAndCounter> {
         counter.node_count()
     );
     tracing::info!("  Total node coordinates cached: {}", node_coords.len());
+    tracing::info!(
+        "  Bus stop nodes (public_transport=stop_position): {}",
+        local_state.bus_stop_node_ids.len()
+    );
 
     Ok((Arc::new(node_coords), counter))
 }
@@ -235,6 +256,13 @@ pub fn parse_pbf_three_way(
 
             // 最小角度が60度以上の場合はT字路とみなして除外
             if min_angle >= 60 {
+                return None;
+            }
+
+            // Exclude paired bus pull-outs (Pattern A): one branch is a service way
+            // leading to a bus_stop that loops back to another branch via a second
+            // service way. Catches both J1 and J2 of the pair symmetrically.
+            if counter.junction_has_bus_stop_loop(junction.node_id) {
                 return None;
             }
 
@@ -383,6 +411,11 @@ pub fn parse_pbf_two_way(
                     min_angle, candidate.node_id, junction_lat, junction_lon,
                     angles[0], angles[1], angles[2]
                 );
+                return None;
+            }
+
+            // Exclude paired bus pull-outs (Pattern A): see parse_pbf_three_way for details.
+            if counter.junction_has_bus_stop_loop(candidate.node_id) {
                 return None;
             }
 


### PR DESCRIPTION
## Summary

3-way / 2-way 双方の取り込みパイプラインで「バス停ループ（パターン A）」を除外する。本線が2つの隣接 junction で分割され、間の service way + bus_stop で閉じる構造（典型的なバスベイ）を構造ベースで検出。

## 判定ルール（パターン A 限定）

junction J の枝のうち1本が以下を**全部**満たすとき除外：

- 枝 way が `highway=service`
- 枝 way の自分以外の端点が `public_transport=stop_position`
- bus_stop の degree が 2（in/out 2本のみ、他 way の分岐なし）
- bus_stop の他方の service way の far endpoint が、J の **他の枝**のノード上にある（ループ閉じ）

```
   ─── 本線 ─── [J1] ─── 本線 ─── [J2] ─── 本線 ───
                 │                  ↑
                 │ service          │ service
                 ↓                  │
                 └──→ [bus_stop] ───┘   ← degree=2
```

J1, J2 の両方からループ条件が成立し、両端の junction とも除外される。

## 検証結果（ローカル, 上海 bbox `121.30,31.10,121.65,31.40`）

- **4,350 → 4,138 件 (-212, -4.9%)**
- 事前に確認した 14 件のサンプルのうち **12 件除外**
- 残り 2 件は **パターンB**（本線中間 node にも bus_stop タグ、J1↔J2 が本線1本で直接繋がらない）。本PRの対象外、別パターンとして後続検討

## なぜ issue #215 原案の方針を採らなかったか

- issue 原案: 「way の `psv ∈ {yes,designated,permissive}`」「末端 bus_stop が **2本以上**」で除外
- 実データ確認した 14 件中 11 件が末端 bus_stop **1 本のみ**で、原案閾値では取り逃す
- `psv` タグも 14 件中 3 件しか付いていない
- 構造シグネチャ（service+oneway+bus_stop ループ）の方が実態に合う

## テスト

`backend/src/importer/detector.rs` に4本追加：

- `test_bus_stop_loop_excludes_j1` — ペアの片端が除外
- `test_bus_stop_loop_excludes_j2` — もう片端も対称に除外
- `test_bus_stop_loop_independent_y_not_excluded` — 独立 Y字路は除外しない
- `test_bus_stop_loop_degree_three_bus_stop_not_excluded` — bus_stop に他 way 分岐がある場合は除外しない（ターミナル等の別パターン）

## 副次変更

- `README.md` のフロントエンド起動ポートを 5173 → 3000 に修正（実態は `frontend/vite.config.ts` で 3000 固定）

## Test plan

- [x] `cargo test --manifest-path backend/Cargo.toml`（追加4本含む 78件）
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] 上海 bbox 再 import で件数差 (-212) と 12/14 サンプル除外を確認

Refs #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated frontend startup configuration and port information in README.

* **Improvements**
  * Enhanced junction detection filtering for transport-related patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->