### PR TITLE
chore: import-baidu-panoid を独立 Cloud Run Job + Cloud Scheduler 化 (#258)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
             pipeline:
               - 'pipeline/**'
               - 'backend/src/bin/pipeline_*.rs'
+              - 'backend/src/bin/import_baidu_panoid.rs'
               - 'backend/src/lib.rs'
               - 'backend/src/importer/**'
               - 'backend/src/pipeline/**'

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -18,7 +18,8 @@ RUN cargo build --release \
       --bin pipeline-extract-three-way \
       --bin pipeline-extract-two-way \
       --bin pipeline-prepare-serving \
-      --bin pipeline-load-to-cockroach
+      --bin pipeline-load-to-cockroach \
+      --bin import-baidu-panoid
 
 FROM debian:bookworm-slim
 RUN apt-get update \
@@ -31,6 +32,7 @@ COPY --from=builder /app/backend/target/release/pipeline-extract-three-way /usr/
 COPY --from=builder /app/backend/target/release/pipeline-extract-two-way /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-prepare-serving /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-load-to-cockroach /usr/local/bin/
+COPY --from=builder /app/backend/target/release/import-baidu-panoid /usr/local/bin/
 
 USER 65532:65532
 

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -687,3 +687,125 @@ resource "google_cloud_scheduler_job" "pipeline_trigger" {
 
   depends_on = [google_project_service.cloudscheduler]
 }
+
+###############################################################################
+# Baidu panoid enrichment (issue #258)
+#
+# Standalone Cloud Run Job triggered directly by Cloud Scheduler — NOT part of
+# the yj-pipeline DAG / dispatcher fan-out. Reasoning is in issue #258:
+# the existing importer uses chunked DB persistence (#214) that survives
+# transient failures by reading "what's already done" from the DB on each run,
+# and converting that to Parquet I/O would re-introduce the all-or-nothing
+# failure mode #214 fixed. Baidu's anti-bot constraints (single-thread,
+# 80-150ms paced) also make catalog fan-out / parallelization unsafe.
+#
+# Writes to the same y_junctions_pipeline DB as the rest of the pipeline; the
+# import-baidu-panoid binary is reused as-is from the operator-facing
+# /add-region flow (no new bin to keep in sync). Cron runs the day after the
+# main pipeline so newly-loaded Chinese junctions are picked up next cycle.
+###############################################################################
+
+resource "google_service_account" "pipeline_enrich_baidu_panoid" {
+  account_id   = "sa-pipeline-enrich-baidu"
+  display_name = "Pipeline: enrich-baidu-panoid (issue #258)"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_secret_manager_secret_iam_member" "enrich_baidu_reads_pipeline_db_secret" {
+  secret_id = google_secret_manager_secret.pipeline_db_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.pipeline_enrich_baidu_panoid.email}"
+}
+
+# Long-running by design: paced single-thread Baidu fetch can run for an hour
+# or more on full-country scale. Timeout-and-resume is the recovery mode —
+# chunked persistence (backend/src/importer/mod.rs) means the next cron run
+# picks up where this one stopped. max_retries=0 because in-Job retry would
+# just re-burn the timeout budget; the next cron is the retry.
+resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
+  name     = "pipeline-enrich-baidu-panoid"
+  location = var.region
+
+  deletion_protection = false
+
+  template {
+    template {
+      service_account = google_service_account.pipeline_enrich_baidu_panoid.email
+      timeout         = "3600s"
+      max_retries     = 0
+
+      containers {
+        image   = local.pipeline_image
+        command = ["import-baidu-panoid"]
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.pipeline_db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_secret_manager_secret_iam_member.enrich_baidu_reads_pipeline_db_secret,
+  ]
+}
+
+# Job-level invoker binding for the scheduler SA. Project-level would also
+# work but resource-level keeps the blast radius minimal — the scheduler SA
+# already has roles/workflows.invoker project-wide for the dispatcher; adding
+# run.invoker project-wide would let it trigger any future Job too.
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invokes_baidu_job" {
+  project  = google_cloud_run_v2_job.pipeline_enrich_baidu_panoid.project
+  location = google_cloud_run_v2_job.pipeline_enrich_baidu_panoid.location
+  name     = google_cloud_run_v2_job.pipeline_enrich_baidu_panoid.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.pipeline_scheduler.email}"
+}
+
+# Scheduler → Cloud Run Job direct trigger (no Workflows in between). Started
+# paused so the first execution is a manual `gcloud run jobs execute
+# pipeline-enrich-baidu-panoid` to verify Baidu reachability from
+# asia-northeast1 egress and DB writes against y_junctions_pipeline. Once
+# verified, unpause via `gcloud scheduler jobs resume yj-baidu-trigger
+# --location=asia-northeast1` (or a follow-up PR flipping `paused = false`).
+#
+# Schedule sits one day after the main pipeline (`0 3 1 * *`) so newly-
+# loaded Chinese junctions in y_junctions_pipeline are visible by the time
+# this runs, and the worst-case 2h pipeline wall-clock has finished.
+resource "google_cloud_scheduler_job" "baidu_trigger" {
+  name        = "yj-baidu-trigger"
+  region      = var.region
+  description = "Scheduled trigger for the Baidu panoid enrichment Job (issue #258)"
+  paused      = true
+  schedule    = "0 3 2 * *" # 03:00 JST on the 2nd of each month (1d after main pipeline)
+  time_zone   = "Asia/Tokyo"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_enrich_baidu_panoid.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.pipeline_scheduler.email
+    }
+  }
+
+  depends_on = [
+    google_project_service.cloudscheduler,
+    google_cloud_run_v2_job_iam_member.scheduler_invokes_baidu_job,
+  ]
+}

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -749,10 +749,16 @@ resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
           }
         }
 
