### PR TITLE
chore: 旧 pipeline_smoke 系リソースを削除 (#242 3/3)

### DIFF
--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -32,9 +32,6 @@ resource "google_project_service" "secretmanager" {
 locals {
   pipeline_image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.main.repository_id}/pipeline:latest"
 
-  pipeline_smoke_db_uri = "postgresql://${cockroach_sql_user.main.name}:${urlencode(var.cockroachdb_sql_password)}@${cockroach_cluster.main.regions[0].sql_dns}:26257/${cockroach_database.pipeline_smoke.name}?sslmode=require"
-
-  # New pipeline DB URI; replaces pipeline_smoke_db_uri after #242 PR2/PR3.
   pipeline_db_uri = "postgresql://${cockroach_sql_user.main.name}:${urlencode(var.cockroachdb_sql_password)}@${cockroach_cluster.main.regions[0].sql_dns}:26257/${cockroach_database.pipeline.name}?sslmode=require"
 }
 
@@ -102,15 +99,6 @@ resource "google_storage_bucket" "yj_serving" {
 # Same cluster as production (asia-southeast1, BASIC plan), separate database.
 # Reuses the existing y_junctions_user; consumes from the cluster's
 # request-unit quota (request_unit_limit = 50_000_000).
-#
-# Two databases coexist during the #242 rename:
-#   - pipeline_smoke: legacy name from #229 walking skeleton (removed in PR3)
-#   - pipeline:      new name (this PR; references switched in PR2)
-
-resource "cockroach_database" "pipeline_smoke" {
-  name       = "y_junctions_pipeline_smoke"
-  cluster_id = cockroach_cluster.main.id
-}
 
 resource "cockroach_database" "pipeline" {
   name       = "y_junctions_pipeline"
@@ -118,23 +106,6 @@ resource "cockroach_database" "pipeline" {
 }
 
 # ---------- Secret Manager: pipeline DB URL ----------------------------------
-#
-# Two secrets coexist during #242 rename; old removed in PR3.
-
-resource "google_secret_manager_secret" "pipeline_smoke_db_url" {
-  secret_id = "cockroachdb-pipeline-smoke-url"
-
-  replication {
-    auto {}
-  }
-
-  depends_on = [google_project_service.secretmanager]
-}
-
-resource "google_secret_manager_secret_version" "pipeline_smoke_db_url_v1" {
-  secret      = google_secret_manager_secret.pipeline_smoke_db_url.id
-  secret_data = local.pipeline_smoke_db_uri
-}
 
 resource "google_secret_manager_secret" "pipeline_db_url" {
   secret_id = "cockroachdb-pipeline-url"
@@ -223,15 +194,6 @@ resource "google_storage_bucket_iam_member" "load_reads_serving" {
   member = "serviceAccount:${google_service_account.pipeline_load_to_cockroach.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "load_reads_db_secret" {
-  secret_id = google_secret_manager_secret.pipeline_smoke_db_url.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.pipeline_load_to_cockroach.email}"
-}
-
-# Mirror IAM grant on the new pipeline_db_url secret. The Cloud Run job env
-# is switched to this secret in #242 PR2; granting access here ensures the
-# job does not fail at startup the moment the env reference changes.
 resource "google_secret_manager_secret_iam_member" "load_reads_pipeline_db_secret" {
   secret_id = google_secret_manager_secret.pipeline_db_url.id
   role      = "roles/secretmanager.secretAccessor"
@@ -337,7 +299,7 @@ resource "google_cloud_run_v2_job" "pipeline_load_to_cockroach" {
 
   depends_on = [
     google_project_service.run,
-    google_secret_manager_secret_iam_member.load_reads_db_secret,
+    google_secret_manager_secret_iam_member.load_reads_pipeline_db_secret,
   ]
 }
 


### PR DESCRIPTION
## Summary

issue #242 (pipeline 用 staging DB 名を smoke から適切な名前にリネーム) の第 3 段階 (contract)。

PR1 (#244) で expand 追加、PR2 (#245) で参照切替済み。本 PR で旧 `pipeline_smoke` 系リソースを削除し、リネーム campaign を完了する。

### TF 削除 (4 件)

- `cockroach_database.pipeline_smoke` (`y_junctions_pipeline_smoke` database)
- `google_secret_manager_secret.pipeline_smoke_db_url` (`cockroachdb-pipeline-smoke-url`)
- `google_secret_manager_secret_version.pipeline_smoke_db_url_v1`
- `google_secret_manager_secret_iam_member.load_reads_db_secret`

### TF コード整理

- local `pipeline_smoke_db_uri` を削除
- 「Two databases coexist...」「Two secrets coexist...」の coexist コメントを削除
- `pipeline_load_to_cockroach` の `depends_on` を旧 IAM → 新 IAM (`load_reads_pipeline_db_secret`) に更新（旧 IAM が消えるため必須）
- 「Mirror IAM grant on the new pipeline_db_url secret...」の経過コメントを削除

### terraform plan

```
Plan: 0 to add, 0 to change, 4 to destroy.
```

## データロスについて

旧 DB `y_junctions_pipeline_smoke` の 128 rows は、PR2 マージ後の動作確認 Workflow 実行で新 DB にも同じレコードが入っているため**ロスはない**。pipeline は冪等で再実行可能。

## マージ後の手順

### 1. terraform apply (ユーザー手動)

\`\`\`bash
cd terraform && terraform apply
\`\`\`

旧 DB / 旧 secret / 旧 version / 旧 IAM が削除される。

### 2. GitHub UI 手動: 旧 GH secret 削除

- repository secrets から `PIPELINE_SMOKE_DATABASE_URL` を削除

### 3. 確認

- CockroachDB Cloud UI で `y_junctions_pipeline_smoke` が消えていることを確認
- GCP Secret Manager で `cockroachdb-pipeline-smoke-url` が消えていることを確認
- `gh secret list --repo cozy-corner/y-junctions | grep PIPELINE` の出力が `PIPELINE_DATABASE_URL` のみであること

## ロールバック

万が一 PR3 apply 後に問題が見つかった場合、旧 DB は CockroachDB Cloud で復元できないが、新 DB が正常稼働中のため pipeline は止まらない。本 PR の revert + apply で TF 設定だけは戻せるが、削除済みの旧 DB は再作成扱いになり、空 DB として復活する（旧 128 rows は復元されない）。データ上の意味はないので revert する状況は基本的に発生しない想定。

## Test plan

- [ ] terraform plan が `4 to destroy` のみであることを確認
- [ ] terraform apply 成功
- [ ] CockroachDB Cloud UI で `y_junctions_pipeline_smoke` 削除確認
- [ ] GCP Secret Manager で旧 secret 削除確認
- [ ] GH UI で `PIPELINE_SMOKE_DATABASE_URL` 削除
- [ ] 新 DB `y_junctions_pipeline` で pipeline が動作し続けることを確認（任意で再実行）
- [ ] issue #242 をクローズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)