### PR TITLE
chore: pipeline path に run_id (日付) を入れて履歴を残す (#232)

### DIFF
--- a/doc/walking-skeleton-cloud-run-jobs.md
+++ b/doc/walking-skeleton-cloud-run-jobs.md
@@ -32,9 +32,11 @@ issue #229 の宣言通り **1 PR にまとめ、分割しない**。
 
 | バイナリ | 入力 → 出力 | 内部呼出 |
 |---|---|---|
-| `backend/src/bin/pipeline_download_osm.rs` | Geofabrik URL → `gs://...-yj-raw/osm/<dataset>.osm.pbf` | reqwest streaming |
-| `backend/src/bin/pipeline_extract_three_way.rs` | `gs://yj-raw/...` を tmpfs に DL → `gs://yj-extracted/three-way/<run_id>.parquet` + `gs://yj-serving/three-way/<run_id>.parquet`（同一ファイルをコピー） | `parser::parse_pbf_three_way` |
-| `backend/src/bin/pipeline_load_to_cockroach.rs` | `gs://yj-serving/three-way/<run_id>.parquet` → CockroachDB | `inserter::insert_junctions` |
+| `backend/src/bin/pipeline_download_osm.rs` | Geofabrik URL → `gs://...-yj-raw/osm/<run_date>/<dataset>.osm.pbf` | reqwest streaming |
+| `backend/src/bin/pipeline_extract_three_way.rs` | `gs://yj-raw/...` を tmpfs に DL → `gs://yj-extracted/three-way/<run_date>/<dataset>.parquet` + `gs://yj-serving/three-way/<run_date>/<dataset>.parquet`（同一ファイルをコピー） | `parser::parse_pbf_three_way` |
+| `backend/src/bin/pipeline_load_to_cockroach.rs` | `gs://yj-serving/three-way/<run_date>/<dataset>.parquet` → CockroachDB | `inserter::insert_junctions` |
+
+`<run_date>` は Workflow `init` ステップで `time.format(sys.now(), "Asia/Tokyo")` から算出する `YYYY-MM-DD`（issue #232）。同 Workflow 実行内で 3 ジョブ間の URI に同じ値が再利用される。
 
 **Cargo 依存追加（`backend/Cargo.toml`）**:
 - `object_store = { version = "0.x", features = ["gcp"] }`

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -347,9 +347,10 @@ resource "google_workflows_workflow" "pipeline" {
               - dataset: $${default(map.get(args, "dataset"), "shikoku-latest")}
               - geofabrik_url: $${default(map.get(args, "geofabrik_url"), "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf")}
               - bbox: $${default(map.get(args, "bbox"), "134.0,34.3,134.1,34.4")}
-              - raw_uri: $${"gs://${google_storage_bucket.yj_raw.name}/osm/" + dataset + ".osm.pbf"}
-              - extracted_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + dataset + ".parquet"}
-              - serving_uri: $${"gs://${google_storage_bucket.yj_serving.name}/three-way/" + dataset + ".parquet"}
+              - run_date: $${text.substring(time.format(sys.now(), "Asia/Tokyo"), 0, 10)}
+              - raw_uri: $${"gs://${google_storage_bucket.yj_raw.name}/osm/" + run_date + "/" + dataset + ".osm.pbf"}
+              - extracted_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + run_date + "/" + dataset + ".parquet"}
+              - serving_uri: $${"gs://${google_storage_bucket.yj_serving.name}/three-way/" + run_date + "/" + dataset + ".parquet"}
         - download:
             call: googleapis.run.v2.projects.locations.jobs.run
             args:


### PR DESCRIPTION
## Summary

- Workflow `init` で `time.format(sys.now(), "Asia/Tokyo")` から `YYYY-MM-DD` の `run_date` を算出
- raw / extracted / serving の 3 本の URI に `/<run_date>/` を挿入
- `doc/walking-skeleton-cloud-run-jobs.md` のパス表記を新スキーマに更新

## なぜ

walking skeleton (#229) 実装で `<run_id>` が落ち、毎実行で同パスを上書きしていた。履歴・差分検査・ロールバックが不可能で、dispatcher (#237) で同日 N dataset 並列実行を始めると衝突する。

## パス変更

| | before | after |
|---|---|---|
| raw | `osm/<dataset>.osm.pbf` | `osm/<run_date>/<dataset>.osm.pbf` |
| extracted | `three-way/<dataset>.parquet` | `three-way/<run_date>/<dataset>.parquet` |
| serving | `three-way/<dataset>.parquet` | `three-way/<run_date>/<dataset>.parquet` |

`run_date` は Workflow 実行ごとに init で 1 度だけ assign され、3 ジョブ間で同じ値が再利用される（ジョブ実行が日を跨いでもパスは固定）。

粒度は 1 日 1 ロード前提で `YYYY-MM-DD`。同日中複数実行が必要になったら秒精度に切り替える（issue #232 の方針）。

## Test plan

- [x] `terraform fmt -check pipeline.tf` 通過
- [x] `terraform validate` 通過
- [ ] merge 後 `terraform apply` で Workflows 更新を反映
- [ ] `gcloud workflows execute yj-pipeline` 手動キックで end-to-end が新パス schema で動くことを確認

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cloud Run Jobs pipeline specification updated to reflect new date-based file organization structure.

* **Chores**
  * Pipeline configuration updated to organize job outputs and inputs by execution date (Asia/Tokyo timezone) and dataset instead of run identifiers, providing consistent file structure across workflow executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->