### PR TITLE
feat: アプリケーションを baidu_panoramas 参照に切り替え (#225 2/3)

### DIFF
--- a/.claude/commands/deploy-data.md
+++ b/.claude/commands/deploy-data.md
@@ -15,7 +15,8 @@ IMPORT INTO が失敗する。新規地域は非重複 bbox を選ぶこと。
 手動で TRUNCATE + 全件 IMPORT INTO を実施する。
 
 Step 4 以降で失敗した場合は userfile が残るので、手動で
-`cockroach userfile delete junctions.csv --url "$PROD_CRDB_URI"` で掃除する。
+`cockroach userfile delete junctions.csv --url "$PROD_CRDB_URI"` と
+`cockroach userfile delete baidu_panoramas.csv --url "$PROD_CRDB_URI"` で掃除する。
 
 ## Step 1: bbox の検証と本番DB接続情報の取得
 
@@ -70,6 +71,19 @@ docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
 LINE_COUNT=$(wc -l < ~/y-junctions-data/junctions.csv)
 [ "$LINE_COUNT" -gt 0 ] || { echo "export produced 0 rows, aborting"; exit 1; }
 echo "exported $LINE_COUNT rows"
+
+# bbox 内の junction に紐付く baidu_panoramas 行も書き出す
+docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
+  psql "postgresql://root@host.docker.internal:26257/y_junction?sslmode=disable" -c "\copy (
+    SELECT bp.osm_node_id, bp.panoid, bp.pano_mc_x, bp.pano_mc_y, bp.queried_at
+    FROM baidu_panoramas bp
+    JOIN y_junctions y ON y.osm_node_id = bp.osm_node_id
+    WHERE y.lon BETWEEN $MIN_LON AND $MAX_LON
+      AND y.lat BETWEEN $MIN_LAT AND $MAX_LAT
+  ) TO '/data/baidu_panoramas.csv' WITH CSV"
+
+BAIDU_COUNT=$(wc -l < ~/y-junctions-data/baidu_panoramas.csv)
+echo "exported $BAIDU_COUNT baidu_panoramas rows"
 ```
 
 ## Step 3: userfile に CSV をアップロード
@@ -84,6 +98,9 @@ PROD_CRDB_URI=$(cd terraform && terraform output -raw cockroachdb_connection_uri
 
 cockroach userfile upload ~/y-junctions-data/junctions.csv \
   junctions.csv --url "$PROD_CRDB_URI"
+
+cockroach userfile upload ~/y-junctions-data/baidu_panoramas.csv \
+  baidu_panoramas.csv --url "$PROD_CRDB_URI"
 ```
 
 ## Step 4: 本番DBに差分追加（IMPORT INTO、TRUNCATE なし）
@@ -105,6 +122,10 @@ cockroach sql --url "$PROD_CRDB_URI" -e "IMPORT INTO y_junctions (
   baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y,
   created_at
 ) CSV DATA ('userfile:///junctions.csv');"
+
+cockroach sql --url "$PROD_CRDB_URI" -e "IMPORT INTO baidu_panoramas (
+  osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at
+) CSV DATA ('userfile:///baidu_panoramas.csv');"
 ```
 
 出力に `status: succeeded` と投入件数が出ていることを確認する。
@@ -130,4 +151,5 @@ cockroach sql --url "$PROD_CRDB_URI" -e "
 
 cockroach sql --url "$PROD_CRDB_URI" -e "SELECT COUNT(*) FROM y_junctions;"
 cockroach userfile delete junctions.csv --url "$PROD_CRDB_URI"
+cockroach userfile delete baidu_panoramas.csv --url "$PROD_CRDB_URI"
 ```

--- a/.claude/commands/sync-from-prod.md
+++ b/.claude/commands/sync-from-prod.md
@@ -18,7 +18,7 @@ PROD_CRDB_URI=$(cd terraform && terraform output -raw cockroachdb_connection_uri
 # ローカルCockroachDB（port 26257）の既存データを削除
 # DELETE はトランザクションのロック予算（デフォルト 1MB）で 100万行規模から詰まるので TRUNCATE を使う
 cockroach sql --url "postgresql://root@localhost:26257/y_junction?sslmode=disable" \
-  --execute "TRUNCATE y_junctions;"
+  --execute "TRUNCATE y_junctions; TRUNCATE baidu_panoramas;"
 
 # 本番DBからCSVエクスポート（~/y-junctions-data/prod_export.csv に出力）
 docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
@@ -39,12 +39,23 @@ docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
     FROM y_junctions
   ) TO '/data/prod_export.csv' WITH CSV HEADER"
 
