### PR TITLE
Cloud Run Jobs walking skeleton: download-osm → extract-3way → load-to-cockroach

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3778,12 +3778,14 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sqlx",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +109,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -352,6 +377,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +487,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -593,6 +654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +672,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -652,6 +734,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,8 +762,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -779,6 +874,37 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
 
 [[package]]
 name = "hash32"
@@ -916,6 +1042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +1057,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -946,6 +1079,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1167,6 +1301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1327,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1359,6 +1508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1564,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.1",
+ "reqwest",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1612,21 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "osmpbf"
@@ -1458,6 +1670,45 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "snap",
+ "thrift",
+ "twox-hash",
+]
+
+[[package]]
+name = "parquet_derive"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdf56ed27c8f06706c9f19c9ea63eb27ea5c4819783c44a4c72ccb9be6c2c60"
+dependencies = [
+ "parquet",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1599,6 +1850,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1829,6 +2090,8 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1841,6 +2104,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1848,12 +2112,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -1965,6 +2231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,12 +2276,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2019,10 +2315,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -2211,6 +2536,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -2570,6 +2901,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2990,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -2754,6 +3118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +3209,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2960,6 +3340,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,6 +3422,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3354,15 +3756,20 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-extra",
+ "bytes",
  "chrono",
  "clap",
  "dashmap",
  "dotenvy",
+ "futures",
  "geo",
  "glob",
  "http-body-util",
  "hyper",
+ "object_store",
  "osmpbf",
+ "parquet",
+ "parquet_derive",
  "rand 0.10.1",
  "rayon",
  "reqwest",
@@ -3372,6 +3779,7 @@ dependencies = [
  "serial_test",
  "sqlx",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,10 @@ path = "src/bin/import_elevation.rs"
 name = "import-baidu-panoid"
 path = "src/bin/import_baidu_panoid.rs"
 
+[[bin]]
+name = "pipeline-download-osm"
+path = "src/bin/pipeline_download_osm.rs"
+
 [dependencies]
 anyhow = "1"
 axum = "0.8"
@@ -47,9 +51,11 @@ parquet_derive = "58"
 bytes = "1"
 tokio-util = { version = "0.7", features = ["io"] }
 futures = "0.3"
+url = "2"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 hyper = "1"
 serial_test = "3"
+tempfile = "3"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,8 +39,14 @@ clap = { version = "4", features = ["derive"] }
 dotenvy = "0.15"
 dashmap = "6.1"
 rayon = "1.12"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"], default-features = false }
 rand = "0.10"
+object_store = { version = "0.13", features = ["gcp"] }
+parquet = { version = "58", default-features = false, features = ["snap"] }
+parquet_derive = "58"
+bytes = "1"
+tokio-util = { version = "0.7", features = ["io"] }
+futures = "0.3"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,6 +27,10 @@ path = "src/bin/pipeline_download_osm.rs"
 name = "pipeline-extract-three-way"
 path = "src/bin/pipeline_extract_three_way.rs"
 
+[[bin]]
+name = "pipeline-load-to-cockroach"
+path = "src/bin/pipeline_load_to_cockroach.rs"
+
 [dependencies]
 anyhow = "1"
 axum = "0.8"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,6 +23,10 @@ path = "src/bin/import_baidu_panoid.rs"
 name = "pipeline-download-osm"
 path = "src/bin/pipeline_download_osm.rs"
 
+[[bin]]
+name = "pipeline-extract-three-way"
+path = "src/bin/pipeline_extract_three_way.rs"
+
 [dependencies]
 anyhow = "1"
 axum = "0.8"
@@ -52,10 +56,10 @@ bytes = "1"
 tokio-util = { version = "0.7", features = ["io"] }
 futures = "0.3"
 url = "2"
+tempfile = "3"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 hyper = "1"
 serial_test = "3"
-tempfile = "3"

--- a/backend/src/bin/pipeline_download_osm.rs
+++ b/backend/src/bin/pipeline_download_osm.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use clap::Parser;
+
+use y_junction_backend::pipeline::storage::{read_uri, write_uri};
+
+#[derive(Parser, Debug)]
+#[command(name = "pipeline-download-osm")]
+#[command(about = "Download an OSM PBF and stage it in raw object storage", long_about = None)]
+struct Args {
+    /// Source URI — https://... (Geofabrik), file://..., or gs://...
+    #[arg(long)]
+    input: String,
+
+    /// Destination URI — gs://... or file://...
+    #[arg(long)]
+    output: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+    tracing::info!("download-osm: {} -> {}", args.input, args.output);
+
+    let body = read_uri(&args.input).await?;
+    tracing::info!("Read {} bytes from source", body.len());
+
+    write_uri(&args.output, body).await?;
+    tracing::info!("Upload complete");
+
+    Ok(())
+}

--- a/backend/src/bin/pipeline_extract_three_way.rs
+++ b/backend/src/bin/pipeline_extract_three_way.rs
@@ -1,0 +1,110 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use clap::Parser;
+use tempfile::NamedTempFile;
+
+use y_junction_backend::importer::parser;
+use y_junction_backend::pipeline::parquet_io::{write_parquet_bytes, JunctionParquetRecord};
+use y_junction_backend::pipeline::storage::{read_uri, write_uri};
+
+#[derive(Parser, Debug)]
+#[command(name = "pipeline-extract-three-way")]
+#[command(about = "Extract 3-way Y-junctions from a PBF and write a Parquet file", long_about = None)]
+struct Args {
+    /// PBF source URI — file://..., gs://..., or https://...
+    #[arg(long)]
+    input: String,
+
+    /// Extracted-stage output URI — gs://...-yj-extracted/... or file://...
+    #[arg(long)]
+    extracted_output: String,
+
+    /// Serving-stage output URI — gs://...-yj-serving/... or file://...
+    /// (walking skeleton: identical to extracted output, no transformation yet)
+    #[arg(long)]
+    serving_output: String,
+
+    /// Bounding box: min_lon,min_lat,max_lon,max_lat
+    #[arg(long)]
+    bbox: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+    let bbox = parse_bbox(&args.bbox)?;
+
+    tracing::info!(
+        "extract-three-way: {} -> {{extracted: {}, serving: {}}}",
+        args.input,
+        args.extracted_output,
+        args.serving_output
+    );
+
+    let local_pbf = stage_pbf_locally(&args.input).await?;
+    let pbf_path = local_pbf.path_str();
+    tracing::info!("PBF staged at {}", pbf_path);
+
+    let junctions = parser::parse_pbf_three_way(pbf_path, bbox.0, bbox.1, bbox.2, bbox.3)?;
+    tracing::info!("Extracted {} 3-way junctions", junctions.len());
+
+    let records: Vec<JunctionParquetRecord> = junctions.into_iter().map(Into::into).collect();
+    let parquet_bytes = write_parquet_bytes(&records)?;
+    tracing::info!("Encoded {} bytes of Parquet", parquet_bytes.len());
+
+    let body = Bytes::from(parquet_bytes);
+    write_uri(&args.extracted_output, body.clone()).await?;
+    write_uri(&args.serving_output, body).await?;
+    tracing::info!("Wrote extracted + serving copies");
+
+    Ok(())
+}
+
+fn parse_bbox(s: &str) -> Result<(f64, f64, f64, f64)> {
+    let parts: Vec<&str> = s.split(',').collect();
+    anyhow::ensure!(
+        parts.len() == 4,
+        "bbox must be min_lon,min_lat,max_lon,max_lat"
+    );
+    Ok((
+        parts[0].parse().context("min_lon")?,
+        parts[1].parse().context("min_lat")?,
+        parts[2].parse().context("max_lon")?,
+        parts[3].parse().context("max_lat")?,
+    ))
+}
+
+/// `osmpbf::ElementReader` requires a real `File`, so non-`file://`
+/// inputs are downloaded to tmpfs before parsing. The walking-skeleton
+/// PBFs (~120 MB) fit comfortably below Cloud Run's memory ceiling;
+/// streaming variants are deferred (issue #229).
+enum LocalPbf {
+    Existing(PathBuf),
+    Owned(NamedTempFile),
+}
+
+impl LocalPbf {
+    fn path_str(&self) -> &str {
+        match self {
+            LocalPbf::Existing(p) => p.to_str().expect("non-UTF8 PBF path"),
+            LocalPbf::Owned(t) => t.path().to_str().expect("non-UTF8 PBF path"),
+        }
+    }
+}
+
+async fn stage_pbf_locally(input: &str) -> Result<LocalPbf> {
+    if let Some(rest) = input.strip_prefix("file://") {
+        return Ok(LocalPbf::Existing(PathBuf::from(rest)));
+    }
+    let bytes = read_uri(input).await?;
+    let mut tmp = NamedTempFile::new()?;
+    use std::io::Write as _;
+    tmp.as_file_mut().write_all(&bytes)?;
+    tmp.as_file_mut().flush()?;
+    Ok(LocalPbf::Owned(tmp))
+}

--- a/backend/src/bin/pipeline_load_to_cockroach.rs
+++ b/backend/src/bin/pipeline_load_to_cockroach.rs
@@ -1,0 +1,48 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use sqlx::postgres::PgPoolOptions;
+
+use y_junction_backend::importer::detector::JunctionForInsert;
+use y_junction_backend::importer::inserter::insert_junctions;
+use y_junction_backend::pipeline::parquet_io::{read_parquet_bytes, JunctionParquetRecord};
+use y_junction_backend::pipeline::storage::read_uri;
+
+#[derive(Parser, Debug)]
+#[command(name = "pipeline-load-to-cockroach")]
+#[command(about = "Load extracted Parquet records into CockroachDB", long_about = None)]
+struct Args {
+    /// Parquet source URI — gs://...-yj-serving/... or file://...
+    #[arg(long)]
+    input: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+    tracing::info!("load-to-cockroach: {}", args.input);
+
+    let bytes = read_uri(&args.input).await?;
+    tracing::info!("Read {} bytes of Parquet", bytes.len());
+
+    let records: Vec<JunctionParquetRecord> = read_parquet_bytes(bytes)?;
+    tracing::info!("Decoded {} records", records.len());
+
+    let junctions: Vec<JunctionForInsert> = records.into_iter().map(Into::into).collect();
+
+    let database_url = std::env::var("DATABASE_URL")
+        .context("DATABASE_URL must be set in environment or .env file")?;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
+    tracing::info!("Database connection established");
+
+    insert_junctions(&pool, junctions).await?;
+    tracing::info!("Load complete");
+
+    Ok(())
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,3 +4,4 @@ pub mod domain;
 pub mod importer;
 pub mod logging;
 pub mod middleware;
+pub mod pipeline;

--- a/backend/src/pipeline/mod.rs
+++ b/backend/src/pipeline/mod.rs
@@ -1,1 +1,2 @@
 pub mod parquet_io;
+pub mod storage;

--- a/backend/src/pipeline/mod.rs
+++ b/backend/src/pipeline/mod.rs
@@ -1,0 +1,1 @@
+pub mod parquet_io;

--- a/backend/src/pipeline/parquet_io.rs
+++ b/backend/src/pipeline/parquet_io.rs
@@ -1,0 +1,152 @@
+use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};
+
+use crate::importer::detector::JunctionForInsert;
+
+/// Flat record format used between pipeline stages (extract → load).
+///
+/// Walking-skeleton scope: elevation/baidu enrichment columns are intentionally
+/// omitted because this pipeline path does not pass through enrich-elevation.
+/// `JunctionForInsert` consumers reconstruct those fields as `None`.
+///
+/// `i32` is used for angle/index fields because Parquet has no `i16` physical
+/// type. `parquet_derive::ParquetRecordReader` does not support `Option<T>`
+/// scalars in the v58 release, so all surviving columns are non-nullable.
+#[derive(Debug, Clone, ParquetRecordWriter, ParquetRecordReader)]
+pub struct JunctionParquetRecord {
+    pub osm_node_id: i64,
+    pub lat: f64,
+    pub lon: f64,
+    pub angle_1: i32,
+    pub angle_2: i32,
+    pub angle_3: i32,
+    pub bearing_1: f64,
+    pub bearing_2: f64,
+    pub bearing_3: f64,
+    pub way_1_bridge: bool,
+    pub way_1_tunnel: bool,
+    pub way_2_bridge: bool,
+    pub way_2_tunnel: bool,
+    pub way_3_bridge: bool,
+    pub way_3_tunnel: bool,
+    pub way_1_highway_type: String,
+    pub way_2_highway_type: String,
+    pub way_3_highway_type: String,
+}
+
+impl From<JunctionForInsert> for JunctionParquetRecord {
+    fn from(j: JunctionForInsert) -> Self {
+        Self {
+            osm_node_id: j.osm_node_id,
+            lat: j.lat,
+            lon: j.lon,
+            angle_1: j.angle_1 as i32,
+            angle_2: j.angle_2 as i32,
+            angle_3: j.angle_3 as i32,
+            bearing_1: j.bearings[0],
+            bearing_2: j.bearings[1],
+            bearing_3: j.bearings[2],
+            way_1_bridge: j.way_1_bridge,
+            way_1_tunnel: j.way_1_tunnel,
+            way_2_bridge: j.way_2_bridge,
+            way_2_tunnel: j.way_2_tunnel,
+            way_3_bridge: j.way_3_bridge,
+            way_3_tunnel: j.way_3_tunnel,
+            way_1_highway_type: j.way_1_highway_type,
+            way_2_highway_type: j.way_2_highway_type,
+            way_3_highway_type: j.way_3_highway_type,
+        }
+    }
+}
+
+impl From<JunctionParquetRecord> for JunctionForInsert {
+    fn from(r: JunctionParquetRecord) -> Self {
+        Self {
+            osm_node_id: r.osm_node_id,
+            lat: r.lat,
+            lon: r.lon,
+            angle_1: r.angle_1 as i16,
+            angle_2: r.angle_2 as i16,
+            angle_3: r.angle_3 as i16,
+            bearings: [r.bearing_1, r.bearing_2, r.bearing_3],
+            elevation: None,
+            neighbor_elevations: None,
+            elevation_diffs: None,
+            min_angle_index: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            way_1_bridge: r.way_1_bridge,
+            way_1_tunnel: r.way_1_tunnel,
+            way_2_bridge: r.way_2_bridge,
+            way_2_tunnel: r.way_2_tunnel,
+            way_3_bridge: r.way_3_bridge,
+            way_3_tunnel: r.way_3_tunnel,
+            way_1_highway_type: r.way_1_highway_type,
+            way_2_highway_type: r.way_2_highway_type,
+            way_3_highway_type: r.way_3_highway_type,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> JunctionForInsert {
+        JunctionForInsert {
+            osm_node_id: 42,
+            lat: 34.5,
+            lon: 134.1,
+            angle_1: 35,
+            angle_2: 145,
+            angle_3: 180,
+            bearings: [10.0, 130.0, 250.0],
+            elevation: None,
+            neighbor_elevations: None,
+            elevation_diffs: None,
+            min_angle_index: None,
+            min_elevation_diff: None,
+            max_elevation_diff: None,
+            way_1_bridge: false,
+            way_1_tunnel: true,
+            way_2_bridge: true,
+            way_2_tunnel: false,
+            way_3_bridge: false,
+            way_3_tunnel: false,
+            way_1_highway_type: "primary".into(),
+            way_2_highway_type: "secondary".into(),
+            way_3_highway_type: "residential".into(),
+        }
+    }
+
+    #[test]
+    fn roundtrip_preserves_core_fields() {
+        let original = sample();
+        let record: JunctionParquetRecord = original.clone().into();
+        let restored: JunctionForInsert = record.into();
+
+        assert_eq!(restored.osm_node_id, original.osm_node_id);
+        assert_eq!(restored.lat, original.lat);
+        assert_eq!(restored.lon, original.lon);
+        assert_eq!(restored.angle_1, original.angle_1);
+        assert_eq!(restored.angle_2, original.angle_2);
+        assert_eq!(restored.angle_3, original.angle_3);
+        assert_eq!(restored.bearings, original.bearings);
+        assert_eq!(restored.way_1_bridge, original.way_1_bridge);
+        assert_eq!(restored.way_2_tunnel, original.way_2_tunnel);
+        assert_eq!(restored.way_1_highway_type, original.way_1_highway_type);
+        assert_eq!(restored.way_3_highway_type, original.way_3_highway_type);
+    }
+
+    #[test]
+    fn extract_drops_enrichment_fields() {
+        let record: JunctionParquetRecord = sample().into();
+        let restored: JunctionForInsert = record.into();
+
+        assert!(restored.elevation.is_none());
+        assert!(restored.neighbor_elevations.is_none());
+        assert!(restored.elevation_diffs.is_none());
+        assert!(restored.min_angle_index.is_none());
+        assert!(restored.min_elevation_diff.is_none());
+        assert!(restored.max_elevation_diff.is_none());
+    }
+}

--- a/backend/src/pipeline/parquet_io.rs
+++ b/backend/src/pipeline/parquet_io.rs
@@ -1,3 +1,13 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use bytes::Bytes;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use parquet::file::reader::FileReader;
+use parquet::file::reader::SerializedFileReader;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::record::{RecordReader, RecordWriter};
 use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};
 
 use crate::importer::detector::JunctionForInsert;
@@ -87,6 +97,41 @@ impl From<JunctionParquetRecord> for JunctionForInsert {
     }
 }
 
+/// Serialize a slice of records as a single-row-group Snappy-compressed
+/// Parquet file in memory.
+pub fn write_parquet_bytes(records: &[JunctionParquetRecord]) -> Result<Vec<u8>> {
+    let schema = records.schema()?;
+    let props = Arc::new(
+        WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build(),
+    );
+
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut writer = SerializedFileWriter::new(&mut buffer, schema, props)?;
+    let mut row_group = writer.next_row_group()?;
+    records.write_to_row_group(&mut row_group)?;
+    row_group.close()?;
+    writer.close()?;
+
+    Ok(buffer)
+}
+
+/// Deserialize a Parquet file (any number of row groups) from an in-memory buffer.
+pub fn read_parquet_bytes(bytes: Bytes) -> Result<Vec<JunctionParquetRecord>> {
+    let reader = SerializedFileReader::new(bytes)?;
+    let metadata = reader.metadata();
+    let mut records: Vec<JunctionParquetRecord> = Vec::new();
+
+    for i in 0..metadata.num_row_groups() {
+        let num_rows = metadata.row_group(i).num_rows() as usize;
+        let mut row_group_reader = reader.get_row_group(i)?;
+        records.read_from_row_group(&mut *row_group_reader, num_rows)?;
+    }
+
+    Ok(records)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,5 +193,29 @@ mod tests {
         assert!(restored.min_angle_index.is_none());
         assert!(restored.min_elevation_diff.is_none());
         assert!(restored.max_elevation_diff.is_none());
+    }
+
+    #[test]
+    fn parquet_roundtrip() {
+        let originals: Vec<JunctionParquetRecord> = (0..10)
+            .map(|i| {
+                let mut j = sample();
+                j.osm_node_id = i;
+                j.into()
+            })
+            .collect();
+
+        let bytes = write_parquet_bytes(&originals).unwrap();
+        assert!(!bytes.is_empty());
+
+        let restored = read_parquet_bytes(Bytes::from(bytes)).unwrap();
+        assert_eq!(restored.len(), originals.len());
+        for (a, b) in originals.iter().zip(restored.iter()) {
+            assert_eq!(a.osm_node_id, b.osm_node_id);
+            assert_eq!(a.angle_1, b.angle_1);
+            assert_eq!(a.bearing_1, b.bearing_1);
+            assert_eq!(a.way_1_highway_type, b.way_1_highway_type);
+            assert_eq!(a.way_1_bridge, b.way_1_bridge);
+        }
     }
 }

--- a/backend/src/pipeline/storage.rs
+++ b/backend/src/pipeline/storage.rs
@@ -1,0 +1,77 @@
+//! URI-keyed I/O helpers shared by pipeline binaries.
+//!
+//! Supported schemes:
+//! - `https://` / `http://` — remote download via reqwest (read only)
+//! - `gs://bucket/path` — Google Cloud Storage via object_store
+//! - `file:///abs/path` — local filesystem via object_store
+//!
+//! `gs://` requires Application Default Credentials at runtime
+//! (`gcloud auth application-default login` locally, metadata server in
+//! Cloud Run).
+
+use anyhow::{anyhow, Context, Result};
+use bytes::Bytes;
+use object_store::ObjectStoreExt;
+use url::Url;
+
+/// Read the contents of a URI fully into memory.
+///
+/// Used by walking-skeleton binaries where input artifacts are small
+/// enough (≤ a few hundred MB) to fit comfortably in Cloud Run memory.
+/// Streaming variants are intentionally deferred; see issue #229.
+pub async fn read_uri(uri: &str) -> Result<Bytes> {
+    if uri.starts_with("http://") || uri.starts_with("https://") {
+        let response = reqwest::get(uri)
+            .await
+            .with_context(|| format!("HTTP GET failed: {uri}"))?
+            .error_for_status()?;
+        Ok(response.bytes().await?)
+    } else {
+        let url = Url::parse(uri).with_context(|| format!("invalid URI: {uri}"))?;
+        let (store, path) = object_store::parse_url(&url)?;
+        let result = store.get(&path).await?;
+        Ok(result.bytes().await?)
+    }
+}
+
+/// Write a byte buffer to a URI.
+///
+/// For `file://` outputs, parent directories are created automatically
+/// because `object_store::local::LocalFileSystem::put` does not create
+/// parents on its own.
+pub async fn write_uri(uri: &str, body: Bytes) -> Result<()> {
+    let url = Url::parse(uri).with_context(|| format!("invalid URI: {uri}"))?;
+
+    if url.scheme() == "file" {
+        let path = url
+            .to_file_path()
+            .map_err(|_| anyhow!("invalid file URL: {uri}"))?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("failed to create parent dir for {uri}"))?;
+        }
+    }
+
+    let (store, path) = object_store::parse_url(&url)?;
+    store.put(&path, body.into()).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn roundtrip_local_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("nested/dir/payload.bin");
+        let uri = format!("file://{}", target.display());
+
+        let body = Bytes::from_static(b"hello pipeline");
+        write_uri(&uri, body.clone()).await.unwrap();
+
+        let read = read_uri(&uri).await.unwrap();
+        assert_eq!(read, body);
+    }
+}

