### PR TITLE
chore: Qodo Merge で dependabot PR をレビュー対象から除外

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,2 @@
+[config]
+ignore_pr_authors = ["dependabot\\[bot\\]"]


### PR DESCRIPTION
## Summary
- `.pr_agent.toml` を追加し `ignore_pr_authors = ["dependabot\\[bot\\]"]` を設定
- Qodo Merge (Pro for Open Source) で dependabot PR の自動レビューをスキップ

## Why
Dependabot PR は機械生成で自動マージ前提のため、Qodo Merge の無料枠 (75 PR/月) を実コード変更のレビューに温存したい。

## Test plan
- [ ] PR が main にマージされた後、次に作成される dependabot PR で Qodo Merge コメントが付かないことを確認
- [ ] 通常 PR では従来通り `/review` 等が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)