+# baidu_panoramas も別CSVに書き出す（osm_node_id をキーに後で結合される）
+docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
+  psql "$PROD_CRDB_URI" -c "\copy (
+    SELECT osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at
+    FROM baidu_panoramas
+  ) TO '/data/prod_export_baidu_panoramas.csv' WITH CSV HEADER"
+
 # CSVをy-junctions-cockroachdbコンテナのexternディレクトリに配置
 docker cp ~/y-junctions-data/prod_export.csv y-junctions-cockroachdb:/cockroach/cockroach-data/extern/prod_export.csv
+docker cp ~/y-junctions-data/prod_export_baidu_panoramas.csv y-junctions-cockroachdb:/cockroach/cockroach-data/extern/prod_export_baidu_panoramas.csv
 
 # IMPORT INTO でローカルCockroachDBにインポート（nodelocal://1/ はコンテナのexternディレクトリを参照）
 cockroach sql --url "postgresql://root@localhost:26257/y_junction?sslmode=disable" \
   --execute "IMPORT INTO y_junctions (osm_node_id, location, angle_1, angle_2, angle_3, bearings, elevation, neighbor_elevation_1, neighbor_elevation_2, neighbor_elevation_3, elevation_diff_1, elevation_diff_2, elevation_diff_3, min_angle_index, min_elevation_diff, max_elevation_diff, way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel, way_3_bridge, way_3_tunnel, way_1_highway_type, way_2_highway_type, way_3_highway_type, baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y, created_at) CSV DATA ('nodelocal://1/prod_export.csv') WITH skip = '1';"
