### PR TITLE
chore: backend.tf の image tag drift を ignore_changes で恒久対策 (#231)

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -64,6 +64,14 @@ resource "google_cloud_run_v2_service" "backend" {
   }
 
   depends_on = [google_project_service.run]
+
+  # The image is rolled by GitHub Actions per-commit (`:${SHA}` tag) while this
+  # config defaults to `:latest`. Both tags point at the same digest, but the
+  # string mismatch surfaces as a noisy in-place update on every `terraform
+  # plan`. Let GitHub Actions own the image; Terraform owns infra shape only.
+  lifecycle {
+    ignore_changes = [template[0].containers[0].image]
+  }
 }
 
 # Allow unauthenticated access to Cloud Run


### PR DESCRIPTION
## Summary

`google_cloud_run_v2_service.backend` に `lifecycle.ignore_changes = [template[0].containers[0].image]` を追加し、`terraform plan` 時の image tag drift を抑止する。

## なぜ

- `terraform/backend.tf:35` で `image = var.backend_image`、デフォルトは `:latest`
- `.github/workflows/deploy.yml` は同一 build から `:${SHA}` と `:latest` を両方 push し、Cloud Run には `:${SHA}` で deploy
- 結果: TF state は `:latest`、live は `:${SHA}` で文字列不一致 → 毎回 plan に in-place update が出る
- 同一 digest なので実害なし、plan ノイズと無駄なリビジョン発行のみ

image の管理を GitHub Actions 側に委ね、Terraform はインフラ形状のみを管理する分離を成立させる。

## Test plan

- [x] `terraform validate` 通過
- [ ] merge 後 `terraform plan` で `google_cloud_run_v2_service.backend` の更新が消えることを確認

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)