### PR TITLE
fix: dispatcher の filter step を parallel.for に inline 化 (#237)

### DIFF
--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -460,7 +460,6 @@ resource "google_workflows_workflow" "dispatcher" {
         - init:
             assign:
               - schedule_filter: $${default(map.get(args, "schedule"), "monthly")}
-              - targets: []
         - read_catalog:
             call: http.get
             args:
@@ -483,35 +482,26 @@ resource "google_workflows_workflow" "dispatcher" {
                   - decode_body:
                       assign:
                         - catalog: $${json.decode(catalog_raw.body)}
-        # Workflows has no built-in `list.filter` / lambda — build the
-        # filtered list with a sequential loop + list.concat instead.
-        - filter_targets:
-            for:
-              value: ds
-              in: $${catalog}
-              steps:
-                - check_schedule:
-                    switch:
-                      - condition: $${ds.schedule == schedule_filter}
-                        steps:
-                          - add_target:
-                              assign:
-                                - targets: $${list.concat(targets, [ds])}
+        # Workflows has no built-in list.filter / lambda; do the schedule
+        # check inline in the parallel.for loop. Non-matching entries are
+        # cheap no-ops, no need for a separate filter pass.
         - fan_out:
             parallel:
               concurrency_limit: 4
               for:
                 value: ds
-                in: $${targets}
+                in: $${catalog}
                 steps:
-                  - run_pipeline:
-                      call: googleapis.workflowexecutions.v1.projects.locations.workflows.executions.create
-                      args:
-                        parent: projects/${var.project_id}/locations/${var.region}/workflows/${google_workflows_workflow.pipeline.name}
-                        body:
-                          argument: $${json.encode_to_string(ds)}
-        - done:
-            return: $${len(targets)}
+                  - dispatch_if_matches:
+                      switch:
+                        - condition: $${ds.schedule == schedule_filter}
+                          steps:
+                            - run_pipeline:
+                                call: googleapis.workflowexecutions.v1.projects.locations.workflows.executions.create
+                                args:
+                                  parent: projects/${var.project_id}/locations/${var.region}/workflows/${google_workflows_workflow.pipeline.name}
+                                  body:
+                                    argument: $${json.encode_to_string(ds)}
   EOT
 
   depends_on = [

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -460,6 +460,7 @@ resource "google_workflows_workflow" "dispatcher" {
         - init:
             assign:
               - schedule_filter: $${default(map.get(args, "schedule"), "monthly")}
+              - targets: []
         - read_catalog:
             call: http.get
             args:
@@ -482,9 +483,20 @@ resource "google_workflows_workflow" "dispatcher" {
                   - decode_body:
                       assign:
                         - catalog: $${json.decode(catalog_raw.body)}
+        # Workflows has no built-in `list.filter` / lambda — build the
+        # filtered list with a sequential loop + list.concat instead.
         - filter_targets:
-            assign:
-              - targets: $${list.filter(catalog, lambda(d, d.schedule == schedule_filter))}
+            for:
+              value: ds
+              in: $${catalog}
+              steps:
+                - check_schedule:
+                    switch:
+                      - condition: $${ds.schedule == schedule_filter}
+                        steps:
+                          - add_target:
+                              assign:
+                                - targets: $${list.concat(targets, [ds])}
         - fan_out:
             parallel:
               concurrency_limit: 4


### PR DESCRIPTION
## Summary

PR #251 (catalog dispatcher) の `terraform apply` が dispatcher Workflow 作成で停止:

```
Error: failed to build: error in step filter_targets:
       subworkflow 'list.filter' not found
```

issue #237 本文の dispatcher YAML 例は `list.filter(catalog, lambda(d, d.schedule == schedule_filter))` という擬似コード形式で、Workflows stdlib に `list.filter` および lambda 記法は実装されていません ([cloud.google.com/workflows/docs/reference/stdlib/](https://cloud.google.com/workflows/docs/reference/stdlib/) で確認)。

## 変更内容

filter 専用 step を撤去し、`parallel.for` の中に inline `switch` を置いて schedule 一致時のみ `run_pipeline` を呼ぶ構造に書き直す。非該当 entry は switch を no-op で抜けるだけなので別 filter pass は不要。

- `targets: []` 初期化を撤去
- `filter_targets` step (sequential loop + `list.concat`) を撤去
- `fan_out` 内の switch でフィルタと dispatch を兼用
- `done: return` step を撤去 (workflow は最終 step 完了で終わる)

## 影響範囲

- 失敗していた `google_workflows_workflow.dispatcher` が apply 通る状態に
- PR #251 の他リソース (yj_config bucket / dispatcher SA / IAM 2件 / yj-pipeline 更新) は既に作成済み
- 残 add は dispatcher Workflow + scheduler URI 切替

## Test plan

- [ ] merge 後 \`terraform apply\` が完走 (dispatcher 作成 + scheduler URI 切替)
- [ ] \`gsutil cp pipeline/datasets.json gs://y-junctions-prod-yj-config/datasets.json\` で bootstrap
- [ ] \`gcloud workflows execute yj-pipeline-dispatcher\` で手動キック
- [ ] yj-pipeline 実行が 2 件 (shikoku + chugoku) 並列で起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pipeline dispatcher workflow logic to directly iterate over catalog entries instead of using precomputed lists.
  * Removed the dataset count return value from the dispatcher workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->