+        # 2Gi to match the rest of the pipeline jobs. The importer collects
+        # all unprocessed junctions into a Vec<Junction> before iterating
+        # (backend/src/importer/mod.rs:184-194), so peak memory scales with
+        # the unprocessed-junction count — 512Mi was risky on first-run
+        # backfill at full-country scale. CPU stays at 1 vCPU; the workload
+        # is HTTP-bound, not compute-bound.
         resources {
           limits = {
             cpu    = "1"
-            memory = "512Mi"
+            memory = "2Gi"
           }
         }
       }


### PR DESCRIPTION
Closes #258

## Summary

- Workflows / dispatcher を経由しない standalone Cloud Run Job `pipeline-enrich-baidu-panoid` を追加し、Cloud Scheduler から直接トリガする
- Baidu の anti-bot 制約 (paced 単スレ、catalog fan-out 不可) と既存の chunked DB persistence (#214) を維持するため Parquet 中継せず、`DATABASE_URL` を pipeline DB secret (`cockroachdb-pipeline-url`) から注入して既存 `import-baidu-panoid` バイナリを再利用
- Cloud Scheduler は `paused = true` で apply。`schedule = "0 3 2 * *"` JST（メイン pipeline `0 3 1 * *` の 24 時間後）

## 変更ファイル

- **pipeline/Dockerfile**: `import-baidu-panoid` を build と COPY に追加
- **terraform/pipeline.tf** (末尾): SA / Secret IAM / Cloud Run Job / Job-level invoker IAM / Cloud Scheduler を追加。secret は既存 `cockroachdb-pipeline-url` を reuse、GCS 権限なし
- **.github/workflows/deploy.yml**: pipeline image rebuild の path filter に `backend/src/bin/import_baidu_panoid.rs` を追加（drift 防止）

## 設計議論で確定した方針

- **書き込み先 DB**: `y_junctions_pipeline`（pipeline 系の layering と一致、既存 secret reuse、user-visible 化は将来の prod promotion 機構の責務）
- **新規 bin は作らない**: 既存 `import-baidu-panoid` の CLI が `--refresh` 1 個で cron 用途に変更不要、二重管理回避（issue の「新 bin」提案からの逸脱は承認済み）
- **Job-level IAM**: `pipeline_scheduler` SA に project-wide `roles/run.invoker` ではなく Job リソース単位で付与し blast radius 最小化

## 完了条件 (issue #258) の状態

| 完了条件 | この PR | apply 後の運用で達成 |
|---|---|---|
| Cloud Scheduler 手動キックで Job 起動 → `baidu_panoramas` に panoid | コード実装 ✅ | 手動 `gcloud run jobs execute` で確認 |
| chunked persistence 機能（途中失敗 → 次回続行） | 既存挙動維持 ✅ | 実機初回で確認 |
| メインパイプラインに影響なし | コード上非干渉 ✅ | apply 後の plan 確認 |

## Test plan

- [x] `terraform fmt -check pipeline.tf` pass
- [x] `terraform validate` Success（無関係の dev override 警告のみ）
- [ ] CI で pipeline image rebuild が triggered されることを確認
- [ ] PR merge 後、main worktree で `terraform plan` → 想定通りのリソース追加のみ
- [ ] `terraform apply`
- [ ] `gcloud run jobs execute pipeline-enrich-baidu-panoid --region=asia-northeast1` で Baidu API 到達性 + DB 書き込み確認（**未検証リスク**: Cloud Run egress からの Baidu 反応）
- [ ] OK なら `gcloud scheduler jobs resume yj-baidu-trigger --location=asia-northeast1`（または follow-up PR で `paused = false`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD deployment configuration to support new enrichment service triggers.
  * Extended pipeline container image with new enrichment service binary.
  * Configured cloud infrastructure including service accounts, automated scheduling, and permissions for the enrichment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->