### PR TITLE
fix: enrich-baidu-panoid Job を daily cron + bounded retry に修正 (#258)

### DIFF
--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -720,9 +720,12 @@ resource "google_secret_manager_secret_iam_member" "enrich_baidu_reads_pipeline_
 
 # Long-running by design: paced single-thread Baidu fetch can run for an hour
 # or more on full-country scale. Timeout-and-resume is the recovery mode —
-# chunked persistence (backend/src/importer/mod.rs) means the next cron run
-# picks up where this one stopped. max_retries=0 because in-Job retry would
-# just re-burn the timeout budget; the next cron is the retry.
+# chunked persistence (backend/src/importer/mod.rs) means each fresh start
+# re-queries `find_without_baidu_panoid` and continues from the current DB
+# state, so a retry does NOT redo flushed work. With max_retries=3 a single
+# cron execution gets up to 4 attempts × 3600s ≈ 4h of wall-clock budget,
+# which is the difference between draining ~31K junctions per cron (1 attempt)
+# and ~125K (4 attempts) at the 80-150ms paced rate.
 resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
   name     = "pipeline-enrich-baidu-panoid"
   location = var.region
@@ -733,7 +736,7 @@ resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
     template {
       service_account = google_service_account.pipeline_enrich_baidu_panoid.email
       timeout         = "3600s"
-      max_retries     = 0
+      max_retries     = 3
 
       containers {
         image   = local.pipeline_image

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -718,20 +718,19 @@ resource "google_secret_manager_secret_iam_member" "enrich_baidu_reads_pipeline_
   member    = "serviceAccount:${google_service_account.pipeline_enrich_baidu_panoid.email}"
 }
 
-# Drain semantics: keep retrying until the queue is empty. Each fresh
-# attempt re-queries `find_without_baidu_panoid` (backend/src/importer/mod.rs)
-# and continues from the current DB state, so chunked persistence makes
-# retries effectively a no-op for already-processed work. The Job exits
-# naturally on success once nothing is left to process.
+# Drain semantics: paired with a daily cron and the idempotent skip in
+# `find_without_baidu_panoid` (backend/src/db/baidu_repository.rs:105-121),
+# which excludes both successfully-fetched junctions and tombstoned-empty
+# ones (panoid IS NULL rows from `bulk_mark_queried`). The Job processes a
+# bounded daily slice and exits — the next cron picks up tomorrow.
 #
-# Both knobs set generously (well within the 7-day / 10-retry Cloud Run Jobs
-# limits) so the per-cron budget is wide enough to drain any realistic
-# backlog: 11 attempts × 24h = 11 days of wall-clock per cron. Full-country
-# China (~600K junctions estimated from Japan-PBF density × China PBF size,
-# ~20h compute at 115ms paced) finishes within a single attempt; the
-# remaining retries are slack for transient Baidu failures. The timeout
-# setting itself is free — Cloud Run Jobs is billed per actual execution
-# second, so an unused budget costs nothing.
+# max_retries=2 (3 attempts max) gives ~3h of wall-clock per cron, enough
+# to drain ~93K junctions/day at the 80-150ms paced rate. Full-country
+# China (~600K, estimated from Japan PBF density × China PBF size) finishes
+# in ~7 daily runs. Bounded retry is also kinder to Baidu's anti-bot: a
+# 429 produces at most ~30s of in-cron retry hits before the Job exits,
+# leaving a 24h gap to next attempt. After drain, daily empty runs cost
+# ~$0.0001/day each (just container start + DB query).
 resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
   name     = "pipeline-enrich-baidu-panoid"
   location = var.region
@@ -741,8 +740,8 @@ resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
   template {
     template {
       service_account = google_service_account.pipeline_enrich_baidu_panoid.email
-      timeout         = "86400s"
-      max_retries     = 10
+      timeout         = "3600s"
+      max_retries     = 2
 
       containers {
         image   = local.pipeline_image
@@ -799,15 +798,16 @@ resource "google_cloud_run_v2_job_iam_member" "scheduler_invokes_baidu_job" {
 # verified, unpause via `gcloud scheduler jobs resume yj-baidu-trigger
 # --location=asia-northeast1` (or a follow-up PR flipping `paused = false`).
 #
-# Schedule sits one day after the main pipeline (`0 3 1 * *`) so newly-
-# loaded Chinese junctions in y_junctions_pipeline are visible by the time
-# this runs, and the worst-case 2h pipeline wall-clock has finished.
+# Daily cadence rather than monthly: the importer skips already-processed
+# junctions via `find_without_baidu_panoid` (idempotent + tombstone), so
+# repeated runs after drain are nearly free (~$0.0001/day). Daily also
+# means a 429-induced failure recovers in 24h instead of 30 days.
 resource "google_cloud_scheduler_job" "baidu_trigger" {
   name        = "yj-baidu-trigger"
   region      = var.region
   description = "Scheduled trigger for the Baidu panoid enrichment Job (issue #258)"
   paused      = true
-  schedule    = "0 3 2 * *" # 03:00 JST on the 2nd of each month (1d after main pipeline)
+  schedule    = "0 3 * * *" # 03:00 JST daily
   time_zone   = "Asia/Tokyo"
 
   http_target {

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -718,14 +718,20 @@ resource "google_secret_manager_secret_iam_member" "enrich_baidu_reads_pipeline_
   member    = "serviceAccount:${google_service_account.pipeline_enrich_baidu_panoid.email}"
 }
 
-# Long-running by design: paced single-thread Baidu fetch can run for an hour
-# or more on full-country scale. Timeout-and-resume is the recovery mode —
-# chunked persistence (backend/src/importer/mod.rs) means each fresh start
-# re-queries `find_without_baidu_panoid` and continues from the current DB
-# state, so a retry does NOT redo flushed work. With max_retries=3 a single
-# cron execution gets up to 4 attempts × 3600s ≈ 4h of wall-clock budget,
-# which is the difference between draining ~31K junctions per cron (1 attempt)
-# and ~125K (4 attempts) at the 80-150ms paced rate.
+# Drain semantics: keep retrying until the queue is empty. Each fresh
+# attempt re-queries `find_without_baidu_panoid` (backend/src/importer/mod.rs)
+# and continues from the current DB state, so chunked persistence makes
+# retries effectively a no-op for already-processed work. The Job exits
+# naturally on success once nothing is left to process.
+#
+# Both knobs set generously (well within the 7-day / 10-retry Cloud Run Jobs
+# limits) so the per-cron budget is wide enough to drain any realistic
+# backlog: 11 attempts × 24h = 11 days of wall-clock per cron. Full-country
+# China (~600K junctions estimated from Japan-PBF density × China PBF size,
+# ~20h compute at 115ms paced) finishes within a single attempt; the
+# remaining retries are slack for transient Baidu failures. The timeout
+# setting itself is free — Cloud Run Jobs is billed per actual execution
+# second, so an unused budget costs nothing.
 resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
   name     = "pipeline-enrich-baidu-panoid"
   location = var.region
@@ -735,8 +741,8 @@ resource "google_cloud_run_v2_job" "pipeline_enrich_baidu_panoid" {
   template {
     template {
       service_account = google_service_account.pipeline_enrich_baidu_panoid.email
-      timeout         = "3600s"
-      max_retries     = 3
+      timeout         = "86400s"
+      max_retries     = 10
 
       containers {
         image   = local.pipeline_image


### PR DESCRIPTION
Refs #258, follow-up to #262

## Summary

#262 で設定した `monthly cron` + `max_retries=0` + `timeout=3600s` の組み合わせは、Baidu の anti-bot リスクと drain 速度の両面で不適切だった。**daily cron + 少ない bounded retry** に切り替える。

## #262 の問題点

- **`max_retries=0`**: 「retry は budget を re-burn する」と書いたが誤り。Cloud Run Jobs の retry は fresh container として起動し、`find_without_baidu_panoid` を再 query するため、chunked persistence でフラッシュ済みは自然に除外される。retry は「続きから」処理を継続する。
- **`schedule="0 3 2 * *"` (monthly)**: drain 速度が遅く、429 失敗時の recovery も 30 日後になる。

## なぜ daily にできるか

`backend/src/db/baidu_repository.rs:105-121` の `find_without_baidu_panoid` は **3 状態を区別する idempotent クエリ**:

| junction の状態 | `baidu_panoramas` 行 | `panoid` | 次回 cron で再処理 |
|---|---|---|---|
| 未照会 | 行なし | — | ✅ 処理対象 |
| 照会済 + 取得成功 | 行あり | NOT NULL | ❌ スキップ |
| 照会済 + coverage 無し (tombstone) | 行あり | NULL | ❌ スキップ |

照会済は `LEFT JOIN ... WHERE bp.osm_node_id IS NULL` で完全に除外されるため、daily に変えても重複 API call は発生しない。drain 終了後の空回りは container 起動 + DB query 数秒のみ (~$0.0001/日)。

## 修正内容

```hcl
schedule    = "0 3 * * *"  # 毎日 03:00 JST (monthly → daily)
timeout     = "3600s"      # 1h (デフォルト水準)
max_retries = 2            # 3 attempts max
```

→ 1 cron 実行あたり最大 **3 attempts × 1h = 3h** wall-clock = 約 93K junctions/日 drain 可能。

## 効能

**drain 速度** (中国全土 ~600K 件、PBF サイズ比から推定):

| 設定 | 1 cron で処理可能 | 600K 件 drain |
|---|---|---|
| `monthly` + `max_retries=0` (修正前) | ~31K | 20 ヶ月 |
| `daily` + `max_retries=2` (本 PR) | ~93K | **~7 日** |

**429 anti-bot リスク**:
- monthly + max_retries=0: 1 cron 内で 5–60s sleep × 3 attempts = 数分の連続 hit、次は 30 日後
- **本 PR (daily + max_retries=2)**: 1 cron 内で最大 ~30 秒の retry hits、その後 24h gap で Baidu cooldown 十分

**コスト**:
- drain 終了後の空回り: ~$0.0001/日 × 365 = **年 $0.04** (誤差)
- 中国全土 backfill 1 回: ~20h × $0.000029/秒 = **約 $2** (前と同じ、daily に分割されるだけ)
- 設定値そのものに対する課金はない (Cloud Run Jobs は実行秒数ベース課金)

## 副次効果なし

- smoke test (catalog に China dataset 無し → 0 件空振り) には影響なし
- メモリ / CPU / paused 等は変更なし
- コメントを daily + idempotent + tombstone の semantics に書き直し
- スコープ外: Baidu rate-limit を clean exit にする `baidu.rs` 修正は別 issue (現在の `MAX_RATE_LIMIT_SLEEP=60s` は短いが、本 PR では触らない)

## Test plan

- [x] `terraform fmt -check pipeline.tf`: pass
- [x] `terraform validate`: Success
- [ ] PR merge 後 `terraform apply` で `pipeline-enrich-baidu-panoid` Job の `timeout` / `max_retries` と Scheduler `schedule` フィールドのみ in-place 更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)