### PR TITLE
chore: extract-two-way Job 追加 + prepare-serving を multi-input merge に拡張 (#256)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,6 +28,10 @@ name = "pipeline-extract-three-way"
 path = "src/bin/pipeline_extract_three_way.rs"
 
 [[bin]]
+name = "pipeline-extract-two-way"
+path = "src/bin/pipeline_extract_two_way.rs"
+
+[[bin]]
 name = "pipeline-prepare-serving"
 path = "src/bin/pipeline_prepare_serving.rs"
 

--- a/backend/src/bin/pipeline_extract_two_way.rs
+++ b/backend/src/bin/pipeline_extract_two_way.rs
@@ -72,8 +72,7 @@ fn parse_bbox(s: &str) -> Result<(f64, f64, f64, f64)> {
 }
 
 /// `osmpbf::ElementReader` requires a real `File`, so non-`file://`
-/// inputs are downloaded to tmpfs before parsing. See
-/// `pipeline_extract_three_way.rs` for the streaming-deferred rationale.
+/// inputs are downloaded to tmpfs before parsing.
 enum LocalPbf {
     Existing(PathBuf),
     Owned(NamedTempFile),

--- a/backend/src/bin/pipeline_extract_two_way.rs
+++ b/backend/src/bin/pipeline_extract_two_way.rs
@@ -1,0 +1,101 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use clap::Parser;
+use tempfile::NamedTempFile;
+
+use y_junction_backend::importer::parser;
+use y_junction_backend::pipeline::parquet_io::{write_parquet_bytes, JunctionParquetRecord};
+use y_junction_backend::pipeline::storage::{read_uri, write_uri};
+
+#[derive(Parser, Debug)]
+#[command(name = "pipeline-extract-two-way")]
+#[command(about = "Extract 2-way Y-junctions from a PBF and write a Parquet file", long_about = None)]
+struct Args {
+    /// PBF source URI — file://..., gs://..., or https://...
+    #[arg(long)]
+    input: String,
+
+    /// Extracted-stage output URI — gs://...-yj-extracted/... or file://...
+    #[arg(long)]
+    extracted_output: String,
+
+    /// Bounding box: min_lon,min_lat,max_lon,max_lat
+    #[arg(long)]
+    bbox: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+    let bbox = parse_bbox(&args.bbox)?;
+
+    tracing::info!(
+        "extract-two-way: {} -> {}",
+        args.input,
+        args.extracted_output
+    );
+
+    let local_pbf = stage_pbf_locally(&args.input).await?;
+    let pbf_path = local_pbf.path_str();
+    tracing::info!("PBF staged at {}", pbf_path);
+
+    let junctions = parser::parse_pbf_two_way(pbf_path, bbox.0, bbox.1, bbox.2, bbox.3)?;
+    tracing::info!("Extracted {} 2-way junctions", junctions.len());
+
+    let records: Vec<JunctionParquetRecord> = junctions.into_iter().map(Into::into).collect();
+    let parquet_bytes = write_parquet_bytes(&records)?;
+    tracing::info!("Encoded {} bytes of Parquet", parquet_bytes.len());
+
+    write_uri(&args.extracted_output, Bytes::from(parquet_bytes)).await?;
+    tracing::info!("Wrote extracted Parquet");
+
+    Ok(())
+}
+
+fn parse_bbox(s: &str) -> Result<(f64, f64, f64, f64)> {
+    let parts: Vec<&str> = s.split(',').collect();
+    anyhow::ensure!(
+        parts.len() == 4,
+        "bbox must be min_lon,min_lat,max_lon,max_lat"
+    );
+    Ok((
+        parts[0].parse().context("min_lon")?,
+        parts[1].parse().context("min_lat")?,
+        parts[2].parse().context("max_lon")?,
+        parts[3].parse().context("max_lat")?,
+    ))
+}
+
+/// `osmpbf::ElementReader` requires a real `File`, so non-`file://`
+/// inputs are downloaded to tmpfs before parsing. See
+/// `pipeline_extract_three_way.rs` for the streaming-deferred rationale.
+enum LocalPbf {
+    Existing(PathBuf),
+    Owned(NamedTempFile),
+}
+
+impl LocalPbf {
+    fn path_str(&self) -> &str {
+        match self {
+            LocalPbf::Existing(p) => p.to_str().expect("non-UTF8 PBF path"),
+            LocalPbf::Owned(t) => t.path().to_str().expect("non-UTF8 PBF path"),
+        }
+    }
+}
+
+async fn stage_pbf_locally(input: &str) -> Result<LocalPbf> {
+    if let Some(rest) = input.strip_prefix("file://") {
+        return Ok(LocalPbf::Existing(PathBuf::from(rest)));
+    }
+    let bytes = read_uri(input).await?;
+    let mut tmp = NamedTempFile::new()?;
+    use std::io::Write as _;
+    tmp.as_file_mut().write_all(&bytes)?;
+    tmp.as_file_mut().flush()?;
+    Ok(LocalPbf::Owned(tmp))
+}

--- a/backend/src/bin/pipeline_prepare_serving.rs
+++ b/backend/src/bin/pipeline_prepare_serving.rs
@@ -1,15 +1,19 @@
 use anyhow::Result;
+use bytes::Bytes;
 use clap::Parser;
 
+use y_junction_backend::pipeline::parquet_io::{
+    read_parquet_bytes, write_parquet_bytes, JunctionParquetRecord,
+};
 use y_junction_backend::pipeline::storage::{read_uri, write_uri};
 
 #[derive(Parser, Debug)]
 #[command(name = "pipeline-prepare-serving")]
-#[command(about = "Stage extracted Parquet into the serving bucket", long_about = None)]
+#[command(about = "Merge extracted Parquet inputs into a single serving Parquet", long_about = None)]
 struct Args {
-    /// Extracted-stage Parquet URI — gs://...-yj-extracted/... or file://...
-    #[arg(long)]
-    input: String,
+    /// Extracted-stage Parquet URI — repeat for each input (3-way / 2-way / ...)
+    #[arg(long = "input", required = true)]
+    inputs: Vec<String>,
 
     /// Serving-stage Parquet URI — gs://...-yj-serving/... or file://...
     #[arg(long)]
@@ -22,12 +26,27 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let args = Args::parse();
-    tracing::info!("prepare-serving: {} -> {}", args.input, args.output);
+    tracing::info!(
+        "prepare-serving: {} inputs -> {}",
+        args.inputs.len(),
+        args.output
+    );
 
-    let body = read_uri(&args.input).await?;
-    tracing::info!("Read {} bytes from extracted", body.len());
+    let mut merged: Vec<JunctionParquetRecord> = Vec::new();
+    for input in &args.inputs {
+        let body = read_uri(input).await?;
+        tracing::info!("Read {} bytes from {}", body.len(), input);
+        let records = read_parquet_bytes(body)?;
+        tracing::info!("Decoded {} records from {}", records.len(), input);
+        merged.extend(records);
+    }
 
-    write_uri(&args.output, body).await?;
+    tracing::info!("Merged {} total records", merged.len());
+
+    let parquet_bytes = write_parquet_bytes(&merged)?;
+    tracing::info!("Encoded {} bytes of serving Parquet", parquet_bytes.len());
+
+    write_uri(&args.output, Bytes::from(parquet_bytes)).await?;
     tracing::info!("Wrote serving copy");
 
     Ok(())

--- a/backend/src/pipeline/parquet_io.rs
+++ b/backend/src/pipeline/parquet_io.rs
@@ -218,4 +218,36 @@ mod tests {
             assert_eq!(a.way_1_bridge, b.way_1_bridge);
         }
     }
+
+    #[test]
+    fn merge_two_inputs_roundtrip() {
+        let three_way: Vec<JunctionParquetRecord> = (0..5)
+            .map(|i| {
+                let mut j = sample();
+                j.osm_node_id = 1000 + i;
+                j.into()
+            })
+            .collect();
+        let two_way: Vec<JunctionParquetRecord> = (0..7)
+            .map(|i| {
+                let mut j = sample();
+                j.osm_node_id = 2000 + i;
+                j.into()
+            })
+            .collect();
+
+        let three_way_bytes = write_parquet_bytes(&three_way).unwrap();
+        let two_way_bytes = write_parquet_bytes(&two_way).unwrap();
+
+        let mut merged = read_parquet_bytes(Bytes::from(three_way_bytes)).unwrap();
+        merged.extend(read_parquet_bytes(Bytes::from(two_way_bytes)).unwrap());
+
+        let serving_bytes = write_parquet_bytes(&merged).unwrap();
+        let restored = read_parquet_bytes(Bytes::from(serving_bytes)).unwrap();
+
+        assert_eq!(restored.len(), 12);
+        let ids: Vec<i64> = restored.iter().map(|r| r.osm_node_id).collect();
+        assert!((1000..1005).all(|i| ids.contains(&i)));
+        assert!((2000..2007).all(|i| ids.contains(&i)));
+    }
 }

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app/backend
 RUN cargo build --release \
       --bin pipeline-download-osm \
       --bin pipeline-extract-three-way \
+      --bin pipeline-extract-two-way \
       --bin pipeline-prepare-serving \
       --bin pipeline-load-to-cockroach
 
@@ -27,6 +28,7 @@ RUN apt-get update \
 
 COPY --from=builder /app/backend/target/release/pipeline-download-osm /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-extract-three-way /usr/local/bin/
+COPY --from=builder /app/backend/target/release/pipeline-extract-two-way /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-prepare-serving /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-load-to-cockroach /usr/local/bin/
 

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -1,7 +1,7 @@
 ###############################################################################
-# Cloud Run Jobs walking-skeleton (issue #229)
+# Cloud Run Jobs pipeline
 #
-# Pipeline: download-osm -> [extract-three-way || extract-two-way] -> prepare-serving -> load-to-cockroach
+# download-osm -> [extract-three-way || extract-two-way] -> prepare-serving -> load-to-cockroach
 #
 # Workload parameters (dataset / geofabrik url / bbox) are NOT baked into
 # the infrastructure. Cloud Run Jobs declare only `command` here; arguments
@@ -497,8 +497,8 @@ resource "google_workflows_workflow" "pipeline" {
                         - $${raw_uri}
             result: download_result
         # 3-way / 2-way share the same PBF input; running them in parallel
-        # keeps failure isolation per #220 (one extractor's OOM doesn't kill
-        # the other) at the cost of parsing the PBF twice.
+        # keeps failure isolation (one extractor's OOM doesn't kill the other)
+        # at the cost of parsing the PBF twice.
         - extract:
             parallel:
               branches:

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -1,7 +1,7 @@
 ###############################################################################
 # Cloud Run Jobs walking-skeleton (issue #229)
 #
-# Pipeline: download-osm -> extract-three-way -> prepare-serving -> load-to-cockroach
+# Pipeline: download-osm -> [extract-three-way || extract-two-way] -> prepare-serving -> load-to-cockroach
 #
 # Workload parameters (dataset / geofabrik url / bbox) are NOT baked into
 # the infrastructure. Cloud Run Jobs declare only `command` here; arguments
@@ -156,6 +156,13 @@ resource "google_service_account" "pipeline_extract_three_way" {
   depends_on = [google_project_service.iam]
 }
 
+resource "google_service_account" "pipeline_extract_two_way" {
+  account_id   = "sa-pipeline-extract-two-way"
+  display_name = "Pipeline: extract-two-way"
+
+  depends_on = [google_project_service.iam]
+}
+
 resource "google_service_account" "pipeline_prepare_serving" {
   account_id   = "sa-pipeline-prepare-serving"
   display_name = "Pipeline: prepare-serving"
@@ -211,6 +218,19 @@ resource "google_storage_bucket_iam_member" "extract_writes_extracted" {
   bucket = google_storage_bucket.yj_extracted.name
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.pipeline_extract_three_way.email}"
+}
+
+# extract-two-way: read yj-raw, write yj-extracted
+resource "google_storage_bucket_iam_member" "extract_two_way_reads_raw" {
+  bucket = google_storage_bucket.yj_raw.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_extract_two_way.email}"
+}
+
+resource "google_storage_bucket_iam_member" "extract_two_way_writes_extracted" {
+  bucket = google_storage_bucket.yj_extracted.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.pipeline_extract_two_way.email}"
 }
 
 # prepare-serving: read yj-extracted, write yj-serving
