### PR TITLE
chore: catalog + dispatcher で N dataset の fan-out を可能にする (#237)

### DIFF
--- a/pipeline/datasets.json
+++ b/pipeline/datasets.json
@@ -4,5 +4,17 @@
     "geofabrik_url": "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf",
     "bbox": "134.0,34.3,134.1,34.4",
     "schedule": "monthly"
+  },
+  {
+    "dataset": "chugoku-latest",
+    "geofabrik_url": "https://download.geofabrik.de/asia/japan/chugoku-latest.osm.pbf",
+    "bbox": "132.45,34.38,132.48,34.41",
+    "schedule": "monthly"
+  },
+  {
+    "dataset": "kyushu-latest",
+    "geofabrik_url": "https://download.geofabrik.de/asia/japan/kyushu-latest.osm.pbf",
+    "bbox": "130.39,33.58,130.42,33.61",
+    "schedule": "monthly"
   }
 ]

--- a/pipeline/datasets.json
+++ b/pipeline/datasets.json
@@ -4,5 +4,11 @@
     "geofabrik_url": "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf",
     "bbox": "134.0,34.3,134.1,34.4",
     "schedule": "monthly"
+  },
+  {
+    "dataset": "chugoku-latest",
+    "geofabrik_url": "https://download.geofabrik.de/asia/japan/chugoku-latest.osm.pbf",
+    "bbox": "132.45,34.38,132.48,34.41",
+    "schedule": "monthly"
   }
 ]

--- a/pipeline/datasets.json
+++ b/pipeline/datasets.json
@@ -4,17 +4,5 @@
     "geofabrik_url": "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf",
     "bbox": "134.0,34.3,134.1,34.4",
     "schedule": "monthly"
-  },
-  {
-    "dataset": "chugoku-latest",
-    "geofabrik_url": "https://download.geofabrik.de/asia/japan/chugoku-latest.osm.pbf",
-    "bbox": "132.45,34.38,132.48,34.41",
-    "schedule": "monthly"
-  },
-  {
-    "dataset": "kyushu-latest",
-    "geofabrik_url": "https://download.geofabrik.de/asia/japan/kyushu-latest.osm.pbf",
-    "bbox": "130.39,33.58,130.42,33.61",
-    "schedule": "monthly"
   }
 ]

--- a/pipeline/datasets.json
+++ b/pipeline/datasets.json
@@ -1,0 +1,8 @@
+[
+  {
+    "dataset": "shikoku-latest",
+    "geofabrik_url": "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf",
+    "bbox": "134.0,34.3,134.1,34.4",
+    "schedule": "monthly"
+  }
+]

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -94,6 +94,24 @@ resource "google_storage_bucket" "yj_serving" {
   depends_on = [google_project_service.storage]
 }
 
+# Catalog bucket for pipeline dataset definitions (issue #237). Object content
+# is operator-managed via `gsutil cp pipeline/datasets.json gs://...-yj-config/`;
+# Terraform owns the bucket only, not the contents. Versioning enabled so a
+# bad edit can be rolled back with `gsutil cp gs://...?generation=...`.
+resource "google_storage_bucket" "yj_config" {
+  name                        = "${var.project_id}-yj-config"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  force_destroy               = false
+
+  versioning {
+    enabled = true
+  }
+
+  depends_on = [google_project_service.storage]
+}
+
 # ---------- CockroachDB pipeline database ------------------------------------
 #
 # Same cluster as production (asia-southeast1, BASIC plan), separate database.
