### PR TITLE
chore: y_junctions から旧 baidu カラム drop (#224 3/3)

### DIFF
--- a/.claude/commands/deploy-data.md
+++ b/.claude/commands/deploy-data.md
@@ -61,7 +61,6 @@ docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
       way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel,
       way_3_bridge, way_3_tunnel,
       way_1_highway_type, way_2_highway_type, way_3_highway_type,
-      baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y,
       created_at
     FROM y_junctions
     WHERE lon BETWEEN $MIN_LON AND $MAX_LON
@@ -119,7 +118,6 @@ cockroach sql --url "$PROD_CRDB_URI" -e "IMPORT INTO y_junctions (
   way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel,
   way_3_bridge, way_3_tunnel,
   way_1_highway_type, way_2_highway_type, way_3_highway_type,
-  baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y,
   created_at
 ) CSV DATA ('userfile:///junctions.csv');"
 

--- a/.claude/commands/sync-from-prod.md
+++ b/.claude/commands/sync-from-prod.md
@@ -34,7 +34,6 @@ docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
       way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel,
       way_3_bridge, way_3_tunnel,
       way_1_highway_type, way_2_highway_type, way_3_highway_type,
-      baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y,
       created_at
     FROM y_junctions
   ) TO '/data/prod_export.csv' WITH CSV HEADER"
@@ -52,7 +51,7 @@ docker cp ~/y-junctions-data/prod_export_baidu_panoramas.csv y-junctions-cockroa
 
 # IMPORT INTO でローカルCockroachDBにインポート（nodelocal://1/ はコンテナのexternディレクトリを参照）
 cockroach sql --url "postgresql://root@localhost:26257/y_junction?sslmode=disable" \
-  --execute "IMPORT INTO y_junctions (osm_node_id, location, angle_1, angle_2, angle_3, bearings, elevation, neighbor_elevation_1, neighbor_elevation_2, neighbor_elevation_3, elevation_diff_1, elevation_diff_2, elevation_diff_3, min_angle_index, min_elevation_diff, max_elevation_diff, way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel, way_3_bridge, way_3_tunnel, way_1_highway_type, way_2_highway_type, way_3_highway_type, baidu_panoid, baidu_pano_mc_x, baidu_pano_mc_y, created_at) CSV DATA ('nodelocal://1/prod_export.csv') WITH skip = '1';"
+  --execute "IMPORT INTO y_junctions (osm_node_id, location, angle_1, angle_2, angle_3, bearings, elevation, neighbor_elevation_1, neighbor_elevation_2, neighbor_elevation_3, elevation_diff_1, elevation_diff_2, elevation_diff_3, min_angle_index, min_elevation_diff, max_elevation_diff, way_1_bridge, way_1_tunnel, way_2_bridge, way_2_tunnel, way_3_bridge, way_3_tunnel, way_1_highway_type, way_2_highway_type, way_3_highway_type, created_at) CSV DATA ('nodelocal://1/prod_export.csv') WITH skip = '1';"
 
 cockroach sql --url "postgresql://root@localhost:26257/y_junction?sslmode=disable" \
   --execute "IMPORT INTO baidu_panoramas (osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at) CSV DATA ('nodelocal://1/prod_export_baidu_panoramas.csv') WITH skip = '1';"

--- a/backend/migrations/010_drop_legacy_baidu_columns.sql
+++ b/backend/migrations/010_drop_legacy_baidu_columns.sql
@@ -1,0 +1,9 @@
+-- CONTRACT half of the expand-and-contract pair started in 009. Now that
+-- application code reads/writes baidu_panoramas exclusively (PR #227) and the
+-- prod backfill has populated the new table, the legacy columns on y_junctions
+-- are dead weight and can be removed.
+ALTER TABLE y_junctions
+  DROP COLUMN baidu_panoid,
+  DROP COLUMN baidu_pano_mc_x,
+  DROP COLUMN baidu_pano_mc_y,
+  DROP COLUMN baidu_queried_at;


### PR DESCRIPTION
## Summary

- #219 expand-and-contract の **contract** 段階。アプリ層は PR #227 で `baidu_panoramas` 参照に切替済
- `backend/migrations/010_drop_legacy_baidu_columns.sql` で `baidu_panoid` / `baidu_pano_mc_x` / `baidu_pano_mc_y` / `baidu_queried_at` の 4 カラムを `y_junctions` から DROP
- skill (`sync-from-prod`, `deploy-data`) からも CSV 列指定を削除

## Prod backfill 確認結果

migration 適用前に prod の状態を確認済み:

| | y_junctions | baidu_panoramas |
|---|---:|---:|
| panoid あり | 3021 | 3021 |
| tombstone (queried, no panoid) | 0 | 0 |
| unqueried | 958006 | — |

**3021 件完全一致 / tombstone 両側 0** → backfill 漏れなし。drop してもデータ消失なし。

## Test plan

- [x] `cargo test --manifest-path backend/Cargo.toml` (125 tests pass)
- [x] `cargo fmt --manifest-path backend/Cargo.toml --check`
- [x] `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- -D warnings`
- [ ] CI green
- [ ] release 後、prod の `y_junctions` から 4 カラムが消えていることを確認

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy panorama data columns from the database during schema cleanup.
  * Updated deployment and data synchronization procedures to align with the simplified database structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->