### PR TITLE
chore: pipeline 参照を新名 secret/DB に切替 (#242 2/3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -404,7 +404,7 @@ jobs:
             .
 
   # Pipeline Staging DB Migration Job
-  # Applies sqlx migrations to the y_junctions_pipeline_smoke staging DB.
+  # Applies sqlx migrations to the y_junctions_pipeline staging DB.
   # Independent of backend-deploy so ordinary backend code edits do not touch it.
   pipeline-staging-migrate:
     name: Pipeline - Staging DB Migrate
@@ -435,7 +435,7 @@ jobs:
       - name: Run database migrations (pipeline staging)
         working-directory: backend
         env:
-          DATABASE_URL: ${{ secrets.PIPELINE_SMOKE_DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.PIPELINE_DATABASE_URL }}
         run: sqlx migrate run
 
   # Post-Deploy Job

--- a/doc/walking-skeleton-cloud-run-jobs.md
+++ b/doc/walking-skeleton-cloud-run-jobs.md
@@ -65,7 +65,7 @@ issue #229 の宣言通り **1 PR にまとめ、分割しない**。
   - `load-to-cockroach`: cpu=1, memory=2Gi
 - **`google_workflows_workflow` 1 個**: YAML inline、3 ジョブ順次実行
 - **`google_cloud_scheduler_job` 1 個**: monthly cron で定義するが初期は disable で開始（手動キックで end-to-end 確認）
-- **`cockroach_database`**: `y_junctions_pipeline_smoke` を既存 cluster 内に追加。`load-to-cockroach` 起動時に既存 migrations を sqlx migrate で流す
+- **`cockroach_database`**: `y_junctions_pipeline` を既存 cluster 内に追加。`load-to-cockroach` 起動時に既存 migrations を sqlx migrate で流す
 
 ### D. パイロット bbox
 
@@ -83,7 +83,7 @@ issue #229 の宣言通り **1 PR にまとめ、分割しない**。
 
 ## 完了条件
 
-- [ ] Cloud Scheduler 手動キック → Workflows → 3 ジョブ順次成功 → `y_junctions_pipeline_smoke` database に Y 字路レコードが入る
+- [ ] Cloud Scheduler 手動キック → Workflows → 3 ジョブ順次成功 → `y_junctions_pipeline` database に Y 字路レコードが入る
 - [ ] パイロット bbox での所要時間・メモリ実測値を取得し issue #229 にコメント
 - [ ] osmpbf GCS 対応の判断材料（一時 DL で十分か / ストリーム化が必要か）を記録
 

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -319,7 +319,7 @@ resource "google_cloud_run_v2_job" "pipeline_load_to_cockroach" {
           name = "DATABASE_URL"
           value_source {
             secret_key_ref {
-              secret  = google_secret_manager_secret.pipeline_smoke_db_url.secret_id
+              secret  = google_secret_manager_secret.pipeline_db_url.secret_id
               version = "latest"
             }
           }


### PR DESCRIPTION
## Summary

issue #242 (pipeline 用 staging DB 名を smoke から適切な名前にリネーム) の第 2 段階 (switch)。

PR1 (#244) で expand 追加した `y_junctions_pipeline` DB / `cockroachdb-pipeline-url` secret / `PIPELINE_DATABASE_URL` GH secret への参照に切替える。3 箇所を編集：

| ファイル | 変更 |
|---|---|
| `terraform/pipeline.tf` | load-to-cockroach Cloud Run job env の secret 参照を `pipeline_smoke_db_url` → `pipeline_db_url` |
| `.github/workflows/deploy.yml` | `pipeline-staging-migrate` job の `PIPELINE_SMOKE_DATABASE_URL` → `PIPELINE_DATABASE_URL` + コメント更新 |
| `doc/walking-skeleton-cloud-run-jobs.md` | `y_junctions_pipeline_smoke` → `y_junctions_pipeline` (2 箇所) |

旧 `pipeline_smoke` 系リソースと旧 GH secret は本 PR では無変更。PR3 (#242 3/3) で削除する。

### terraform plan

```
Plan: 0 to add, 1 to change, 0 to destroy.
```

```diff
  google_cloud_run_v2_job.pipeline_load_to_cockroach
    secret_key_ref {
-     secret = "cockroachdb-pipeline-smoke-url"
+     secret = "cockroachdb-pipeline-url"
    }
```

## マージ後の手順

### 1. CI 自動実行: deploy.yml `pipeline-staging-migrate`

main マージ時に自動で発火し、新 secret `PIPELINE_DATABASE_URL` 経由で `y_junctions_pipeline` DB に sqlx migrate を実行（既に手動適用済みなので idempotent に skip 完了）。

### 2. terraform apply (ユーザー手動)

\`\`\`bash
cd terraform && terraform apply
\`\`\`

Cloud Run job の env が新 secret 参照に更新される。

### 3. pipeline 動作確認

\`\`\`bash
gcloud workflows execute yj-pipeline --location=asia-northeast1
\`\`\`

実行成功 + 新 DB `y_junctions_pipeline` に Y 字路レコードが入ることを確認：

\`\`\`sql
SELECT COUNT(*) FROM y_junctions;
\`\`\`

## ロールバック手順

問題が発生した場合は、本 PR の revert で旧 secret 参照に戻る。旧 `pipeline_smoke` 系リソースは PR3 まで残しているので、revert + apply で完全に戻せる。

## Test plan

- [ ] PR2 マージ後、deploy.yml `pipeline-staging-migrate` job が緑で完了
- [ ] terraform apply 成功（plan: 1 change のみ）
- [ ] CockroachDB Cloud UI で `y_junctions_pipeline` の `_sqlx_migrations` が 10 件確認
- [ ] Workflow 1 回実行で新 DB に Y 字路レコードが入る
- [ ] PR3 (削除) の準備完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)