--- a/doc/walking-skeleton-cloud-run-jobs.md
+++ b/doc/walking-skeleton-cloud-run-jobs.md
@@ -50,7 +50,7 @@ issue #229 の宣言通り **1 PR にまとめ、分割しない**。
 
 ### B. Docker / Build
 
-- `pipeline/Dockerfile` — マルチステージ、3 バイナリを単一イメージに同梱、entrypoint を引数で切替
+- `pipeline/Dockerfile` — マルチステージ、3 バイナリを単一イメージに同梱。Dockerfile は placeholder `CMD` のみを持ち、各 Cloud Run Job が `terraform/pipeline.tf` の `command` フィールドで実行バイナリを切り替える
 - `pipeline/cloudbuild.yaml` — `asia-northeast1-docker.pkg.dev/y-junctions-prod/y-junctions/pipeline:latest` に push（既存 Artifact Registry リポジトリ共用、`pipeline:` プレフィックス）
 
 ### C. Terraform `terraform/pipeline.tf`（既存ファイル無変更）
@@ -94,7 +94,7 @@ issue #229 の宣言通り **1 PR にまとめ、分割しない**。
 - **PBF の GCS ストリーム化** — issue #229 既に却下（クレート改造 or 自前 `Read` 実装が要り、walking skeleton の趣旨から外れる。tmpfs 一時 DL で十分）
 - **prep PR で抽出/ロード分離リファクタを先行** — issue #229 既に却下（`parser` / `inserter` は既に分離済み）
 - **中間フォーマットに JSON Lines / Arrow IPC を採用** — issue #229 既に却下（Parquet が事実上の標準、DuckDB / BigQuery 直クエリも将来効く）