+
+cockroach sql --url "postgresql://root@localhost:26257/y_junction?sslmode=disable" \
+  --execute "IMPORT INTO baidu_panoramas (osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at) CSV DATA ('nodelocal://1/prod_export_baidu_panoramas.csv') WITH skip = '1';"
 ```
 
 件数を確認する:

--- a/backend/migrations/009_extract_baidu_panoramas.sql
+++ b/backend/migrations/009_extract_baidu_panoramas.sql
@@ -1,0 +1,17 @@
+-- Extract Baidu panorama metadata to a separate table keyed by osm_node_id.
+-- Why: y_junctions.id is auto-incremented, so DELETE + re-import (e.g. when
+-- tweaking import filters) churns ids and orphans the panoid cache. Keying on
+-- osm_node_id (stable across re-imports) means the cache survives.
+--
+-- This migration is the EXPAND half of an expand-and-contract pair. It only
+-- creates the new table; existing rows in y_junctions.baidu_* must be moved
+-- via backend/scripts/backfill_baidu_panoramas.sql (run once after this
+-- migration). A follow-up migration drops the legacy columns from
+-- y_junctions after the new code path is verified in prod.
+CREATE TABLE baidu_panoramas (
+  osm_node_id BIGINT PRIMARY KEY,
+  panoid VARCHAR NULL,
+  pano_mc_x DOUBLE PRECISION NULL,
+  pano_mc_y DOUBLE PRECISION NULL,
+  queried_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/src/api/streetview_enricher.rs
+++ b/backend/src/api/streetview_enricher.rs
@@ -12,13 +12,13 @@ pub async fn enrich_collection(
     pool: &PgPool,
     junctions: Vec<Junction>,
 ) -> Result<serde_json::Value, sqlx::Error> {
-    let ids: Vec<i64> = junctions.iter().map(|j| j.id).collect();
-    let baidu_map = baidu_repository::find_by_junction_ids(pool, &ids).await?;
+    let osm_node_ids: Vec<i64> = junctions.iter().map(|j| j.osm_node_id).collect();
+    let baidu_map = baidu_repository::find_by_osm_node_ids(pool, &osm_node_ids).await?;
 
     let features: Vec<serde_json::Value> = junctions
         .iter()
         .filter_map(|j| {
-            let baidu = baidu_map.get(&j.id);
+            let baidu = baidu_map.get(&j.osm_node_id);
             if china::is_in_china_mainland(j.lon, j.lat) && baidu.is_none() {
                 return None;
             }
@@ -42,10 +42,10 @@ pub async fn enrich_feature(
     pool: &PgPool,
     junction: Junction,
 ) -> Result<serde_json::Value, sqlx::Error> {
-    let baidu_map = baidu_repository::find_by_junction_ids(pool, &[junction.id]).await?;
+    let baidu_map = baidu_repository::find_by_osm_node_ids(pool, &[junction.osm_node_id]).await?;
     let mut feature = junction.to_feature();
     feature["properties"]["streetview_url"] =
-        serde_json::Value::String(build_url(&junction, baidu_map.get(&junction.id)));
+        serde_json::Value::String(build_url(&junction, baidu_map.get(&junction.osm_node_id)));
     Ok(feature)
 }
 

--- a/backend/src/db/baidu_repository.rs
+++ b/backend/src/db/baidu_repository.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, FromRow)]
 struct BaiduRow {
-    id: i64,
+    osm_node_id: i64,
     panoid: String,
     pano_mc_x: f64,
     pano_mc_y: f64,
@@ -61,24 +61,23 @@ impl From<JunctionRow> for Junction {
     }
 }
 
-/// Fetch saved Baidu panorama metadata for the given junction ids. Rows with
-/// NULL panoid are skipped so the returned map contains only junctions that
-/// actually have a linked panorama.
-pub async fn find_by_junction_ids(
+/// Fetch saved Baidu panorama metadata for the given OSM node ids. Rows whose
+/// `panoid` is NULL (tombstones for "queried, no coverage") are skipped so the
+/// returned map contains only nodes that actually have a linked panorama.
+pub async fn find_by_osm_node_ids(
     pool: &PgPool,
-    ids: &[i64],
+    osm_node_ids: &[i64],
 ) -> Result<HashMap<i64, BaiduPanorama>, sqlx::Error> {
-    if ids.is_empty() {
+    if osm_node_ids.is_empty() {
         return Ok(HashMap::new());
     }
 
     let rows: Vec<BaiduRow> = sqlx::query_as(
-        "SELECT id, baidu_panoid AS panoid, \
-                baidu_pano_mc_x AS pano_mc_x, baidu_pano_mc_y AS pano_mc_y \
-         FROM y_junctions \
-         WHERE id = ANY($1) AND baidu_panoid IS NOT NULL",
+        "SELECT osm_node_id, panoid, pano_mc_x, pano_mc_y \
+         FROM baidu_panoramas \
+         WHERE osm_node_id = ANY($1) AND panoid IS NOT NULL",
     )
-    .bind(ids)
+    .bind(osm_node_ids)
     .fetch_all(pool)
     .await?;
 
@@ -86,7 +85,7 @@ pub async fn find_by_junction_ids(
         .into_iter()
         .map(|r| {
             (
-                r.id,
+                r.osm_node_id,
                 BaiduPanorama {
                     panoid: r.panoid,
                     pano_mc_x: r.pano_mc_x,
@@ -97,20 +96,23 @@ pub async fn find_by_junction_ids(
         .collect())
 }
 
-/// Fetch every junction that has never been queried against Baidu. Rows that
-/// were queried previously and returned no coverage are skipped via the
-/// `baidu_queried_at` tombstone so re-runs don't re-hit dead coordinates;
-/// use `find_all_for_refresh` to force a full re-query.
+/// Fetch every junction that has never been queried against Baidu. A junction
+/// is "never queried" iff no row exists in `baidu_panoramas` for its
+/// `osm_node_id` — tombstones (queried-but-no-coverage) are stored as rows
+/// with `panoid IS NULL` and excluded by the LEFT JOIN filter so re-runs
+/// don't re-hit dead coordinates. Use `find_all_for_refresh` to force a full
+/// re-query.
 pub async fn find_without_baidu_panoid(pool: &PgPool) -> Result<Vec<Junction>, sqlx::Error> {
     let rows: Vec<JunctionRow> = sqlx::query_as(
-        "SELECT id, osm_node_id, \
-         lat, lon, \
-         angle_1, angle_2, angle_3, bearings, created_at, \
-         elevation, min_elevation_diff, max_elevation_diff, min_angle_elevation_diff, \
-         way_1_highway_type, way_2_highway_type, way_3_highway_type, \
-         way_1_category, way_2_category, way_3_category \
-         FROM y_junctions \
-         WHERE baidu_panoid IS NULL AND baidu_queried_at IS NULL",
+        "SELECT y.id, y.osm_node_id, \
+         y.lat, y.lon, \
+         y.angle_1, y.angle_2, y.angle_3, y.bearings, y.created_at, \
+         y.elevation, y.min_elevation_diff, y.max_elevation_diff, y.min_angle_elevation_diff, \
+         y.way_1_highway_type, y.way_2_highway_type, y.way_3_highway_type, \
+         y.way_1_category, y.way_2_category, y.way_3_category \
+         FROM y_junctions y \
+         LEFT JOIN baidu_panoramas bp ON bp.osm_node_id = y.osm_node_id \
+         WHERE bp.osm_node_id IS NULL",
     )
     .fetch_all(pool)
     .await?;
@@ -135,8 +137,10 @@ pub async fn find_all_for_refresh(pool: &PgPool) -> Result<Vec<Junction>, sqlx::
     Ok(rows.into_iter().map(Junction::from).collect())
 }
 
-/// Bulk upsert panorama metadata for the given junction ids. Batched with a
-/// `FROM (VALUES ...)` update to avoid exceeding PostgreSQL's parameter limit.
+/// Bulk upsert panorama metadata keyed by `osm_node_id`. Existing rows
+/// (tombstones or stale panoids) are overwritten; `queried_at` is refreshed
+/// to NOW() on every successful fetch. Batched with a single VALUES list per
+/// chunk to avoid exceeding PostgreSQL's parameter limit.
 pub async fn bulk_update_baidu(
     pool: &PgPool,
     updates: &[(i64, BaiduPanorama)],
@@ -151,32 +155,30 @@ pub async fn bulk_update_baidu(
 
     for chunk in updates.chunks(BATCH_SIZE) {
         let mut qb = QueryBuilder::new(
-            "UPDATE y_junctions SET \
-             baidu_panoid = updates.panoid, \
-             baidu_pano_mc_x = updates.pano_mc_x, \
-             baidu_pano_mc_y = updates.pano_mc_y, \
-             baidu_queried_at = NOW() \
-             FROM (VALUES ",
+            "INSERT INTO baidu_panoramas (osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at) VALUES ",
         );
 
-        for (i, (id, pano)) in chunk.iter().enumerate() {
+        for (i, (osm_node_id, pano)) in chunk.iter().enumerate() {
             if i > 0 {
                 qb.push(", ");
             }
             qb.push("(");
-            qb.push_bind(*id);
+            qb.push_bind(*osm_node_id);
             qb.push(", ");
             qb.push_bind(pano.panoid.clone());
             qb.push(", ");
             qb.push_bind(pano.pano_mc_x);
             qb.push(", ");
             qb.push_bind(pano.pano_mc_y);
-            qb.push(")");
+            qb.push(", NOW())");
         }
 
         qb.push(
-            ") AS updates(id, panoid, pano_mc_x, pano_mc_y) \
-             WHERE y_junctions.id = updates.id",
+            " ON CONFLICT (osm_node_id) DO UPDATE SET \
+             panoid = EXCLUDED.panoid, \
+             pano_mc_x = EXCLUDED.pano_mc_x, \
+             pano_mc_y = EXCLUDED.pano_mc_y, \
+             queried_at = NOW()",
         );
 
         let result = qb.build().execute(&mut *tx).await?;
@@ -187,23 +189,31 @@ pub async fn bulk_update_baidu(
     Ok(total_updated)
 }
 
-/// Stamp `baidu_queried_at = NOW()` for junctions that returned no panorama
-/// so they're excluded from the next `find_without_baidu_panoid` run. The
-/// `AND baidu_panoid IS NULL` clause keeps this strictly a tombstone writer:
-/// if a caller mistakenly passes an id for a successful row, we leave the
-/// existing `baidu_queried_at` (set by `bulk_update_baidu`) untouched.
-pub async fn bulk_mark_queried(pool: &PgPool, ids: &[i64]) -> Result<usize, sqlx::Error> {
-    if ids.is_empty() {
+/// Stamp a tombstone (`panoid` NULL, `queried_at = NOW()`) for OSM nodes that
+/// returned no panorama, so they're excluded from the next
+/// `find_without_baidu_panoid` run. `ON CONFLICT DO NOTHING` keeps this
+/// strictly a tombstone writer: if a row already exists in `baidu_panoramas`
+/// (either a successful fetch or a prior tombstone) we leave it untouched —
+/// callers that mistakenly pass a node id with an existing panoid won't
+/// damage the success row's `queried_at`.
+pub async fn bulk_mark_queried(pool: &PgPool, osm_node_ids: &[i64]) -> Result<usize, sqlx::Error> {
+    if osm_node_ids.is_empty() {
         return Ok(0);
     }
 
-    let result = sqlx::query(
-        "UPDATE y_junctions SET baidu_queried_at = NOW() \
-         WHERE id = ANY($1) AND baidu_panoid IS NULL",
-    )
-    .bind(ids)
-    .execute(pool)
-    .await?;
+    let mut qb = QueryBuilder::new("INSERT INTO baidu_panoramas (osm_node_id, queried_at) VALUES ");
 
+    for (i, osm_node_id) in osm_node_ids.iter().enumerate() {
+        if i > 0 {
+            qb.push(", ");
+        }
+        qb.push("(");
+        qb.push_bind(*osm_node_id);
+        qb.push(", NOW())");
+    }
+
+    qb.push(" ON CONFLICT (osm_node_id) DO NOTHING");
+
+    let result = qb.build().execute(pool).await?;
     Ok(result.rows_affected() as usize)
 }

--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -200,7 +200,7 @@ pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<us
     let client = baidu::build_client()?;
     let mut updates: Vec<(i64, crate::domain::china::BaiduPanorama)> =
         Vec::with_capacity(CHUNK_SIZE);
-    let mut missed_ids: Vec<i64> = Vec::with_capacity(CHUNK_SIZE);
+    let mut missed_osm_node_ids: Vec<i64> = Vec::with_capacity(CHUNK_SIZE);
     let mut total_updated: usize = 0;
     let mut total_tombstoned: usize = 0;
 
@@ -210,12 +210,12 @@ pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<us
         }
 
         match baidu::fetch_nearest_panorama(&client, junction.lon, junction.lat).await {
-            Ok(Some(pano)) => updates.push((junction.id, pano)),
-            Ok(None) => missed_ids.push(junction.id),
+            Ok(Some(pano)) => updates.push((junction.osm_node_id, pano)),
+            Ok(None) => missed_osm_node_ids.push(junction.osm_node_id),
             Err(e) => {
                 return Err(anyhow::anyhow!(
-                    "Baidu qsdata failed for junction {} ({}, {}): {}",
-                    junction.id,
+                    "Baidu qsdata failed for junction osm_node_id={} ({}, {}): {}",
+                    junction.osm_node_id,
                     junction.lat,
                     junction.lon,
                     e
@@ -223,11 +223,11 @@ pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<us
             }
         }
 
-        if updates.len() + missed_ids.len() >= CHUNK_SIZE {
+        if updates.len() + missed_osm_node_ids.len() >= CHUNK_SIZE {
             flush_baidu_chunk(
                 pool,
                 &mut updates,
-                &mut missed_ids,
+                &mut missed_osm_node_ids,
                 &mut total_updated,
                 &mut total_tombstoned,
             )
@@ -246,7 +246,7 @@ pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<us
     flush_baidu_chunk(
         pool,
         &mut updates,
-        &mut missed_ids,
+        &mut missed_osm_node_ids,
         &mut total_updated,
         &mut total_tombstoned,
     )
@@ -269,22 +269,23 @@ pub async fn import_baidu_panoid_data(pool: &PgPool, refresh: bool) -> Result<us
 async fn flush_baidu_chunk(
     pool: &PgPool,
     updates: &mut Vec<(i64, crate::domain::china::BaiduPanorama)>,
-    missed_ids: &mut Vec<i64>,
+    missed_osm_node_ids: &mut Vec<i64>,
     total_updated: &mut usize,
     total_tombstoned: &mut usize,
 ) -> Result<()> {
-    if updates.is_empty() && missed_ids.is_empty() {
+    if updates.is_empty() && missed_osm_node_ids.is_empty() {
         return Ok(());
     }
 
     let updated = crate::db::baidu_repository::bulk_update_baidu(pool, updates).await?;
-    let tombstoned = crate::db::baidu_repository::bulk_mark_queried(pool, missed_ids).await?;
+    let tombstoned =
+        crate::db::baidu_repository::bulk_mark_queried(pool, missed_osm_node_ids).await?;
 
     *total_updated += updated;
     *total_tombstoned += tombstoned;
 
     updates.clear();
-    missed_ids.clear();
+    missed_osm_node_ids.clear();
 
     Ok(())
 }

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -74,6 +74,12 @@ async fn setup_test_db() -> PgPool {
         .await
         .expect("Failed to truncate table");
 
+    // baidu_panoramas は y_junctions に FK を持たないため CASCADE で消えない
+    sqlx::query("TRUNCATE TABLE baidu_panoramas")
+        .execute(&pool)
+        .await
+        .expect("Failed to truncate baidu_panoramas");
+
     pool
 }
 
@@ -230,6 +236,13 @@ impl TestJunctionData {
         self.min_angle_index = Some(min_idx);
         self
     }
+}
+
+// テストヘルパー: テストデータ挿入＋(id, osm_node_id) を返す
+async fn insert_test_junction_with_ids(pool: &PgPool, data: TestJunctionData) -> (i64, i64) {
+    let osm_node_id = data.osm_node_id;
+    let id = insert_test_junction(pool, data).await;
+    (id, osm_node_id)
 }
 
 // テストヘルパー: テストデータ挿入
@@ -1093,9 +1106,9 @@ const SHANGHAI_LON: f64 = 121.4737;
 
 #[tokio::test]
 #[serial]
-async fn test_baidu_find_by_junction_ids_empty_input() {
+async fn test_baidu_find_by_osm_node_ids_empty_input() {
     let pool = setup_test_db().await;
-    let result = baidu_repository::find_by_junction_ids(&pool, &[])
+    let result = baidu_repository::find_by_osm_node_ids(&pool, &[])
         .await
         .expect("query failed");
     assert!(result.is_empty());
@@ -1103,15 +1116,15 @@ async fn test_baidu_find_by_junction_ids_empty_input() {
 
 #[tokio::test]
 #[serial]
-async fn test_baidu_find_by_junction_ids_skips_rows_without_panoid() {
+async fn test_baidu_find_by_osm_node_ids_skips_rows_without_panoid() {
     let pool = setup_test_db().await;
-    let id = insert_test_junction(
+    let (_, osm_node_id) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
     .await;
 
-    let result = baidu_repository::find_by_junction_ids(&pool, &[id])
+    let result = baidu_repository::find_by_osm_node_ids(&pool, &[osm_node_id])
         .await
         .expect("query failed");
     assert!(
@@ -1124,7 +1137,7 @@ async fn test_baidu_find_by_junction_ids_skips_rows_without_panoid() {
 #[serial]
 async fn test_baidu_bulk_update_and_find_roundtrip() {
     let pool = setup_test_db().await;
-    let id = insert_test_junction(
+    let (_, osm_node_id) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
@@ -1135,16 +1148,18 @@ async fn test_baidu_bulk_update_and_find_roundtrip() {
         pano_mc_x: 13_523_770.0,
         pano_mc_y: 3_640_859.0,
     };
-    let updated = baidu_repository::bulk_update_baidu(&pool, &[(id, pano.clone())])
+    let updated = baidu_repository::bulk_update_baidu(&pool, &[(osm_node_id, pano.clone())])
         .await
         .expect("bulk update failed");
     assert_eq!(updated, 1);
 
-    let result = baidu_repository::find_by_junction_ids(&pool, &[id])
+    let result = baidu_repository::find_by_osm_node_ids(&pool, &[osm_node_id])
         .await
         .expect("query failed");
     assert_eq!(result.len(), 1);
-    let got = result.get(&id).expect("id missing from map");
+    let got = result
+        .get(&osm_node_id)
+        .expect("osm_node_id missing from map");
     assert_eq!(got, &pano);
 }
 
@@ -1152,7 +1167,7 @@ async fn test_baidu_bulk_update_and_find_roundtrip() {
 #[serial]
 async fn test_baidu_bulk_update_overwrites_existing() {
     let pool = setup_test_db().await;
-    let id = insert_test_junction(
+    let (_, osm_node_id) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
@@ -1163,7 +1178,7 @@ async fn test_baidu_bulk_update_overwrites_existing() {
         pano_mc_x: 13_000_000.0,
         pano_mc_y: 3_600_000.0,
     };
-    baidu_repository::bulk_update_baidu(&pool, &[(id, first)])
+    baidu_repository::bulk_update_baidu(&pool, &[(osm_node_id, first)])
         .await
         .unwrap();
 
@@ -1172,14 +1187,14 @@ async fn test_baidu_bulk_update_overwrites_existing() {
         pano_mc_x: 13_523_770.0,
         pano_mc_y: 3_640_859.0,
     };
-    baidu_repository::bulk_update_baidu(&pool, &[(id, second.clone())])
+    baidu_repository::bulk_update_baidu(&pool, &[(osm_node_id, second.clone())])
         .await
         .unwrap();
 
-    let result = baidu_repository::find_by_junction_ids(&pool, &[id])
+    let result = baidu_repository::find_by_osm_node_ids(&pool, &[osm_node_id])
         .await
         .unwrap();
-    assert_eq!(result.get(&id), Some(&second));
+    assert_eq!(result.get(&osm_node_id), Some(&second));
 }
 
 #[tokio::test]
@@ -1196,7 +1211,7 @@ async fn test_baidu_bulk_update_empty_is_noop() {
 #[serial]
 async fn test_baidu_find_all_for_refresh_returns_every_row() {
     let pool = setup_test_db().await;
-    let id_with = insert_test_junction(
+    let (id_with, osm_with) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
@@ -1209,7 +1224,7 @@ async fn test_baidu_find_all_for_refresh_returns_every_row() {
     baidu_repository::bulk_update_baidu(
         &pool,
         &[(
-            id_with,
+            osm_with,
             BaiduPanorama {
                 panoid: "EXISTING".to_string(),
                 pano_mc_x: 13_523_770.0,
@@ -1232,7 +1247,7 @@ async fn test_baidu_find_all_for_refresh_returns_every_row() {
 #[serial]
 async fn test_baidu_find_without_panoid_returns_only_null_rows() {
     let pool = setup_test_db().await;
-    let id_with = insert_test_junction(
+    let (id_with, osm_with) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
@@ -1246,7 +1261,7 @@ async fn test_baidu_find_without_panoid_returns_only_null_rows() {
     baidu_repository::bulk_update_baidu(
         &pool,
         &[(
-            id_with,
+            osm_with,
             BaiduPanorama {
                 panoid: "HAS_PANOID".to_string(),
                 pano_mc_x: 13_523_770.0,
@@ -1274,13 +1289,13 @@ async fn test_baidu_find_without_panoid_skips_tombstoned_rows() {
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
     .await;
-    let id_tombstoned = insert_test_junction(
+    let (id_tombstoned, osm_tombstoned) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::normal_type().with_location(SHANGHAI_LAT, SHANGHAI_LON + 0.001),
     )
     .await;
 
-    let marked = baidu_repository::bulk_mark_queried(&pool, &[id_tombstoned])
+    let marked = baidu_repository::bulk_mark_queried(&pool, &[osm_tombstoned])
         .await
         .expect("bulk mark failed");
     assert_eq!(marked, 1);
@@ -1310,12 +1325,12 @@ async fn test_baidu_bulk_mark_queried_empty_is_noop() {
 #[serial]
 async fn test_baidu_bulk_mark_queried_skips_rows_with_panoid() {
     let pool = setup_test_db().await;
-    let id_with_panoid = insert_test_junction(
+    let (_, osm_with_panoid) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
     .await;
-    let id_without = insert_test_junction(
+    let (_, osm_without) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::normal_type().with_location(SHANGHAI_LAT, SHANGHAI_LON + 0.001),
     )
@@ -1324,7 +1339,7 @@ async fn test_baidu_bulk_mark_queried_skips_rows_with_panoid() {
     baidu_repository::bulk_update_baidu(
         &pool,
         &[(
-            id_with_panoid,
+            osm_with_panoid,
             BaiduPanorama {
                 panoid: "EXISTING".to_string(),
                 pano_mc_x: 13_523_770.0,
@@ -1336,20 +1351,20 @@ async fn test_baidu_bulk_mark_queried_skips_rows_with_panoid() {
     .unwrap();
 
     let original_queried_at: chrono::DateTime<chrono::Utc> =
-        sqlx::query_scalar("SELECT baidu_queried_at FROM y_junctions WHERE id = $1")
-            .bind(id_with_panoid)
+        sqlx::query_scalar("SELECT queried_at FROM baidu_panoramas WHERE osm_node_id = $1")
+            .bind(osm_with_panoid)
             .fetch_one(&pool)
             .await
             .expect("query failed");
 
-    let marked = baidu_repository::bulk_mark_queried(&pool, &[id_with_panoid, id_without])
+    let marked = baidu_repository::bulk_mark_queried(&pool, &[osm_with_panoid, osm_without])
         .await
         .expect("bulk mark failed");
     assert_eq!(marked, 1, "only the panoid-less row should be tombstoned");
 
     let after_queried_at: chrono::DateTime<chrono::Utc> =
-        sqlx::query_scalar("SELECT baidu_queried_at FROM y_junctions WHERE id = $1")
-            .bind(id_with_panoid)
+        sqlx::query_scalar("SELECT queried_at FROM baidu_panoramas WHERE osm_node_id = $1")
+            .bind(osm_with_panoid)
             .fetch_one(&pool)
             .await
             .expect("query failed");
@@ -1363,7 +1378,7 @@ async fn test_baidu_bulk_mark_queried_skips_rows_with_panoid() {
 #[serial]
 async fn test_baidu_bulk_update_stamps_queried_at() {
     let pool = setup_test_db().await;
-    let id = insert_test_junction(
+    let (_, osm_node_id) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
@@ -1372,7 +1387,7 @@ async fn test_baidu_bulk_update_stamps_queried_at() {
     baidu_repository::bulk_update_baidu(
         &pool,
         &[(
-            id,
+            osm_node_id,
             BaiduPanorama {
                 panoid: "STAMPED".to_string(),
                 pano_mc_x: 13_523_770.0,
@@ -1384,14 +1399,14 @@ async fn test_baidu_bulk_update_stamps_queried_at() {
     .unwrap();
 
     let queried_at: Option<chrono::DateTime<chrono::Utc>> =
-        sqlx::query_scalar("SELECT baidu_queried_at FROM y_junctions WHERE id = $1")
-            .bind(id)
+        sqlx::query_scalar("SELECT queried_at FROM baidu_panoramas WHERE osm_node_id = $1")
+            .bind(osm_node_id)
             .fetch_one(&pool)
             .await
             .expect("query failed");
     assert!(
         queried_at.is_some(),
-        "baidu_queried_at must be set after successful bulk_update_baidu"
+        "queried_at must be set after successful bulk_update_baidu"
     );
 }
 
@@ -1401,7 +1416,7 @@ async fn test_baidu_bulk_update_stamps_queried_at() {
 #[serial]
 async fn test_china_junction_with_baidu_returns_baidu_url() {
     let pool = setup_test_db().await;
-    let id = insert_test_junction(
+    let (id, osm_node_id) = insert_test_junction_with_ids(
         &pool,
         TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
     )
@@ -1409,7 +1424,7 @@ async fn test_china_junction_with_baidu_returns_baidu_url() {
     baidu_repository::bulk_update_baidu(
         &pool,
         &[(
-            id,
+            osm_node_id,
             BaiduPanorama {
                 panoid: "SHANGHAI_TEST".to_string(),
                 pano_mc_x: 13_523_770.0,


### PR DESCRIPTION
## Summary

アプリケーションコードを `y_junctions.baidu_*` から `baidu_panoramas` テーブル参照に切り替え。旧カラムは orphan として残し、(3/3) #224 で drop。

#219 (Baidu panoid を別テーブルに分離) を 3 PR + 1 ops に分けたうちの 2 番目。

```
1.    #226 merged: テーブル追加 (baidu_panoramas)
2.    operator が backfill SQL を prod で実行済 (3,021 件投入)
3. ⬅︎ このPR: アプリケーションを baidu_panoramas 参照に切り替え
4.    #224: 旧カラム drop (別 PR)
```

## 変更内容

- `backend/src/db/baidu_repository.rs`: 5 関数を osm_node_id ベースに書き換え
  - `find_by_junction_ids` → `find_by_osm_node_ids` (rename)
  - `find_without_baidu_panoid`, `find_all_for_refresh`, `bulk_update_baidu`, `bulk_mark_queried`
- `backend/src/importer/mod.rs`: buffer を `(osm_node_id, BaiduPanorama)` に
- `backend/src/api/streetview_enricher.rs`: `j.osm_node_id` 引きに
- `backend/tests/api_tests.rs`: `insert_test_junction_with_ids` helper 追加、baidu テストを osm_node_id ベースに、`setup_test_db` に `TRUNCATE baidu_panoramas` 追加
- skill 更新（旧カラムも残しつつ新テーブル経路を追加）:
  - `.claude/commands/sync-from-prod.md`
  - `.claude/commands/deploy-data.md`

## 既知事項

- prod の backfill 済 3,021 件は migration 008 以前に取得された success rows で、`queried_at` の本来の取得時刻が不明。backfill では `COALESCE(baidu_queried_at, NOW())` で代用したため、これらの行の `queried_at` は「backfill 実行時刻」を示している。現状 queried_at の値はロジックに使われないため動作影響なし。将来時間ベース機能を足す時は注意

## Test plan

- [x] `cargo test` 47/47 通過
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過
- [ ] CI (backend-ci) green
- [ ] merge & release 後、上海 bbox を再 import しても Baidu API が呼ばれないこと（既存 baidu_panoramas 3,021 行の osm_node_id がそのまま使われる）

Closes #225