### PR TITLE
chore: Dependabot PR の自動マージを有効化する workflow を追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,8 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened]
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Comment on major version updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "$PR_URL" --body "Major version update detected. auto-merge は無効化されています。手動レビューが必要です。"

--- a/.github/workflows/pr-ready.yml
+++ b/.github/workflows/pr-ready.yml
@@ -1,0 +1,117 @@
+name: PR Ready
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
+
+jobs:
+  ready:
+    name: ready
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Detect changed paths
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          BACKEND=false
+          FRONTEND=false
+          while IFS= read -r f; do
+            case "$f" in
+              backend/*|.github/workflows/backend-ci.yml) BACKEND=true ;;
+              frontend/*|.github/workflows/frontend-ci.yml) FRONTEND=true ;;
+            esac
+          done < <(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          echo "backend=$BACKEND" >> "$GITHUB_OUTPUT"
+          echo "frontend=$FRONTEND" >> "$GITHUB_OUTPUT"
+          echo "Backend changed: $BACKEND"
+          echo "Frontend changed: $FRONTEND"
+
+      - name: Wait for required CI checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          BACKEND: ${{ steps.changes.outputs.backend }}
+          FRONTEND: ${{ steps.changes.outputs.frontend }}
+        run: |
+          set -euo pipefail
+
+          EXPECTED=()
+          if [ "$BACKEND" = "true" ]; then
+            EXPECTED+=("Backend - Checks" "Backend - Test" "Backend - Security audit")
+          fi
+          if [ "$FRONTEND" = "true" ]; then
+            EXPECTED+=("Frontend - Checks" "Frontend - Test")
+          fi
+
+          if [ ${#EXPECTED[@]} -eq 0 ]; then
+            echo "No backend/frontend changes; nothing to wait on."
+            exit 0
+          fi
+
+          echo "Waiting for: ${EXPECTED[*]}"
+
+          INTERVAL=30
+          MAX_ITERATIONS=120
+
+          for i in $(seq 1 "$MAX_ITERATIONS"); do
+            RUNS=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100")
+
+            ALL_DONE=true
+            FAIL_LIST=()
+
+            for NAME in "${EXPECTED[@]}"; do
+              RUN=$(jq -c --arg n "$NAME" '
+                .check_runs
+                | map(select(.name == $n))
+                | sort_by(.started_at // "")
+                | last // null
+              ' <<< "$RUNS")
+
+              if [ "$RUN" = "null" ]; then
+                echo "  pending: $NAME (not started)"
+                ALL_DONE=false
+                continue
+              fi
+
+              STATUS=$(jq -r '.status' <<< "$RUN")
+              CONCLUSION=$(jq -r '.conclusion // ""' <<< "$RUN")
+
+              if [ "$STATUS" != "completed" ]; then
+                echo "  pending: $NAME ($STATUS)"
+                ALL_DONE=false
+                continue
+              fi
+
+              if [ "$CONCLUSION" = "success" ] || [ "$CONCLUSION" = "skipped" ]; then
+                echo "  ok: $NAME ($CONCLUSION)"
+              else
+                echo "  failed: $NAME ($CONCLUSION)"
+                FAIL_LIST+=("$NAME")
+              fi
+            done
+
+            if [ "$ALL_DONE" = "true" ]; then
+              if [ ${#FAIL_LIST[@]} -gt 0 ]; then
+                echo "Failed checks: ${FAIL_LIST[*]}"
+                exit 1
+              fi
+              echo "All required CIs passed."
+              exit 0
+            fi
+
+            echo "[$i/$MAX_ITERATIONS] sleeping ${INTERVAL}s"
+            sleep "$INTERVAL"
+          done
+
+          echo "Timed out waiting for required CIs."
+          exit 1


### PR DESCRIPTION
## Summary
- Dependabot PR が CI 通過後に自動 merge されるよう workflow 2 個を追加
- `pr-ready.yml`: 全 PR で起動するアグリゲータ。`gh api` で Backend/Frontend CI の完了を shell で待ち、関連する全部が success なら `ready` job を pass させる
- `dependabot-auto-merge.yml`: Dependabot 作成 PR で `dependabot/fetch-metadata` を使い update type を判定。minor/patch なら `gh pr merge --auto --squash`、major は手動レビューを促すコメントを残す

## マージ後の運用ステップ（要オーナー操作）
このPR自体は workflow を追加するだけ。Dependabot 自動マージを実際に効かせるには、merge 後に以下が必要:

1. `gh api -X PATCH repos/cozy-corner/y-junctions -f allow_auto_merge=true`
2. main branch protection を追加し、required status check として `pr-ready / ready` のみを指定
3. Enforce for admins は無効（脱出用）、required reviews は 0

## Test plan
- [ ] このPR自体で `pr-ready / ready` が起動し、backend/frontend の変更がないため即 success すること
- [ ] マージ後、設定変更を適用
- [ ] 次の Dependabot PR（来週月曜 09:00 JST）で auto-merge が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated merging of non-major dependency updates to streamline dependency maintenance
  * Added PR validation that waits for and verifies all required CI checks pass before marking PRs ready

<!-- end of auto-generated comment: release notes by coderabbit.ai -->