### PR TITLE
chore: prepare-serving Job を追加し extract → serving 直書きを撤去 (#255)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,6 +28,10 @@ name = "pipeline-extract-three-way"
 path = "src/bin/pipeline_extract_three_way.rs"
 
 [[bin]]
+name = "pipeline-prepare-serving"
+path = "src/bin/pipeline_prepare_serving.rs"
+
+[[bin]]
 name = "pipeline-load-to-cockroach"
 path = "src/bin/pipeline_load_to_cockroach.rs"
 

--- a/backend/src/bin/pipeline_extract_three_way.rs
+++ b/backend/src/bin/pipeline_extract_three_way.rs
@@ -21,11 +21,6 @@ struct Args {
     #[arg(long)]
     extracted_output: String,
 
-    /// Serving-stage output URI — gs://...-yj-serving/... or file://...
-    /// (walking skeleton: identical to extracted output, no transformation yet)
-    #[arg(long)]
-    serving_output: String,
-
     /// Bounding box: min_lon,min_lat,max_lon,max_lat
     #[arg(long)]
     bbox: String,
@@ -40,10 +35,9 @@ async fn main() -> Result<()> {
     let bbox = parse_bbox(&args.bbox)?;
 
     tracing::info!(
-        "extract-three-way: {} -> {{extracted: {}, serving: {}}}",
+        "extract-three-way: {} -> {}",
         args.input,
-        args.extracted_output,
-        args.serving_output
+        args.extracted_output
     );
 
     let local_pbf = stage_pbf_locally(&args.input).await?;
@@ -57,10 +51,8 @@ async fn main() -> Result<()> {
     let parquet_bytes = write_parquet_bytes(&records)?;
     tracing::info!("Encoded {} bytes of Parquet", parquet_bytes.len());
 
-    let body = Bytes::from(parquet_bytes);
-    write_uri(&args.extracted_output, body.clone()).await?;
-    write_uri(&args.serving_output, body).await?;
-    tracing::info!("Wrote extracted + serving copies");
+    write_uri(&args.extracted_output, Bytes::from(parquet_bytes)).await?;
+    tracing::info!("Wrote extracted Parquet");
 
     Ok(())
 }

--- a/backend/src/bin/pipeline_prepare_serving.rs
+++ b/backend/src/bin/pipeline_prepare_serving.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use clap::Parser;
+
+use y_junction_backend::pipeline::storage::{read_uri, write_uri};
+
+#[derive(Parser, Debug)]
+#[command(name = "pipeline-prepare-serving")]
+#[command(about = "Stage extracted Parquet into the serving bucket", long_about = None)]
+struct Args {
+    /// Extracted-stage Parquet URI — gs://...-yj-extracted/... or file://...
+    #[arg(long)]
+    input: String,
+
+    /// Serving-stage Parquet URI — gs://...-yj-serving/... or file://...
+    #[arg(long)]
+    output: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+    tracing::info!("prepare-serving: {} -> {}", args.input, args.output);
+
+    let body = read_uri(&args.input).await?;
+    tracing::info!("Read {} bytes from extracted", body.len());
+
+    write_uri(&args.output, body).await?;
+    tracing::info!("Wrote serving copy");
+
+    Ok(())
+}

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app/backend
 RUN cargo build --release \
       --bin pipeline-download-osm \
       --bin pipeline-extract-three-way \
+      --bin pipeline-prepare-serving \
       --bin pipeline-load-to-cockroach
 
 FROM debian:bookworm-slim
@@ -26,6 +27,7 @@ RUN apt-get update \
 
 COPY --from=builder /app/backend/target/release/pipeline-download-osm /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-extract-three-way /usr/local/bin/
+COPY --from=builder /app/backend/target/release/pipeline-prepare-serving /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-load-to-cockroach /usr/local/bin/
 
 USER 65532:65532

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -1,7 +1,7 @@
 ###############################################################################
 # Cloud Run Jobs walking-skeleton (issue #229)
 #
-# Pipeline: download-osm -> extract-three-way -> load-to-cockroach
+# Pipeline: download-osm -> extract-three-way -> prepare-serving -> load-to-cockroach
 #
 # Workload parameters (dataset / geofabrik url / bbox) are NOT baked into
 # the infrastructure. Cloud Run Jobs declare only `command` here; arguments
@@ -156,6 +156,13 @@ resource "google_service_account" "pipeline_extract_three_way" {
   depends_on = [google_project_service.iam]
 }
 
+resource "google_service_account" "pipeline_prepare_serving" {
+  account_id   = "sa-pipeline-prepare-serving"
+  display_name = "Pipeline: prepare-serving"
+
+  depends_on = [google_project_service.iam]
+}
+
 resource "google_service_account" "pipeline_load_to_cockroach" {
   account_id   = "sa-pipeline-load-to-cockroach"
   display_name = "Pipeline: load-to-cockroach"
@@ -193,7 +200,7 @@ resource "google_storage_bucket_iam_member" "download_osm_writes_raw" {
   member = "serviceAccount:${google_service_account.pipeline_download_osm.email}"
 }
 
-# extract-three-way: read yj-raw, write yj-extracted + yj-serving
+# extract-three-way: read yj-raw, write yj-extracted
 resource "google_storage_bucket_iam_member" "extract_reads_raw" {
   bucket = google_storage_bucket.yj_raw.name
   role   = "roles/storage.objectViewer"
@@ -206,10 +213,17 @@ resource "google_storage_bucket_iam_member" "extract_writes_extracted" {
   member = "serviceAccount:${google_service_account.pipeline_extract_three_way.email}"
 }
 
-resource "google_storage_bucket_iam_member" "extract_writes_serving" {
+# prepare-serving: read yj-extracted, write yj-serving
+resource "google_storage_bucket_iam_member" "prepare_serving_reads_extracted" {
+  bucket = google_storage_bucket.yj_extracted.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_prepare_serving.email}"
+}
+
+resource "google_storage_bucket_iam_member" "prepare_serving_writes_serving" {
   bucket = google_storage_bucket.yj_serving.name
   role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${google_service_account.pipeline_extract_three_way.email}"
+  member = "serviceAccount:${google_service_account.pipeline_prepare_serving.email}"
 }
 
 # load-to-cockroach: read yj-serving, read DB secret
@@ -288,6 +302,35 @@ resource "google_cloud_run_v2_job" "pipeline_extract_three_way" {
   depends_on = [google_project_service.run]
 }
 
+resource "google_cloud_run_v2_job" "pipeline_prepare_serving" {
+  name     = "pipeline-prepare-serving"
+  location = var.region
+
+  deletion_protection = false
+
+  template {
+    template {
+      service_account = google_service_account.pipeline_prepare_serving.email
+      timeout         = "1800s"
+      max_retries     = 1
+
+      containers {
+        image   = local.pipeline_image
+        command = ["pipeline-prepare-serving"]
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "2Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [google_project_service.run]
+}
+
 resource "google_cloud_run_v2_job" "pipeline_load_to_cockroach" {
   name     = "pipeline-load-to-cockroach"
   location = var.region
@@ -349,6 +392,12 @@ resource "google_service_account_iam_member" "workflow_acts_as_extract" {
   member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
 }
 
+resource "google_service_account_iam_member" "workflow_acts_as_prepare_serving" {
+  service_account_id = google_service_account.pipeline_prepare_serving.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
+}
+
 resource "google_service_account_iam_member" "workflow_acts_as_load" {
   service_account_id = google_service_account.pipeline_load_to_cockroach.name
   role               = "roles/iam.serviceAccountUser"
@@ -403,11 +452,22 @@ resource "google_workflows_workflow" "pipeline" {
                         - $${raw_uri}
                         - "--extracted-output"
                         - $${extracted_uri}
-                        - "--serving-output"
-                        - $${serving_uri}
                         - "--bbox"
                         - $${bbox}
             result: extract_result
+        - prepare_serving:
+            call: googleapis.run.v2.projects.locations.jobs.run
+            args:
+              name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_prepare_serving.name}
+              body:
+                overrides:
+                  containerOverrides:
+                    - args:
+                        - "--input"
+                        - $${extracted_uri}
+                        - "--output"
+                        - $${serving_uri}
+            result: prepare_serving_result
         - load:
             call: googleapis.run.v2.projects.locations.jobs.run
             args:


### PR DESCRIPTION
## 概要
walking skeleton (#229) で `pipeline-extract-three-way` が extracted と serving に同一 Parquet を 2 回書いていた一時妥協 (`backend/src/bin/pipeline_extract_three_way.rs:60-62`) を撤去する。enrich 系 Job (#256, #257) を載せた時に extracted → serving 直書きでは標高 / panoid を反映できないため、新 Job `pipeline-prepare-serving` を間に挟む。

Closes #255

## 変更点

### backend
- `pipeline-prepare-serving` (新規 bin): extracted Parquet を読んで serving Parquet に pass-through で書き写す
- `pipeline-extract-three-way`: `--serving-output` 引数と 2 回目の `write_uri` を削除、log 文言修正

### infra
- `pipeline/Dockerfile`: 新 bin の build / COPY 追加
- `terraform/pipeline.tf`:
  - `pipeline_prepare_serving` SA / Cloud Run Job 追加
  - prepare-serving 用 IAM 追加（`yj-extracted` read / `yj-serving` write）
  - `extract_writes_serving` IAM 削除（extract は `yj-extracted` のみ書く）
  - workflow が prepare-serving SA を act-as できる IAM 追加
  - Workflows YAML: `extract → prepare-serving → load` の 3 ステップ化、extract から `--serving-output` 渡しを削除

## デプロイ順
密結合な変更なので **PR マージ → image build (#233 自動) → operator が `terraform apply`** の順でデプロイする必要あり。

- image だけ先行: 旧 workflow YAML が新 binary に `--serving-output` を渡してエラー
- terraform だけ先行: 新 workflow YAML が prepare-serving binary を呼ぶが旧 image に未含 → エラー

## 完了条件
- [x] `pipeline_extract_three_way.rs` から `--serving-output` 削除
- [x] `pipeline-prepare-serving` bin 追加 (extracted → serving pass-through)
- [x] Workflows YAML を 3 ステップ化
- [x] extract-three-way の serving バケット書き込み IAM 削除
- [x] cargo fmt / clippy -D warnings / test (129 件 pass)
- [x] terraform validate
- [ ] (deploy 後) Workflows 実行で extract → prepare-serving → load 全成功、`y_junctions` にレコードが入る — operator が `terraform apply` 後に確認

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --bins -- -D warnings
- [x] cargo test (lib 82件 + api_tests 47件 = 129件 pass)
- [x] terraform validate (pipeline.tf fmt-clean)
- [ ] post-deploy: workflow 手動キックで 3 ステップが順次成功し、Y 字路レコードが `y_junctions_pipeline.y_junctions` に入る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new 'prepare-serving' stage in the data pipeline that processes extracted data before the loading phase, enhancing the overall data workflow.

* **Infrastructure Updates**
  * Updated cloud infrastructure and pipeline orchestration to support the new preparation stage, with improved data flow management between extraction and loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->