### PR TITLE
chore: pipeline DB を新名で expand 追加 (#242 1/3)

### DIFF
--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -33,6 +33,9 @@ locals {
   pipeline_image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.main.repository_id}/pipeline:latest"
 
   pipeline_smoke_db_uri = "postgresql://${cockroach_sql_user.main.name}:${urlencode(var.cockroachdb_sql_password)}@${cockroach_cluster.main.regions[0].sql_dns}:26257/${cockroach_database.pipeline_smoke.name}?sslmode=require"
+
+  # New pipeline DB URI; replaces pipeline_smoke_db_uri after #242 PR2/PR3.
+  pipeline_db_uri = "postgresql://${cockroach_sql_user.main.name}:${urlencode(var.cockroachdb_sql_password)}@${cockroach_cluster.main.regions[0].sql_dns}:26257/${cockroach_database.pipeline.name}?sslmode=require"
 }
 
 # ---------- GCS buckets ------------------------------------------------------
@@ -94,18 +97,29 @@ resource "google_storage_bucket" "yj_serving" {
   depends_on = [google_project_service.storage]
 }
 
-# ---------- CockroachDB staging database -------------------------------------
+# ---------- CockroachDB pipeline database ------------------------------------
 #
 # Same cluster as production (asia-southeast1, BASIC plan), separate database.
-# Reuses the existing y_junctions_user; the smoke DB consumes from the cluster's
-# request-unit quota (request_unit_limit = 50_000_000) — monitor in step 7.
+# Reuses the existing y_junctions_user; consumes from the cluster's
+# request-unit quota (request_unit_limit = 50_000_000).
+#
+# Two databases coexist during the #242 rename:
+#   - pipeline_smoke: legacy name from #229 walking skeleton (removed in PR3)
+#   - pipeline:      new name (this PR; references switched in PR2)
 
 resource "cockroach_database" "pipeline_smoke" {
   name       = "y_junctions_pipeline_smoke"
   cluster_id = cockroach_cluster.main.id
 }
 
-# ---------- Secret Manager: staging DB URL -----------------------------------
+resource "cockroach_database" "pipeline" {
+  name       = "y_junctions_pipeline"
+  cluster_id = cockroach_cluster.main.id
+}
+
+# ---------- Secret Manager: pipeline DB URL ----------------------------------
+#
+# Two secrets coexist during #242 rename; old removed in PR3.
 
 resource "google_secret_manager_secret" "pipeline_smoke_db_url" {
   secret_id = "cockroachdb-pipeline-smoke-url"
@@ -120,6 +134,21 @@ resource "google_secret_manager_secret" "pipeline_smoke_db_url" {
 resource "google_secret_manager_secret_version" "pipeline_smoke_db_url_v1" {
   secret      = google_secret_manager_secret.pipeline_smoke_db_url.id
   secret_data = local.pipeline_smoke_db_uri
+}
+
+resource "google_secret_manager_secret" "pipeline_db_url" {
+  secret_id = "cockroachdb-pipeline-url"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "pipeline_db_url_v1" {
+  secret      = google_secret_manager_secret.pipeline_db_url.id
+  secret_data = local.pipeline_db_uri
 }
 
 # ---------- Service accounts (one per job) -----------------------------------
@@ -196,6 +225,15 @@ resource "google_storage_bucket_iam_member" "load_reads_serving" {
 
 resource "google_secret_manager_secret_iam_member" "load_reads_db_secret" {
   secret_id = google_secret_manager_secret.pipeline_smoke_db_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.pipeline_load_to_cockroach.email}"
+}
+
+# Mirror IAM grant on the new pipeline_db_url secret. The Cloud Run job env
+# is switched to this secret in #242 PR2; granting access here ensures the
+# job does not fail at startup the moment the env reference changes.
+resource "google_secret_manager_secret_iam_member" "load_reads_pipeline_db_secret" {
+  secret_id = google_secret_manager_secret.pipeline_db_url.id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.pipeline_load_to_cockroach.email}"
 }


### PR DESCRIPTION
## Summary

issue #242 (pipeline 用 staging DB 名を smoke から適切な名前にリネーム) の第 1 段階 (expand-and-contract の expand)。

新名は議論の結果 `y_junctions_pipeline` に決定（env サフィックスなし。`staging` は staging 環境と紛らわしいため不採用）。

`terraform/pipeline.tf` に新リソースを純粋に追加するだけで、旧 `pipeline_smoke` 系リソースや Cloud Run job env / deploy.yml / doc は **一切触らない**。

### 追加リソース

- `cockroach_database.pipeline` (`y_junctions_pipeline`)
- `google_secret_manager_secret.pipeline_db_url` (`cockroachdb-pipeline-url`)
- `google_secret_manager_secret_version.pipeline_db_url_v1`
- `google_secret_manager_secret_iam_member.load_reads_pipeline_db_secret` (load-to-cockroach SA に新 secret read 権限。PR2 で env が切り替わった瞬間に job が起動できるように先行で付与)

### terraform plan

```
Plan: 4 to add, 1 to change, 0 to destroy.
```

`1 to change` は backend image tag drift (issue #231) で、本 PR とは無関係。

## マージ後の手順

このあとの作業は順序があります：

### 1. terraform apply (ユーザー手動)

\`\`\`bash
cd terraform && terraform apply
\`\`\`

新 DB / 新 secret / 新 IAM が作成される。

### 2. ops 手動

- GitHub UI で repository secret `PIPELINE_DATABASE_URL` を新規追加（値は新 secret `cockroachdb-pipeline-url` の中身と同じ接続文字列）
- ローカルから新 DB にスキーマ適用：

  \`\`\`bash
  cd backend
  DATABASE_URL='<new-db-url>' sqlx migrate run
  \`\`\`

- 新 DB にスキーマが入ったことを CockroachDB Cloud UI で確認

### 3. PR2 (#242 2/3) — Cloud Run / deploy.yml / doc 参照を新名に切替

PR1 マージ後、別 PR で：
- `terraform/pipeline.tf` の load-to-cockroach env を `pipeline_smoke_db_url` → `pipeline_db_url`
- `.github/workflows/deploy.yml` の `PIPELINE_SMOKE_DATABASE_URL` → `PIPELINE_DATABASE_URL`
- `doc/walking-skeleton-cloud-run-jobs.md` の DB 名参照を更新

PR2 マージ + apply 後、pipeline 1 回実行で新 DB に書けることを確認。

### 4. PR3 (#242 3/3) — 旧 pipeline_smoke 系リソース削除

PR2 動作確認後、別 PR で：
- TF の旧 5 リソース削除（database / secret / version / IAM 2 つの参照削除に伴うクリーンアップ）
- GitHub UI で旧 GH secret `PIPELINE_SMOKE_DATABASE_URL` 削除

## Test plan

- [ ] terraform plan が `4 to add, 0 to destroy` であることを確認（apply 前の最終チェック）
- [ ] terraform apply 成功
- [ ] CockroachDB Cloud UI で `y_junctions_pipeline` database が作成されていることを確認
- [ ] GCP Secret Manager で `cockroachdb-pipeline-url` secret が作成されていることを確認
- [ ] GH UI で `PIPELINE_DATABASE_URL` repository secret を追加
- [ ] ローカルから `sqlx migrate run` で新 DB にスキーマ適用
- [ ] 新 DB に旧 DB と同じスキーマが入っていることを `\d y_junctions` 等で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Provisioned new pipeline database infrastructure
  * Added secure credential storage for the pipeline database via Secret Manager
  * Updated service account permissions to access pipeline database secrets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->