@@ -155,6 +173,13 @@ resource "google_service_account" "pipeline_workflow" {
 resource "google_service_account" "pipeline_scheduler" {
   account_id   = "sa-pipeline-scheduler"
   display_name = "Pipeline: scheduler trigger"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_service_account" "pipeline_dispatcher" {
+  account_id   = "sa-pipeline-dispatcher"
+  display_name = "Pipeline: catalog dispatcher (issue #237)"
 
   depends_on = [google_project_service.iam]
 }
@@ -330,9 +355,11 @@ resource "google_service_account_iam_member" "workflow_acts_as_load" {
   member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
 }
 
-# Workflow holds the workload defaults (dataset / geofabrik URL / bbox) and
-# constructs per-job containerOverrides. Callers can override any of these by
-# passing JSON to `gcloud workflows execute --data`.
+# Workflow constructs per-job containerOverrides from caller-supplied args.
+# All of `dataset` / `geofabrik_url` / `bbox` are required — the dispatcher
+# (issue #237) sources them from `gs://...-yj-config/datasets.json`, ad-hoc
+# runs pass them via `gcloud workflows execute --data='{...}'`. Removing the
+# defaults keeps workload identity out of infrastructure-as-code.
 resource "google_workflows_workflow" "pipeline" {
   name            = "yj-pipeline"
   region          = var.region
@@ -344,9 +371,9 @@ resource "google_workflows_workflow" "pipeline" {
       steps:
         - init:
             assign:
-              - dataset: $${default(map.get(args, "dataset"), "shikoku-latest")}
-              - geofabrik_url: $${default(map.get(args, "geofabrik_url"), "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf")}
-              - bbox: $${default(map.get(args, "bbox"), "134.0,34.3,134.1,34.4")}
+              - dataset: $${args.dataset}
+              - geofabrik_url: $${args.geofabrik_url}
+              - bbox: $${args.bbox}
               - run_date: $${text.substring(time.format(sys.now(), "Asia/Tokyo"), 0, 10)}
               - raw_uri: $${"gs://${google_storage_bucket.yj_raw.name}/osm/" + run_date + "/" + dataset + ".osm.pbf"}
               - extracted_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + run_date + "/" + dataset + ".parquet"}
@@ -399,6 +426,74 @@ resource "google_workflows_workflow" "pipeline" {
   depends_on = [google_project_service.workflows]
 }
 
+# ---------- Catalog dispatcher (issue #237) ----------------------------------
+#
+# Single Cloud Scheduler trigger -> dispatcher Workflow -> fan-out to
+# yj-pipeline executions, one per dataset matching the requested schedule.
+# Adding a dataset is a `gsutil cp pipeline/datasets.json gs://...-yj-config/`,
+# not a `terraform apply` — workload identity stays out of IaC.
+
+# Dispatcher SA reads catalog from yj-config bucket.
+resource "google_storage_bucket_iam_member" "dispatcher_reads_config" {
+  bucket = google_storage_bucket.yj_config.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_dispatcher.email}"
+}
+
+# Dispatcher SA invokes yj-pipeline executions. Project-level matches the
+# scheduler pattern; tighten to per-workflow if/when invoker count grows.
+resource "google_project_iam_member" "dispatcher_invokes_pipeline" {
+  project = var.project_id
+  role    = "roles/workflows.invoker"
+  member  = "serviceAccount:${google_service_account.pipeline_dispatcher.email}"
+}
+
+resource "google_workflows_workflow" "dispatcher" {
+  name            = "yj-pipeline-dispatcher"
+  region          = var.region
+  service_account = google_service_account.pipeline_dispatcher.id
+
+  source_contents = <<-EOT
+    main:
+      params: [args]
+      steps:
+        - init:
+            assign:
+              - schedule_filter: $${default(map.get(args, "schedule"), "monthly")}
+        - read_catalog:
+            call: http.get
+            args:
+              url: https://storage.googleapis.com/${google_storage_bucket.yj_config.name}/datasets.json
+              auth:
+                type: OAuth2
+            result: catalog_raw
+        - filter_targets:
+            assign:
+              - targets: $${list.filter(catalog_raw.body, lambda(d, d.schedule == schedule_filter))}
+        - fan_out:
+            parallel:
+              concurrency_limit: 4
+              for:
+                value: ds
+                in: $${targets}
+                steps:
+                  - run_pipeline:
+                      call: googleapis.workflowexecutions.v1.projects.locations.workflows.executions.create
+                      args:
+                        parent: projects/${var.project_id}/locations/${var.region}/workflows/${google_workflows_workflow.pipeline.name}
+                        body:
+                          argument: $${json.encode_to_string(ds)}
+        - done:
+            return: $${len(targets)}
+  EOT
+
+  depends_on = [
+    google_project_service.workflows,
+    google_storage_bucket_iam_member.dispatcher_reads_config,
+    google_project_iam_member.dispatcher_invokes_pipeline,
+  ]
+}
+
 # ---------- Cloud Scheduler --------------------------------------------------
 
 resource "google_project_iam_member" "scheduler_invokes_workflow" {
@@ -407,23 +502,25 @@ resource "google_project_iam_member" "scheduler_invokes_workflow" {
   member  = "serviceAccount:${google_service_account.pipeline_scheduler.email}"
 }
 
-# Scheduled trigger for the pipeline. The cron cadence is data, not part
+# Scheduled trigger for the dispatcher. The cron cadence is data, not part
 # of the resource identity — change `schedule` (or pause via `gcloud
 # scheduler jobs pause yj-pipeline-trigger`) without renaming the resource.
+# The dispatcher reads `gs://...-yj-config/datasets.json`, filters to
+# `schedule == "monthly"`, and fans out to yj-pipeline executions.
 #
-# Initial verification path:
-#   gcloud workflows execute yj-pipeline --location=asia-northeast1
+# Manual verification path:
+#   gcloud workflows execute yj-pipeline-dispatcher --location=asia-northeast1
 resource "google_cloud_scheduler_job" "pipeline_trigger" {
   name        = "yj-pipeline-trigger"
   region      = var.region
-  description = "Scheduled trigger for the walking-skeleton pipeline (issue #229)"
-  paused      = true        # Manual verification only; unpause once dispatcher (#237) lands.
+  description = "Scheduled trigger for the catalog dispatcher (issue #237)"
+  paused      = false       # Active: dispatcher reads catalog and fans out monthly.
   schedule    = "0 3 1 * *" # 03:00 JST on the 1st of each month
   time_zone   = "Asia/Tokyo"
 
   http_target {
     http_method = "POST"
-    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.pipeline.id}/executions"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.dispatcher.id}/executions"
 
     oauth_token {
       service_account_email = google_service_account.pipeline_scheduler.email

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -467,9 +467,24 @@ resource "google_workflows_workflow" "dispatcher" {
               auth:
                 type: OAuth2
             result: catalog_raw
+        # http.get auto-parses body when Content-Type is application/json, but
+        # gsutil's content-type detection is best-effort — fall back to an
+        # explicit json.decode when the body comes back as a string/bytes.
+        - parse_catalog:
+            switch:
+              - condition: $${get_type(catalog_raw.body) == "list"}
+                steps:
+                  - body_already_list:
+                      assign:
+                        - catalog: $${catalog_raw.body}
+              - condition: true
+                steps:
+                  - decode_body:
+                      assign:
+                        - catalog: $${json.decode(catalog_raw.body)}
         - filter_targets:
             assign:
-              - targets: $${list.filter(catalog_raw.body, lambda(d, d.schedule == schedule_filter))}
+              - targets: $${list.filter(catalog, lambda(d, d.schedule == schedule_filter))}
         - fan_out:
             parallel:
               concurrency_limit: 4


### PR DESCRIPTION
## Summary

- Cloud Scheduler が直接 yj-pipeline を叩く現状 (1 dataset/実行) を改修。dispatcher Workflow を挟み、`gs://...-yj-config/datasets.json` の catalog から `schedule` マッチする dataset を filter して `parallel.for` で yj-pipeline を fan-out 起動する。
- dataset の追加・削除は ops が `gsutil cp pipeline/datasets.json gs://...-yj-config/` で完結。\`terraform apply\` は不要 (workload identity を IaC から分離)。
- `yj-pipeline` の default args (dataset/geofabrik_url/bbox) は撤廃し、caller 必須化。

## 変更内容

| 種別 | リソース |
|---|---|
| 追加 | `yj_config` GCS bucket (versioning 有効、内容は TF 非管理) |
| 追加 | `pipeline/datasets.json` (bootstrap 用テンプレ、shikoku-latest 1 件) |
| 追加 | `sa-pipeline-dispatcher` SA |
| 追加 | IAM: dispatcher SA → yj-config `storage.objectViewer` |
| 追加 | IAM: dispatcher SA → project `workflows.invoker` |
| 追加 | `yj-pipeline-dispatcher` Workflow |
| 変更 | `yj-pipeline` Workflow: init から default args 撤廃 |
| 変更 | `yj-pipeline-trigger` scheduler: URI を dispatcher に切替 + unpause |

`terraform plan`: **5 to add, 2 to change, 0 to destroy**

## 設計決定

- **catalog field name は `dataset`**: issue 例の `name` ではなく既存 yj-pipeline の `args.dataset` 命名と整合させた。
- **datasets.json は TF 非管理**: bucket versioning + 手動 `gsutil cp` 運用 (issue 設計通り)。repo の `pipeline/datasets.json` はテンプレ兼ドキュメント。将来 CI 同期に拡張可能。
- **scheduler の paused は明示的に `false`**: 削除すると provider が変更を検知しない (現状 PAUSED のまま) ため。
- **dispatcher の workflows.invoker は project-level**: scheduler の既存パターンに合わせた。invoker が増えれば per-workflow に絞る。

## Test plan

- [ ] merge 後 `terraform apply`
- [ ] `gsutil cp pipeline/datasets.json gs://y-junctions-prod-yj-config/datasets.json` で bootstrap
- [ ] `gcloud workflows execute yj-pipeline-dispatcher --location=asia-northeast1` で手動キック
- [ ] `gcloud workflows executions list --workflow=yj-pipeline` で yj-pipeline 実行が新規生成されたことを確認
- [ ] yj-pipeline の 3 ジョブ (download / extract / load) が成功し、`y_junctions_pipeline.y_junctions` にレコードが追加されること

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)