-- **3 バイナリを別イメージ化** — Cloud Build 時間倍増・Terraform も冗長。1 イメージ + entrypoint 切替で十分
+- **3 バイナリを別イメージ化** — Cloud Build 時間倍増・Terraform も冗長。1 イメージ + Cloud Run Job 側の `command` 切替で十分
 - **`yj-enriched` バケット先行作成** — 後続 sub-issue で要件が固まってから
 
 ## リスク / 未確認事項

--- a/doc/walking-skeleton-cloud-run-jobs.md
+++ b/doc/walking-skeleton-cloud-run-jobs.md
@@ -1,0 +1,108 @@
+# 設計: Cloud Run Jobs walking skeleton（issue #229）
+
+親 issue: #220 / sub-issue: #229
+
+## 課題の要約
+
+issue #220 の 7 ジョブ構成（GCS 4 バケット + Cloud Run Jobs + Workflows + Eventarc）に進む前に、**最小縦串 1 本**（`download-osm` → `extract-3way` → `load-to-cockroach`）を Cloud Run Jobs で end-to-end に通し、以下 4 点を実測で潰す:
+
+- (a) `osmpbf` クレートの GCS 対応（一時 DL で十分か / ストリーム化が必要か）
+- (b) Cloud Run Jobs のメモリ消費（パイロット bbox での実測）
+- (c) CockroachDB Cloud に staging cluster / database を作る方法
+- (d) Artifact Registry 構成（既存 `y-junctions` リポジトリ共用 vs 別作り）
+
+issue #229 の宣言通り **1 PR にまとめ、分割しない**。
+
+## 現状
+
+- 3-way 取込本体は parse / insert が既に分離済 — `backend/src/importer/mod.rs:15-35`
+  - `parser::parse_pbf_three_way(input_path, bbox) -> Vec<JunctionForInsert>`（DB 非依存）
+  - `inserter::insert_junctions(pool, junctions)`（PBF 非依存）
+  - 新バイナリは両関数を**そのまま呼ぶだけ**で、既存ロジックは無変更で再利用可能
+- `parser::parse_pbf_three_way` は `File::open(input_path)` でローカルファイル前提 — `backend/src/importer/parser.rs:48-50`
+- 既存 `import` バイナリは `--input` / `--bbox` で動作 — `backend/src/bin/import.rs:5-16`
+- Artifact Registry `y-junctions`（asia-northeast1） / Cloud Run・Cloud Build API 有効化済 — `terraform/backend.tf:1-25`
+- CockroachDB cluster は **asia-southeast1**（GCP は asia-northeast1） — `terraform/cockroachdb.tf:5-15` → ジョブは cross-region で書く形になる
+- `object_store` / `parquet` クレート未導入 — `backend/Cargo.toml:22-44`
+- 本 worktree には `doc/todo.md` 不在（`doc/` 直下に Phase 単位 doc が並ぶ運用）
+
+## 提案する変更
+
+### A. 新規 Rust バイナリ 3 個（既存 `import.rs` 等は無変更）
+
+| バイナリ | 入力 → 出力 | 内部呼出 |
+|---|---|---|
+| `backend/src/bin/pipeline_download_osm.rs` | Geofabrik URL → `gs://...-yj-raw/osm/<dataset>.osm.pbf` | reqwest streaming |
+| `backend/src/bin/pipeline_extract_three_way.rs` | `gs://yj-raw/...` を tmpfs に DL → `gs://yj-extracted/three-way/<run_id>.parquet` + `gs://yj-serving/three-way/<run_id>.parquet`（同一ファイルをコピー） | `parser::parse_pbf_three_way` |
+| `backend/src/bin/pipeline_load_to_cockroach.rs` | `gs://yj-serving/three-way/<run_id>.parquet` → CockroachDB | `inserter::insert_junctions` |
+
+**Cargo 依存追加（`backend/Cargo.toml`）**:
+- `object_store = { version = "0.x", features = ["gcp"] }`
+- `parquet = "..."`, `parquet-derive = "..."`
+- `bytes`, `tokio-util`
+
+**Parquet I/O 用 DTO**:
+- `JunctionForInsert` 自体は無変更
+- I/O 用に別途 DTO を定義し、`bearings: [u32;3]` は `bearing_1/2/3` にフラット展開、`Option<f32>` は nullable column
+- `#[derive(ParquetRecordWriter, ParquetRecordReader)]` を試し、動かない場合は手書き schema にフォールバック
+
+**PBF の `Read` ブリッジ**: `osmpbf::ElementReader::new` が `Read` impl を要求するので、`object_store::get` で取得したオブジェクトを Cloud Run の writable FS（tmpfs）に書き出してから `File::open` で渡す。`file://` 入力時は `LocalFileSystem` 経由でパスを直接取得しコピーを避ける。
+
+### B. Docker / Build
+
+- `pipeline/Dockerfile` — マルチステージ、3 バイナリを単一イメージに同梱、entrypoint を引数で切替
+- `pipeline/cloudbuild.yaml` — `asia-northeast1-docker.pkg.dev/y-junctions-prod/y-junctions/pipeline:latest` に push（既存 Artifact Registry リポジトリ共用、`pipeline:` プレフィックス）
+
+### C. Terraform `terraform/pipeline.tf`（既存ファイル無変更）
+
+- **GCS バケット 3 個**: `y-junctions-prod-yj-raw` / `y-junctions-prod-yj-extracted` / `y-junctions-prod-yj-serving`
+  - location `asia-northeast1`、uniform_bucket_level_access、90 日 lifecycle 削除
+- **ジョブ専用 SA 3 個**: `sa-pipeline-download-osm` / `sa-pipeline-extract-3way` / `sa-pipeline-load-to-cockroach`
+  - 各 SA は対応するバケットの read/write のみ、`load-to-cockroach` のみ DB シークレット参照可
+- **`google_cloud_run_v2_job` 3 個**:
+  - `download-osm`: cpu=1, memory=2Gi
+  - `extract-3way`: cpu=2, memory=8Gi
+  - `load-to-cockroach`: cpu=1, memory=2Gi
+- **`google_workflows_workflow` 1 個**: YAML inline、3 ジョブ順次実行
+- **`google_cloud_scheduler_job` 1 個**: monthly cron で定義するが初期は disable で開始（手動キックで end-to-end 確認）
+- **`cockroach_database`**: `y_junctions_pipeline_smoke` を既存 cluster 内に追加。`load-to-cockroach` 起動時に既存 migrations を sqlx migrate で流す
+
+### D. パイロット bbox
+
+**shikoku-latest（~120MB）+ 香川県相当の小 bbox** で開始。日本全国・上海は本 PR 対象外。
+
+### E. 実装順序（1 PR 内のコミット粒度）
+
+1. Cargo 依存追加 + Parquet DTO
+2. `pipeline_download_osm` 実装 + ローカル `file://` smoke
+3. `pipeline_extract_three_way` 実装 + ローカル smoke
+4. `pipeline_load_to_cockroach` 実装 + ローカル smoke（staging DB は事前手動作成）
+5. Dockerfile + cloudbuild + イメージ push
+6. `terraform/pipeline.tf` 追加 + apply
+7. Scheduler 手動キックで end-to-end → 完了条件 3 項目を issue #229 にコメント
+
+## 完了条件
+
+- [ ] Cloud Scheduler 手動キック → Workflows → 3 ジョブ順次成功 → `y_junctions_pipeline_smoke` database に Y 字路レコードが入る
+- [ ] パイロット bbox での所要時間・メモリ実測値を取得し issue #229 にコメント
+- [ ] osmpbf GCS 対応の判断材料（一時 DL で十分か / ストリーム化が必要か）を記録
+
+## 却下した選択肢
+
+- **PR 分割** — issue #229 既に却下（Workflows YAML が宙ぶらりんになる工程が出るため、3 ジョブは 1 PR にまとめる）
+- **`object_store` を薄いヘルパで代用** — issue #229 既に却下（後続ジョブで結局必要になるリファクタが発生）
+- **PBF の GCS ストリーム化** — issue #229 既に却下（クレート改造 or 自前 `Read` 実装が要り、walking skeleton の趣旨から外れる。tmpfs 一時 DL で十分）
+- **prep PR で抽出/ロード分離リファクタを先行** — issue #229 既に却下（`parser` / `inserter` は既に分離済み）
+- **中間フォーマットに JSON Lines / Arrow IPC を採用** — issue #229 既に却下（Parquet が事実上の標準、DuckDB / BigQuery 直クエリも将来効く）
+- **3 バイナリを別イメージ化** — Cloud Build 時間倍増・Terraform も冗長。1 イメージ + entrypoint 切替で十分
+- **`yj-enriched` バケット先行作成** — 後続 sub-issue で要件が固まってから
+
+## リスク / 未確認事項
+
+- **cross-region**: Cluster は asia-southeast1、ジョブは asia-northeast1。レイテンシ・egress 課金は実測待ち。実測次第で staging cluster を asia-northeast1 に作る案を別 sub-issue 化
+- **`object_store::gcp` の認証**: Cloud Run Jobs SA からの ADC 取得経路は未検証（ローカル smoke 時は `gcloud auth application-default login` が必要かも）
+- **`parquet-derive`**: `i32` / `f32` / `bool` / `String` / `Option` の組合せで動くか未確認。失敗時は手書き schema へフォールバック
+- **同一 cluster で staging DB を共存** → `request_unit_limit = 50000000`（`terraform/cockroachdb.tf:18`）を消費。月次ロード程度なら軽微見込みだが要監視
+- **Cloud Run の writable filesystem は in-memory tmpfs**、書き込みはメモリ上限に算入される（[公式 docs](https://cloud.google.com/run/docs/container-contract)）。パイロット bbox の小さい PBF なら問題なし、日本全国（〜2GB）でも 32GB 上限内に収まる見込みだが要実測
+- **CockroachDB Cloud Free tier に追加 database 作成のクォータ制限**があるか未確認
+- **Workflows 月次 cron の課金**が無料枠内か未確認（issue #220 の見積もり通りか）

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-binary image hosting all walking-skeleton pipeline jobs.
+# Cloud Run Jobs override `command` per Job to pick which binary to run.
+#
+# Build context is the repository root so that `backend/` is in scope.
+
+FROM rust:1.90-slim-bookworm AS builder
+
+WORKDIR /app
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY backend/ /app/backend/
+WORKDIR /app/backend
+
+RUN cargo build --release \
+      --bin pipeline-download-osm \
+      --bin pipeline-extract-three-way \
+      --bin pipeline-load-to-cockroach
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/backend/target/release/pipeline-download-osm /usr/local/bin/
+COPY --from=builder /app/backend/target/release/pipeline-extract-three-way /usr/local/bin/
+COPY --from=builder /app/backend/target/release/pipeline-load-to-cockroach /usr/local/bin/
+
+# Placeholder; Cloud Run Job spec sets the actual `command` per job.
+CMD ["pipeline-download-osm", "--help"]

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -21,11 +21,14 @@ RUN cargo build --release \
 FROM debian:bookworm-slim
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system --create-home --uid 65532 appuser
 
 COPY --from=builder /app/backend/target/release/pipeline-download-osm /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-extract-three-way /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-load-to-cockroach /usr/local/bin/
+
+USER 65532:65532
 
 # Placeholder; Cloud Run Job spec sets the actual `command` per job.
 CMD ["pipeline-download-osm", "--help"]

--- a/pipeline/cloudbuild.yaml
+++ b/pipeline/cloudbuild.yaml
@@ -5,14 +5,14 @@ steps:
       - -t
       - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:latest
       - -t
-      - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:$SHORT_SHA
+      - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:$BUILD_ID
       - -f
       - pipeline/Dockerfile
       - .
 
 images:
   - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:latest
-  - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:$SHORT_SHA
+  - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:$BUILD_ID
 
 options:
   machineType: E2_HIGHCPU_8

--- a/pipeline/cloudbuild.yaml
+++ b/pipeline/cloudbuild.yaml
@@ -1,0 +1,21 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -t
+      - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:latest
+      - -t
+      - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:$SHORT_SHA
+      - -f
+      - pipeline/Dockerfile
+      - .
+
+images:
+  - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:latest
+  - asia-northeast1-docker.pkg.dev/$PROJECT_ID/y-junctions/pipeline:$SHORT_SHA
+
+options:
+  machineType: E2_HIGHCPU_8
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 1800s

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -208,6 +208,8 @@ resource "google_cloud_run_v2_job" "pipeline_download_osm" {
   name     = "pipeline-download-osm"
   location = var.region
 
+  deletion_protection = false
+
   template {
     template {
       service_account = google_service_account.pipeline_download_osm.email
@@ -339,10 +341,9 @@ resource "google_workflows_workflow" "pipeline" {
       steps:
         - init:
             assign:
-              - args_in: $${default(args, {})}
-              - dataset: $${default(map.get(args_in, "dataset"), "shikoku-latest")}
-              - geofabrik_url: $${default(map.get(args_in, "geofabrik_url"), "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf")}
-              - bbox: $${default(map.get(args_in, "bbox"), "134.0,34.3,134.1,34.4")}
+              - dataset: $${default(map.get(args, "dataset"), "shikoku-latest")}
+              - geofabrik_url: $${default(map.get(args, "geofabrik_url"), "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf")}
+              - bbox: $${default(map.get(args, "bbox"), "134.0,34.3,134.1,34.4")}
               - raw_uri: $${"gs://${google_storage_bucket.yj_raw.name}/osm/" + dataset + ".osm.pbf"}
               - extracted_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + dataset + ".parquet"}
               - serving_uri: $${"gs://${google_storage_bucket.yj_serving.name}/three-way/" + dataset + ".parquet"}

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -1,0 +1,428 @@
+###############################################################################
+# Cloud Run Jobs walking-skeleton (issue #229)
+#
+# Pipeline: download-osm -> extract-three-way -> load-to-cockroach
+#
+# Workload parameters (dataset / geofabrik url / bbox) are NOT baked into
+# the infrastructure. Cloud Run Jobs declare only `command` here; arguments
+# are supplied per execution via the Workflow's containerOverrides. Defaults
+# live in the Workflow source, and ad-hoc runs can override them via
+# `gcloud workflows execute --data='{"dataset": ..., "bbox": ...}'`.
+###############################################################################
+
+# ---------- API enablement ---------------------------------------------------
+
+resource "google_project_service" "workflows" {
+  service            = "workflows.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudscheduler" {
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+# ---------- Configuration ----------------------------------------------------
+
+locals {
+  pipeline_image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.main.repository_id}/pipeline:latest"
+
+  pipeline_smoke_db_uri = "postgresql://${cockroach_sql_user.main.name}:${urlencode(var.cockroachdb_sql_password)}@${cockroach_cluster.main.regions[0].sql_dns}:26257/${cockroach_database.pipeline_smoke.name}?sslmode=require"
+}
+
+# ---------- GCS buckets ------------------------------------------------------
+
+resource "google_storage_bucket" "yj_raw" {
+  name                        = "${var.project_id}-yj-raw"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = true
+
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  depends_on = [google_project_service.storage]
+}
+
+resource "google_storage_bucket" "yj_extracted" {
+  name                        = "${var.project_id}-yj-extracted"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = true
+
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  depends_on = [google_project_service.storage]
+}
+
+resource "google_storage_bucket" "yj_serving" {
+  name                        = "${var.project_id}-yj-serving"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = true
+
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  depends_on = [google_project_service.storage]
+}
+
+# ---------- CockroachDB staging database -------------------------------------
+#
+# Same cluster as production (asia-southeast1, BASIC plan), separate database.
+# Reuses the existing y_junctions_user; the smoke DB consumes from the cluster's
+# request-unit quota (request_unit_limit = 50_000_000) — monitor in step 7.
+
+resource "cockroach_database" "pipeline_smoke" {
+  name       = "y_junctions_pipeline_smoke"
+  cluster_id = cockroach_cluster.main.id
+}
+
+# ---------- Secret Manager: staging DB URL -----------------------------------
+
+resource "google_secret_manager_secret" "pipeline_smoke_db_url" {
+  secret_id = "cockroachdb-pipeline-smoke-url"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "pipeline_smoke_db_url_v1" {
+  secret      = google_secret_manager_secret.pipeline_smoke_db_url.id
+  secret_data = local.pipeline_smoke_db_uri
+}
+
+# ---------- Service accounts (one per job) -----------------------------------
+
+resource "google_service_account" "pipeline_download_osm" {
+  account_id   = "sa-pipeline-download-osm"
+  display_name = "Pipeline: download-osm"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_service_account" "pipeline_extract_three_way" {
+  account_id   = "sa-pipeline-extract-three-way"
+  display_name = "Pipeline: extract-three-way"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_service_account" "pipeline_load_to_cockroach" {
+  account_id   = "sa-pipeline-load-to-cockroach"
+  display_name = "Pipeline: load-to-cockroach"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_service_account" "pipeline_workflow" {
+  account_id   = "sa-pipeline-workflow"
+  display_name = "Pipeline: workflow orchestrator"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_service_account" "pipeline_scheduler" {
+  account_id   = "sa-pipeline-scheduler"
+  display_name = "Pipeline: scheduler trigger"
+
+  depends_on = [google_project_service.iam]
+}
+
+# ---------- IAM: per-bucket access ------------------------------------------
+
+# download-osm: write to yj-raw
+resource "google_storage_bucket_iam_member" "download_osm_writes_raw" {
+  bucket = google_storage_bucket.yj_raw.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.pipeline_download_osm.email}"
+}
+
+# extract-three-way: read yj-raw, write yj-extracted + yj-serving
+resource "google_storage_bucket_iam_member" "extract_reads_raw" {
+  bucket = google_storage_bucket.yj_raw.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_extract_three_way.email}"
+}
+
+resource "google_storage_bucket_iam_member" "extract_writes_extracted" {
+  bucket = google_storage_bucket.yj_extracted.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.pipeline_extract_three_way.email}"
+}
+
+resource "google_storage_bucket_iam_member" "extract_writes_serving" {
+  bucket = google_storage_bucket.yj_serving.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.pipeline_extract_three_way.email}"
+}
+
+# load-to-cockroach: read yj-serving, read DB secret
+resource "google_storage_bucket_iam_member" "load_reads_serving" {
+  bucket = google_storage_bucket.yj_serving.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_load_to_cockroach.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "load_reads_db_secret" {
+  secret_id = google_secret_manager_secret.pipeline_smoke_db_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.pipeline_load_to_cockroach.email}"
+}
+
+# ---------- Cloud Run Jobs ---------------------------------------------------
+#
+# `args` is intentionally omitted; the Workflow supplies arguments per
+# execution via containerOverrides. This keeps "what to process" out of
+# infrastructure-as-code so a different dataset / bbox does not require
+# `terraform apply`.
+
+resource "google_cloud_run_v2_job" "pipeline_download_osm" {
+  name     = "pipeline-download-osm"
+  location = var.region
+
+  template {
+    template {
+      service_account = google_service_account.pipeline_download_osm.email
+      timeout         = "1800s"
+      max_retries     = 1
+
+      containers {
+        image   = local.pipeline_image
+        command = ["pipeline-download-osm"]
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "2Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [google_project_service.run]
+}
+
+resource "google_cloud_run_v2_job" "pipeline_extract_three_way" {
+  name     = "pipeline-extract-three-way"
+  location = var.region
+
+  template {
+    template {
+      service_account = google_service_account.pipeline_extract_three_way.email
+      timeout         = "1800s"
+      max_retries     = 1
+
+      containers {
+        image   = local.pipeline_image
+        command = ["pipeline-extract-three-way"]
+
+        resources {
+          limits = {
+            cpu    = "2"
+            memory = "8Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [google_project_service.run]
+}
+
+resource "google_cloud_run_v2_job" "pipeline_load_to_cockroach" {
+  name     = "pipeline-load-to-cockroach"
+  location = var.region
+
+  template {
+    template {
+      service_account = google_service_account.pipeline_load_to_cockroach.email
+      timeout         = "1800s"
+      max_retries     = 1
+
+      containers {
+        image   = local.pipeline_image
+        command = ["pipeline-load-to-cockroach"]
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.pipeline_smoke_db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "2Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_secret_manager_secret_iam_member.load_reads_db_secret,
+  ]
+}
+
+# ---------- Workflows --------------------------------------------------------
+
+resource "google_project_iam_member" "workflow_runs_jobs" {
+  project = var.project_id
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.pipeline_workflow.email}"
+}
+
+# Workflows needs to act-as the Cloud Run Jobs' service accounts to invoke them.
+resource "google_service_account_iam_member" "workflow_acts_as_download_osm" {
+  service_account_id = google_service_account.pipeline_download_osm.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
+}
+
+resource "google_service_account_iam_member" "workflow_acts_as_extract" {
+  service_account_id = google_service_account.pipeline_extract_three_way.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
+}
+
+resource "google_service_account_iam_member" "workflow_acts_as_load" {
+  service_account_id = google_service_account.pipeline_load_to_cockroach.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
+}
+
+# Workflow holds the workload defaults (dataset / geofabrik URL / bbox) and
+# constructs per-job containerOverrides. Callers can override any of these by
+# passing JSON to `gcloud workflows execute --data`.
+resource "google_workflows_workflow" "pipeline" {
+  name            = "yj-pipeline"
+  region          = var.region
+  service_account = google_service_account.pipeline_workflow.id
+
+  source_contents = <<-EOT
+    main:
+      params: [args]
+      steps:
+        - init:
+            assign:
+              - args_in: $${default(args, {})}
+              - dataset: $${default(map.get(args_in, "dataset"), "shikoku-latest")}
+              - geofabrik_url: $${default(map.get(args_in, "geofabrik_url"), "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf")}
+              - bbox: $${default(map.get(args_in, "bbox"), "134.0,34.3,134.1,34.4")}
+              - raw_uri: $${"gs://${google_storage_bucket.yj_raw.name}/osm/" + dataset + ".osm.pbf"}
+              - extracted_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + dataset + ".parquet"}
+              - serving_uri: $${"gs://${google_storage_bucket.yj_serving.name}/three-way/" + dataset + ".parquet"}
+        - download:
+            call: googleapis.run.v2.projects.locations.jobs.run
+            args:
+              name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_download_osm.name}
+              body:
+                overrides:
+                  containerOverrides:
+                    - args:
+                        - "--input"
+                        - $${geofabrik_url}
+                        - "--output"
+                        - $${raw_uri}
+            result: download_result
+        - extract:
+            call: googleapis.run.v2.projects.locations.jobs.run
+            args:
+              name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_extract_three_way.name}
+              body:
+                overrides:
+                  containerOverrides:
+                    - args:
+                        - "--input"
+                        - $${raw_uri}
+                        - "--extracted-output"
+                        - $${extracted_uri}
+                        - "--serving-output"
+                        - $${serving_uri}
+                        - "--bbox"
+                        - $${bbox}
+            result: extract_result
+        - load:
+            call: googleapis.run.v2.projects.locations.jobs.run
+            args:
+              name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_load_to_cockroach.name}
+              body:
+                overrides:
+                  containerOverrides:
+                    - args:
+                        - "--input"
+                        - $${serving_uri}
+            result: load_result
+        - done:
+            return: $${load_result}
+  EOT
+
+  depends_on = [google_project_service.workflows]
+}
+
+# ---------- Cloud Scheduler --------------------------------------------------
+
+resource "google_project_iam_member" "scheduler_invokes_workflow" {
+  project = var.project_id
+  role    = "roles/workflows.invoker"
+  member  = "serviceAccount:${google_service_account.pipeline_scheduler.email}"
+}
+
+# Scheduled trigger for the pipeline. The cron cadence is data, not part
+# of the resource identity — change `schedule` (or pause via `gcloud
+# scheduler jobs pause yj-pipeline-trigger`) without renaming the resource.
+#
+# Initial verification path:
+#   gcloud workflows execute yj-pipeline --location=asia-northeast1
+resource "google_cloud_scheduler_job" "pipeline_trigger" {
+  name        = "yj-pipeline-trigger"
+  region      = var.region
+  description = "Scheduled trigger for the walking-skeleton pipeline (issue #229)"
+  schedule    = "0 3 1 * *" # 03:00 JST on the 1st of each month
+  time_zone   = "Asia/Tokyo"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.pipeline.id}/executions"
+
+    oauth_token {
+      service_account_email = google_service_account.pipeline_scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.cloudscheduler]
+}

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -41,6 +41,7 @@ resource "google_storage_bucket" "yj_raw" {
   name                        = "${var.project_id}-yj-raw"
   location                    = var.region
   uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
   force_destroy               = true
 
   lifecycle_rule {
@@ -59,6 +60,7 @@ resource "google_storage_bucket" "yj_extracted" {
   name                        = "${var.project_id}-yj-extracted"
   location                    = var.region
   uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
   force_destroy               = true
 
   lifecycle_rule {
@@ -77,6 +79,7 @@ resource "google_storage_bucket" "yj_serving" {
   name                        = "${var.project_id}-yj-serving"
   location                    = var.region
   uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
   force_destroy               = true
 
   lifecycle_rule {

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -413,6 +413,7 @@ resource "google_cloud_scheduler_job" "pipeline_trigger" {
   name        = "yj-pipeline-trigger"
   region      = var.region
   description = "Scheduled trigger for the walking-skeleton pipeline (issue #229)"
+  paused      = true        # Manual verification only; unpause once dispatcher (#237) lands.
   schedule    = "0 3 1 * *" # 03:00 JST on the 1st of each month
   time_zone   = "Asia/Tokyo"
 


### PR DESCRIPTION
## Summary

issue #229 (sub-issue of #220) の最小縦串 1 本を実装。**Cloud Run Jobs 上で end-to-end 動作確認済**。

- 3 ジョブ: `download-osm` → `extract-three-way` → `load-to-cockroach`
- GCS バケット 3: `yj-raw` / `yj-extracted` / `yj-serving`
- 既存の `parser::parse_pbf_three_way` / `inserter::insert_junctions` を**無変更で再利用**
- I/O は `object_store` クレートで `file://` / `gs://` 統一、中間フォーマットは Parquet (Snappy)
- Workflows + Scheduler でオーケストレーション、staging DB は本番と同 cluster の別 database

## end-to-end smoke 結果

[issue #229 のコメント](https://github.com/cozy-corner/y-junctions/issues/229#issuecomment-4363437134) に詳細。

| ジョブ | 所要時間 | 出力 |
|---|---|---|
| download-osm | 27 秒 | 83.3 MiB PBF |
| extract-three-way | 24 秒 | 11.9 KiB Parquet |
| load-to-cockroach | 14 秒 | 128 rows |

Workflow 全体: 96 秒。staging DB に 128 件 INSERT 完了。

## ファイル構成

**Rust (backend/):**
- `src/pipeline/parquet_io.rs` — JunctionForInsert ⇄ Parquet DTO + write/read helper
- `src/pipeline/storage.rs` — URI ベースの read/write ヘルパ (https/gs/file)
- `src/bin/pipeline_download_osm.rs`
- `src/bin/pipeline_extract_three_way.rs`
- `src/bin/pipeline_load_to_cockroach.rs`

**インフラ:**
- `pipeline/Dockerfile` — マルチステージ・3 バイナリ単一イメージ
- `pipeline/cloudbuild.yaml` — Artifact Registry に push
- `terraform/pipeline.tf` — GCS / SA / IAM / Cloud Run Jobs / Workflow / Scheduler 一式

**ドキュメント:**
- `doc/walking-skeleton-cloud-run-jobs.md` — 設計

## 設計上の決定

- **Cloud Run Jobs は `command` のみ宣言、`args` は Workflow が containerOverrides で実行時に注入**: dataset / bbox を変えても terraform apply 不要。`gcloud workflows execute --data` で上書き可
- **Job リソース名から周期 (monthly) を排除**: schedule 変更で resource rename 不要
- **walking skeleton は最小縦串**: 2-way / elevation / Baidu / yj-enriched は対象外

## 残課題（別 issue 化済）

- #231 backend image tag drift（既存）
- #232 path に run_id (日付) を入れて履歴を残す
- #233 CI/CD: pipeline image build を deploy.yml に統合する
- #234 staging DB migrations の自動適用
- #235 CockroachDB staging cluster の region 検討
- #237 catalog + dispatcher パターンで N dataset を fan-out 実行する

## Test plan

- [x] `cargo test`: 82 passed (parquet roundtrip / storage roundtrip 含む)
- [x] `cargo fmt --check`: clean
- [x] `cargo clippy -- -D warnings`: clean
- [x] ローカル smoke: shikoku-latest + 高松 bbox で 130 件抽出 → Parquet → ローカル CockroachDB
- [x] docker build (3.5 分) + 3 バイナリ `--help` 動作確認
- [x] terraform validate: clean
- [x] **Cloud 上 end-to-end smoke**: Workflow 96 秒で SUCCEEDED, 128 件 INSERT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated pipeline for downloading and processing OpenStreetMap data to extract junction information and load into database
  * Added Cloud Run Jobs orchestration with workflow scheduling capabilities for end-to-end data processing pipelines

* **Documentation**
  * Added design documentation for pipeline infrastructure setup and cloud deployment

* **Chores**
  * Added Docker containerization support and updated dependencies for data serialization and cloud storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->