@@ -288,6 +308,35 @@ resource "google_cloud_run_v2_job" "pipeline_extract_three_way" {
       containers {
         image   = local.pipeline_image
         command = ["pipeline-extract-three-way"]
+
+        resources {
+          limits = {
+            cpu    = "2"
+            memory = "8Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [google_project_service.run]
+}
+
+resource "google_cloud_run_v2_job" "pipeline_extract_two_way" {
+  name     = "pipeline-extract-two-way"
+  location = var.region
+
+  deletion_protection = false
+
+  template {
+    template {
+      service_account = google_service_account.pipeline_extract_two_way.email
+      timeout         = "1800s"
+      max_retries     = 1
+
+      containers {
+        image   = local.pipeline_image
+        command = ["pipeline-extract-two-way"]
 
         resources {
           limits = {
@@ -392,6 +441,12 @@ resource "google_service_account_iam_member" "workflow_acts_as_extract" {
   member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
 }
 
+resource "google_service_account_iam_member" "workflow_acts_as_extract_two_way" {
+  service_account_id = google_service_account.pipeline_extract_two_way.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
+}
+
 resource "google_service_account_iam_member" "workflow_acts_as_prepare_serving" {
   service_account_id = google_service_account.pipeline_prepare_serving.name
   role               = "roles/iam.serviceAccountUser"
@@ -425,8 +480,9 @@ resource "google_workflows_workflow" "pipeline" {
               - bbox: $${args.bbox}
               - run_date: $${text.substring(time.format(sys.now(), "Asia/Tokyo"), 0, 10)}
               - raw_uri: $${"gs://${google_storage_bucket.yj_raw.name}/osm/" + run_date + "/" + dataset + ".osm.pbf"}
-              - extracted_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + run_date + "/" + dataset + ".parquet"}
-              - serving_uri: $${"gs://${google_storage_bucket.yj_serving.name}/three-way/" + run_date + "/" + dataset + ".parquet"}
+              - extracted_three_way_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + run_date + "/" + dataset + ".parquet"}
+              - extracted_two_way_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/two-way/" + run_date + "/" + dataset + ".parquet"}
+              - serving_uri: $${"gs://${google_storage_bucket.yj_serving.name}/" + run_date + "/" + dataset + ".parquet"}
         - download:
             call: googleapis.run.v2.projects.locations.jobs.run
             args:
@@ -440,21 +496,44 @@ resource "google_workflows_workflow" "pipeline" {
                         - "--output"
                         - $${raw_uri}
             result: download_result
+        # 3-way / 2-way share the same PBF input; running them in parallel
+        # keeps failure isolation per #220 (one extractor's OOM doesn't kill
+        # the other) at the cost of parsing the PBF twice.
         - extract:
-            call: googleapis.run.v2.projects.locations.jobs.run
-            args:
-              name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_extract_three_way.name}
-              body:
-                overrides:
-                  containerOverrides:
-                    - args:
-                        - "--input"
-                        - $${raw_uri}
-                        - "--extracted-output"
-                        - $${extracted_uri}
-                        - "--bbox"
-                        - $${bbox}
-            result: extract_result
+            parallel:
+              branches:
+                - extract_three_way:
+                    steps:
+                      - run_extract_three_way:
+                          call: googleapis.run.v2.projects.locations.jobs.run
+                          args:
+                            name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_extract_three_way.name}
+                            body:
+                              overrides:
+                                containerOverrides:
+                                  - args:
+                                      - "--input"
+                                      - $${raw_uri}
+                                      - "--extracted-output"
+                                      - $${extracted_three_way_uri}
+                                      - "--bbox"
+                                      - $${bbox}
+                - extract_two_way:
+                    steps:
+                      - run_extract_two_way:
+                          call: googleapis.run.v2.projects.locations.jobs.run
+                          args:
+                            name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_extract_two_way.name}
+                            body:
+                              overrides:
+                                containerOverrides:
+                                  - args:
+                                      - "--input"
+                                      - $${raw_uri}
+                                      - "--extracted-output"
+                                      - $${extracted_two_way_uri}
+                                      - "--bbox"
+                                      - $${bbox}
         - prepare_serving:
             call: googleapis.run.v2.projects.locations.jobs.run
             args:
@@ -464,7 +543,9 @@ resource "google_workflows_workflow" "pipeline" {
                   containerOverrides:
                     - args:
                         - "--input"
-                        - $${extracted_uri}
+                        - $${extracted_three_way_uri}
+                        - "--input"
+                        - $${extracted_two_way_uri}
                         - "--output"
                         - $${serving_uri}
             result: prepare_serving_result


### PR DESCRIPTION
## 概要

#220 walking skeleton (#229 / #255) の続き。3-way Y字路だけが pipeline 化されていた状態から、2-way を新 Job 化して Workflows の `parallel.branches` で並列に走らせ、`prepare-serving` で両 extracted Parquet を 1 つの serving Parquet に merge する。region 非依存（catalog の全 dataset が対象）。

Closes #256

## 変更点

### backend
- `pipeline-extract-two-way` (新規 bin): `pipeline-extract-three-way` のミラー、`parser::parse_pbf_two_way` を呼ぶ薄いラッパ
- `pipeline-prepare-serving`: `--input` を `Vec<String>` (repeated) に変更、各 input を `read_parquet_bytes` で decode → 連結 → `write_parquet_bytes` で再エンコード
- `parquet_io.rs`: `merge_two_inputs_roundtrip` test 追加（2 input が 1 output に正しく merge されること）

### infra
- `pipeline/Dockerfile`: `pipeline-extract-two-way` を build & COPY に追加
- `terraform/pipeline.tf`:
  - SA `pipeline_extract_two_way` + `yj-raw` reader / `yj-extracted` writer IAM + workflow act-as IAM
  - Cloud Run Job (cpu=2, mem=8Gi、3-way と同設定)
  - Workflows YAML を `parallel.branches` 化、prepare-serving に `--input` × 2 で 3-way / 2-way URI を渡す
  - serving path を `three-way/<date>/<ds>.parquet` → `<date>/<ds>.parquet` に変更（merge 後は extract type 区別なし）

## 設計判断

- **`--input` repeated を採用**（vs `--three-way-input`/`--two-way-input` named flag）: enricher が増える度に flag が増えるのを避ける。順序非依存の merge なので named にする必要がない
- **3-way / 2-way を別 Job に分離維持**: failure isolation（一方の OOM が他方を巻き込まない）+ リソース最適化を優先。PBF を 2 回 parse するコストは #220 で許容済み
- **catalog 駆動には変更しない**: catalog 読みは dispatcher の責務。prepare-serving は workflow から URI list を受ければ十分

## デプロイ順

#255 と同様、image と workflow YAML が密結合のため：

1. PR merge → `pipeline image` 自動 build (#233)
2. operator が `terraform apply`

順序を逆にすると、新 workflow が旧 image の bin を呼んでエラー / 旧 workflow が新 bin に未知の引数を渡してエラー。

## 完了条件

- [x] `pipeline-extract-two-way` bin 追加
- [x] `prepare-serving` を multi-input merge に拡張 + unit test
- [x] Workflows YAML を parallel.branches 化、prepare-serving に 2 input
- [x] terraform に SA / IAM / Job / workflow act-as 追加
- [x] cargo fmt --check / clippy --bins -D warnings / cargo test (lib 83 + api 47 = 130 件 pass)
- [x] terraform validate (pipeline.tf fmt-clean)
- [ ] (deploy 後) Workflows 実行で 3-way / 2-way が並列に走り、両 extracted から merged serving が出来て、`y_junctions_pipeline.y_junctions` に 3-way + 2-way レコードが入る — operator が `terraform apply` 後に確認

## リスク / 未確認事項

- 日本全国 PBF (~2GB) で 2-way 抽出の memory が Cloud Run Job 8Gi 内に収まるか未測定。**パイロット bbox で実測値が出たらこの PR にコメント追記する**
- 旧 `three-way/<date>/<ds>.parquet` の serving Parquet は orphan 化するが、bucket lifecycle 90日で自動削除（`pipeline.tf:46-54`）

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --bins -- -D warnings
- [x] cargo test (lib 83 件 + api 47 件 = 130 件 pass、新 `merge_two_inputs_roundtrip` 含む)
- [x] terraform validate
- [ ] post-deploy: `gcloud workflows execute yj-pipeline --data='{"dataset":"shikoku-latest","geofabrik_url":"...","bbox":"134.0,34.3,134.1,34.4"}'` で 4 step (download → parallel(3w/2w) → prepare → load) が成功し、`y_junctions_pipeline.y_junctions` に 3-way + 2-way レコードが入る

🤖 Generated with [Claude Code](https://claude.com/claude-code)