### PR TITLE
feat: y_junctions から旧 baidu カラム drop (#224 3/3)

### DIFF
--- a/.claude/commands/deploy-data.md
+++ b/.claude/commands/deploy-data.md
@@ -61,7 +61,6 @@ docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
       way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel,
       way_3_bridge, way_3_tunnel,
       way_1_highway_type, way_2_highway_type, way_3_highway_type,
-      baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y,
       created_at
     FROM y_junctions
     WHERE lon BETWEEN $MIN_LON AND $MAX_LON
@@ -119,7 +118,6 @@ cockroach sql --url "$PROD_CRDB_URI" -e "IMPORT INTO y_junctions (
   way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel,
   way_3_bridge, way_3_tunnel,
   way_1_highway_type, way_2_highway_type, way_3_highway_type,
-  baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y,
   created_at
 ) CSV DATA ('userfile:///junctions.csv');"
 

--- a/.claude/commands/sync-from-prod.md
+++ b/.claude/commands/sync-from-prod.md
@@ -34,7 +34,6 @@ docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
       way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel,
       way_3_bridge, way_3_tunnel,
       way_1_highway_type, way_2_highway_type, way_3_highway_type,
-      baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y,
       created_at
     FROM y_junctions
   ) TO '/data/prod_export.csv' WITH CSV HEADER"
@@ -52,7 +51,7 @@ docker cp ~/y-junctions-data/prod_export_baidu_panoramas.csv y-junctions-cockroa
 
 # IMPORT INTO でローカルCockroachDBにインポート（nodelocal://1/ はコンテナのexternディレクトリを参照）
 cockroach sql --url "postgresql://root@localhost:26257/y_junction?sslmode=disable" \
-  --execute "IMPORT INTO y_junctions (osm_node_id, location, angle_1, angle_2, angle_3, bearings, elevation, neighbor_elevation_1, neighbor_elevation_2, neighbor_elevation_3, elevation_diff_1, elevation_diff_2, elevation_diff_3, min_angle_index, min_elevation_diff, max_elevation_diff, way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel, way_3_bridge, way_3_tunnel, way_1_highway_type, way_2_highway_type, way_3_highway_type, baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y, created_at) CSV DATA ('nodelocal://1/prod_export.csv') WITH skip = '1';"
+  --execute "IMPORT INTO y_junctions (osm_node_id, location, angle_1, angle_2, angle_3, bearings, elevation, neighbor_elevation_1, neighbor_elevation_2, neighbor_elevation_3, elevation_diff_1, elevation_diff_2, elevation_diff_3, min_angle_index, min_elevation_diff, max_elevation_diff, way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel, way_3_bridge, way_3_tunnel, way_1_highway_type, way_2_highway_type, way_3_highway_type, created_at) CSV DATA ('nodelocal://1/prod_export.csv') WITH skip = '1';"
 
 cockroach sql --url "postgresql://root@localhost:26257/y_junction?sslmode=disable" \
   --execute "IMPORT INTO baidu_panoramas (osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at) CSV DATA ('nodelocal://1/prod_export_baidu_panoramas.csv') WITH skip = '1';"

--- a/backend/migrations/010_drop_legacy_baidu_columns.sql
+++ b/backend/migrations/010_drop_legacy_baidu_columns.sql
@@ -1,0 +1,12 @@
+-- Drop the legacy Baidu panorama columns from y_junctions. By this point all
+-- application code reads/writes baidu_panoramas (added in 009 and switched in
+-- the (2/3) PR), and the prod data has been backfilled to the new table, so
+-- these columns are pure orphans.
+--
+-- This is the CONTRACT half of the expand-and-contract pair started by
+-- migration 009.
+ALTER TABLE y_junctions
+  DROP COLUMN baidu_panoid,
+  DROP COLUMN baidu_pano_mc_x,
+  DROP COLUMN baidu_pano_mc_y,
+  DROP COLUMN baidu_queried_at;


### PR DESCRIPTION
## Summary

`y_junctions` から baidu 関連 4 カラムを drop し、skill からも旧カラム参照を削除。expand-and-contract の contract phase。

#219 (Baidu panoid を別テーブルに分離) を 3 PR + 1 ops に分けたうちの 3 番目（最後）。

```
1.    #226 merged: テーブル追加 (baidu_panoramas)
2.    operator が backfill SQL を prod で実行済 (3,021 件投入)
3.    #227 (#225): アプリケーションを baidu_panoramas 参照に切り替え
4. ⬅︎ このPR: 旧カラム drop
```

**注意**: stacked PR。base = `internal/225-switch-app-to-baidu-panoramas`。#227 が main に merge されたら GitHub が自動的に base を main に rebase する。**#227 が merge & release されてから merge すること**。

## 変更内容

- `backend/migrations/010_drop_legacy_baidu_columns.sql`: y_junctions から `baidu_panoid` / `baidu_pano_mc_x` / `baidu_pano_mc_y` / `baidu_queried_at` を drop
- `.claude/commands/sync-from-prod.md`: SELECT / IMPORT INTO の column list から旧カラム参照を削除
- `.claude/commands/deploy-data.md`: 同上

## リスク / 確認事項

- CockroachDB で `ALTER TABLE ... DROP COLUMN` を 4 カラムまとめて 1 文で書けることをローカルテスト DB で確認済（test result: ok. 47 passed）
- merge 前に prod の `baidu_panoramas` 件数を最終確認:
  ```sql
  SELECT COUNT(*) FROM baidu_panoramas WHERE panoid IS NOT NULL;
  -- 期待: 3,021 以上
  ```

## Test plan

- [x] `cargo test` 47/47 通過
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過
- [ ] CI (backend-ci) green
- [ ] (3/3) merge: #227 が release 済 + アプリが新スキーマで安定稼働を確認してから

Closes #224