### PR TITLE
ci: staging DB migrations を独立 job として deploy.yml に追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
       backend-deploy: ${{ steps.filter.outputs.backend-deploy }}
       frontend: ${{ steps.filter.outputs.frontend }}
       pipeline: ${{ steps.filter.outputs.pipeline }}
+      pipeline-staging-migrate: ${{ steps.filter.outputs.pipeline-staging-migrate }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -58,6 +59,12 @@ jobs:
               - 'backend/src/domain/**'
               - 'backend/Cargo.toml'
               - 'backend/Cargo.lock'
+              - '.github/workflows/deploy.yml'
+            # pipeline-staging-migrate: Triggers staging DB migrations only when
+            # migration files (or this workflow) change. Kept narrow on purpose so
+            # that ordinary backend code edits do not touch the staging DB.
+            pipeline-staging-migrate:
+              - 'backend/migrations/**'
               - '.github/workflows/deploy.yml'
 
   # Backend Test Job
@@ -396,16 +403,52 @@ jobs:
             -t ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/y-junctions/pipeline:latest \
             .
 
+  # Pipeline Staging DB Migration Job
+  # Applies sqlx migrations to the y_junctions_pipeline_smoke staging DB.
+  # Independent of backend-deploy so ordinary backend code edits do not touch it.
+  pipeline-staging-migrate:
+    name: Pipeline - Staging DB Migrate
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.pipeline-staging-migrate == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Rust for migrations
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache SQLx CLI
+        id: cache-sqlx
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/sqlx
+          key: ${{ runner.os }}-sqlx-cli
+
+      - name: Install SQLx CLI
+        if: steps.cache-sqlx.outputs.cache-hit != 'true'
+        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
+
+      - name: Run database migrations (pipeline staging)
+        working-directory: backend
+        env:
+          DATABASE_URL: ${{ secrets.PIPELINE_SMOKE_DATABASE_URL }}
+        run: sqlx migrate run
+
   # Post-Deploy Job
   post-deploy:
     name: Post-Deploy Summary
     runs-on: ubuntu-latest
-    needs: [changes, backend-deploy, frontend-deploy, pipeline-deploy]
+    needs: [changes, backend-deploy, frontend-deploy, pipeline-deploy, pipeline-staging-migrate]
     if: |
       always() &&
       (needs.backend-deploy.result != 'skipped' ||
        needs.frontend-deploy.result != 'skipped' ||
-       needs.pipeline-deploy.result != 'skipped')
+       needs.pipeline-deploy.result != 'skipped' ||
+       needs.pipeline-staging-migrate.result != 'skipped')
 
     permissions:
       contents: read
@@ -461,6 +504,16 @@ jobs:
             echo "❌ **Pipeline image**: Build/push failed" >> $GITHUB_STEP_SUMMARY
           fi
 
+          # Pipeline staging migration status
+          PIPELINE_STAGING_MIGRATE_RESULT="${{ needs.pipeline-staging-migrate.result }}"
+          if [ "$PIPELINE_STAGING_MIGRATE_RESULT" == "success" ]; then
+            echo "✅ **Pipeline staging migrate**: Applied successfully" >> $GITHUB_STEP_SUMMARY
+          elif [ "$PIPELINE_STAGING_MIGRATE_RESULT" == "skipped" ]; then
+            echo "⏭️ **Pipeline staging migrate**: Skipped (no migration changes)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **Pipeline staging migrate**: Failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "**Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
@@ -470,6 +523,7 @@ jobs:
           BACKEND_STATUS="${{ needs.backend-deploy.result }}"
           FRONTEND_STATUS="${{ needs.frontend-deploy.result }}"
           PIPELINE_STATUS="${{ needs.pipeline-deploy.result }}"
+          PIPELINE_STAGING_MIGRATE_STATUS="${{ needs.pipeline-staging-migrate.result }}"
 
           # スキップされたものは無視し、実行されたものが全て成功かチェック
           FAILED=false
