### PR TITLE
feat: baidu_panoramas テーブル追加 (#223 1/3)

### DIFF
--- a/backend/migrations/009_extract_baidu_panoramas.sql
+++ b/backend/migrations/009_extract_baidu_panoramas.sql
@@ -1,0 +1,17 @@
+-- Extract Baidu panorama metadata to a separate table keyed by osm_node_id.
+-- Why: y_junctions.id is auto-incremented, so DELETE + re-import (e.g. when
+-- tweaking import filters) churns ids and orphans the panoid cache. Keying on
+-- osm_node_id (stable across re-imports) means the cache survives.
+--
+-- This migration is the EXPAND half of an expand-and-contract pair. It only
+-- creates the new table; existing rows in y_junctions.baidu_* must be moved
+-- via backend/scripts/backfill_baidu_panoramas.sql (run once after this
+-- migration). A follow-up migration drops the legacy columns from
+-- y_junctions after the new code path is verified in prod.
+CREATE TABLE baidu_panoramas (
+  osm_node_id BIGINT PRIMARY KEY,
+  panoid VARCHAR NULL,
+  pano_mc_x DOUBLE PRECISION NULL,
+  pano_mc_y DOUBLE PRECISION NULL,
+  queried_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary

- `backend/migrations/009_extract_baidu_panoramas.sql` を新規追加
- `baidu_panoramas` (osm_node_id 主キー) を作成するだけの pure DDL migration
- application コード変更なし、データ移行なし、旧カラム削除なし

#219 (Baidu panoid を別テーブルに分離) を 3 PR + 1 ops に分けたうちの 1 番目。

```
1. ⬅︎ このPR: テーブル追加
2.    operator が backfill SQL を prod で 1 回手動実行 (PR にしない)
3.    #225: アプリケーションを baidu_panoramas 参照に切り替え (別 PR)
4.    #224: 旧カラム drop (別 PR)
```

## merge & release 後に operator が実行する backfill SQL

```sql
INSERT INTO baidu_panoramas (osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at)
SELECT osm_node_id, baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y, baidu_queried_at
FROM y_junctions
WHERE baidu_queried_at IS NOT NULL
ON CONFLICT (osm_node_id) DO NOTHING;
```

idempotent。これを (2/3) PR デプロイ前に流しておかないと、新コードが空の `baidu_panoramas` を見て中国の junction が map から消える。

## Test plan

- [x] `cargo test` 47/47 通過
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過
- [ ] CI (backend-ci) green
- [ ] merge → CI が `sqlx migrate run` で 009 を prod に適用
- [ ] operator が prod に backfill SQL を実行 (上記)
- [ ] `SELECT COUNT(*) FROM baidu_panoramas;` で 4138+ 件確認

Closes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database infrastructure to support Baidu panorama data storage with timestamp tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->