@@ -486,6 +540,11 @@ jobs:
 
           if [ "$PIPELINE_STATUS" != "skipped" ] && [ "$PIPELINE_STATUS" != "success" ]; then
             echo "❌ Pipeline image build/push failed or was cancelled"
+            FAILED=true
+          fi
+
+          if [ "$PIPELINE_STAGING_MIGRATE_STATUS" != "skipped" ] && [ "$PIPELINE_STAGING_MIGRATE_STATUS" != "success" ]; then
+            echo "❌ Pipeline staging DB migration failed or was cancelled"
             FAILED=true
           fi
 


### PR DESCRIPTION
## Summary

issue #234 を解決。staging DB (`y_junctions_pipeline_smoke`) の migration を CI で自動適用する。

### 変更内容 (`.github/workflows/deploy.yml`)

1. **`changes` job**: 新フィルタ `pipeline-staging-migrate` を追加
   - 対象パス: `backend/migrations/**`, `.github/workflows/deploy.yml`
   - `outputs` にも `pipeline-staging-migrate` を追加
2. **新規 job `pipeline-staging-migrate`**: prod migration step と同じ sqlx-cli セットアップ pattern を使用
   - `Setup Rust for migrations` → `Cache SQLx CLI` → `Install SQLx CLI` → `sqlx migrate run`
   - `working-directory: backend` で実行
   - `DATABASE_URL: ${{ secrets.PIPELINE_SMOKE_DATABASE_URL }}`
3. **`post-deploy` job**: `needs` / `if` / summary / status check に新 job を加える (#239 で他 job 追加した時の pattern を踏襲)

### 設計判断: なぜ独立 job か

prod migration は `backend-deploy` に同梱されており、`backend/src/**` 等の広い trigger で毎回走る。staging migration を同じ pattern にすると、`backend/src/api/handler.rs` の編集だけでも staging DB に接続が走り無駄。staging migration は **migration ファイル追加/編集時だけ走れば十分** なので、独立 job + 狭い filter (`backend/migrations/**` のみ) とした。

prod 側の同じ問題 (filter が広い) は別 issue #240 で扱う想定 — 本 PR では触らない。

却下した代替案 (issue 本文より):
- A. load-to-cockroach バイナリ起動時に `sqlx::migrate!()` → 責務混在、Job 並列起動時の競合
- B. 専用 Cloud Run Job → 実行ごとに走る、IAM/SA 増
- C. terraform null_resource → TF Cloud では不可

## 手動アクション必須 (merge 前)

新しい GitHub Actions secret `PIPELINE_SMOKE_DATABASE_URL` を追加する必要があります (agent では追加不可)。

```bash
# 1. GCP Secret Manager から値を取得
gcloud secrets versions access latest \
  --secret=cockroachdb-pipeline-smoke-url \
  --project=y-junctions-prod

# 2. GitHub Settings → Secrets and variables → Actions → New repository secret
#    Name:  PIPELINE_SMOKE_DATABASE_URL
#    Value: 上記コマンドの出力をそのまま貼り付け
```

secret が無い状態で merge すると、初回の `sqlx migrate run` が空 URL で失敗します。

## Test plan

- [ ] `PIPELINE_SMOKE_DATABASE_URL` secret を GitHub に追加する
- [ ] merge 後、main の deploy run で `pipeline-staging-migrate` job が成功することを確認
- [ ] migration を含まない次回 PR の merge で `pipeline-staging-migrate` が `skipped` になることを確認 (filter が効いている検証)
- [ ] 動作検証の限界: 実 secret 無しで end-to-end は確認不可。構造を prod migration step と完全に揃え、yaml の構文妥当性 (`python yaml.safe_load`) は確認済み

Closes #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment automation to detect and automatically execute database migrations for staging environments when relevant changes are identified.
  * Improved deployment visibility with detailed migration status reporting in deployment summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->