### PR TITLE
fix: ElevationProvider が DEM5A/5B/5C の精度差を考慮しない問題を修正 (#267)

### DIFF
--- a/backend/src/importer/elevation.rs
+++ b/backend/src/importer/elevation.rs
@@ -112,14 +112,29 @@ impl ElevationProvider {
             pattern
         );
 
-        let mut mesh_to_file = HashMap::new();
+        // Index files by mesh code, keeping the highest-precision DEM type per mesh.
+        // GSI DEM5A (±0.3m) > 5B (±0.7m) > 5C (±1.4m). Same-precision ties are
+        // resolved by glob iteration order (last-wins). See issue #267.
+        let mut indexed: HashMap<String, (PathBuf, u8)> = HashMap::new();
         for path in xml_files {
-            if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
-                if let Some(mesh_code) = Self::extract_mesh_code(filename) {
-                    mesh_to_file.insert(mesh_code, path);
-                }
+            let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
+                continue;
+            };
+            let Some((mesh_code, new_pri)) = Self::extract_mesh_code_and_priority(filename) else {
+                continue;
+            };
+
+            if indexed
+                .get(&mesh_code)
+                .is_none_or(|(_, existing_pri)| new_pri >= *existing_pri)
+            {
+                indexed.insert(mesh_code, (path, new_pri));
             }
         }
+        let mesh_to_file: HashMap<String, PathBuf> = indexed
+            .into_iter()
+            .map(|(k, (path, _))| (k, path))
+            .collect();
 
         tracing::info!(
             "Initialized ElevationProvider: {} mesh codes indexed",
@@ -132,15 +147,24 @@ impl ElevationProvider {
         })
     }
 
-    fn extract_mesh_code(filename: &str) -> Option<String> {
-        if let Some(start) = filename.find("FG-GML-") {
-            let after_prefix = &filename[start + 7..];
-            let parts: Vec<&str> = after_prefix.split('-').collect();
-            if parts.len() >= 3 {
-                return Some(format!("{}-{}-{}", parts[0], parts[1], parts[2]));
-            }
+    /// Parses a GSI DEM filename and returns (mesh_code, precision_priority).
+    /// Priority: DEM5A=3, DEM5B=2, DEM5C=1, other DEM types=0.
+    /// Returns None if the filename does not match `FG-GML-pppp-qq-rr-...`.
+    fn extract_mesh_code_and_priority(filename: &str) -> Option<(String, u8)> {
+        let start = filename.find("FG-GML-")?;
+        let after_prefix = &filename[start + 7..];
+        let parts: Vec<&str> = after_prefix.split('-').collect();
+        if parts.len() < 3 {
+            return None;
         }
-        None
+        let mesh_code = format!("{}-{}-{}", parts[0], parts[1], parts[2]);
+        let priority = parts.get(3).map_or(0, |s| match *s {
+            "DEM5A" => 3,
+            "DEM5B" => 2,
+            "DEM5C" => 1,
+            _ => 0,
+        });
+        Some((mesh_code, priority))
     }
 
     /// Gets elevation at a specific coordinate
@@ -419,6 +443,68 @@ mod tests {
 
         assert_eq!(files_1, files_2, "Cache size should not increase");
         assert!(files_1 > 0, "At least one file should be cached");
+    }
+
+    #[test]
+    fn test_extract_mesh_code_and_priority_known_dem_types() {
+        // Precision: DEM5A=3 > DEM5B=2 > DEM5C=1 (issue #267).
+        assert_eq!(
+            ElevationProvider::extract_mesh_code_and_priority(
+                "FG-GML-5238-40-00-DEM5A-20210115.xml"
+            ),
+            Some(("5238-40-00".to_string(), 3))
+        );
+        assert_eq!(
+            ElevationProvider::extract_mesh_code_and_priority(
+                "FG-GML-5238-40-00-DEM5B-20210115.xml"
+            ),
+            Some(("5238-40-00".to_string(), 2))
+        );
+        assert_eq!(
+            ElevationProvider::extract_mesh_code_and_priority(
+                "FG-GML-5238-40-00-DEM5C-20210115.xml"
+            ),
+            Some(("5238-40-00".to_string(), 1))
+        );
+    }
+
+    #[test]
+    fn test_extract_mesh_code_and_priority_unknown_or_invalid() {
+        // Unknown DEM type still indexed (priority 0) so it wins only when
+        // no DEM5x sibling exists.
+        assert_eq!(
+            ElevationProvider::extract_mesh_code_and_priority(
+                "FG-GML-5238-40-00-DEM10B-20210115.xml"
+            ),
+            Some(("5238-40-00".to_string(), 0))
+        );
+        // Filenames not matching FG-GML-pppp-qq-rr-... return None.
+        assert_eq!(
+            ElevationProvider::extract_mesh_code_and_priority("not-a-gsi-file.xml"),
+            None
+        );
+        assert_eq!(
+            ElevationProvider::extract_mesh_code_and_priority("FG-GML-too-few.xml"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_priority_selection_dem5a_wins_over_5b_5c() {
+        // Mesh 5238-40-00 has DEM5A / 5B / 5C fixtures. After construction,
+        // the highest-precision file (DEM5A) must be selected regardless of
+        // glob iteration order. See issue #267.
+        let provider = ElevationProvider::new(&get_fixture_dir()).unwrap();
+        let path = provider
+            .mesh_to_file
+            .get("5238-40-00")
+            .expect("mesh 5238-40-00 should be indexed");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert!(
+            filename.contains("DEM5A"),
+            "Should select DEM5A over 5B/5C, got: {}",
+            filename
+        );
     }
 
     #[test]

--- a/backend/tests/fixtures/gsi/xml/FG-GML-5238-40-00-DEM5A-20211015.xml
+++ b/backend/tests/fixtures/gsi/xml/FG-GML-5238-40-00-DEM5A-20211015.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Dataset xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://fgd.gsi.go.jp/spec/2008/FGD_GMLSchema" xsi:schemaLocation="http://fgd.gsi.go.jp/spec/2008/FGD_GMLSchema FGD_GMLSchema.xsd" gml:id="Dataset1">
+ <gml:description>Test fixture for elevation tests</gml:description>
+ <gml:name>Test DEM Data</gml:name>
+<DEM gml:id="DEM001">
+ <fid>test-fixture-001</fid>
+ <type>5mメッシュ（標高）</type>
+ <mesh>test</mesh>
+ <coverage gml:id="DEM001-3">
+  <gml:boundedBy>
+   <gml:Envelope srsName="fguuid:jgd2024.bl">
+    <gml:lowerCorner>35.0 138.0</gml:lowerCorner>
+    <gml:upperCorner>35.01 138.01</gml:upperCorner>
+   </gml:Envelope>
+  </gml:boundedBy>
+  <gml:gridDomain>
+   <gml:Grid dimension="2" gml:id="DEM001-4">
+    <gml:limits>
+     <gml:GridEnvelope>
+      <gml:low>0 0</gml:low>
+      <gml:high>4 4</gml:high>
+     </gml:GridEnvelope>
+    </gml:limits>
+    <gml:axisLabels>x y</gml:axisLabels>
+   </gml:Grid>
+  </gml:gridDomain>
+  <gml:rangeSet>
+   <gml:DataBlock>
+    <gml:rangeParameters>
+     <gml:QuantityList uom="DEM構成点"></gml:QuantityList>
+    </gml:rangeParameters>
+<gml:tupleList>
+地表面,100.0
+地表面,101.0
+地表面,102.0
+地表面,103.0
+地表面,104.0
+地表面,110.0
+地表面,111.0
+地表面,112.0
+地表面,113.0
+地表面,114.0
+地表面,120.0
+地表面,121.0
+地表面,122.0
+地表面,123.0
+地表面,124.0
+地表面,130.0
+地表面,131.0
+地表面,132.0
+地表面,133.0
+地表面,134.0
+地表面,140.0
+地表面,141.0
+地表面,142.0
+地表面,143.0
+地表面,144.0
+</gml:tupleList>
+   </gml:DataBlock>
+  </gml:rangeSet>
+  <gml:coverageFunction>
+   <gml:GridFunction>
+    <gml:sequenceRule order="+x-y">Linear</gml:sequenceRule>
+    <gml:startPoint>0 0</gml:startPoint>
+   </gml:GridFunction>
+  </gml:coverageFunction>
+ </coverage>
+</DEM>
+</Dataset>

--- a/backend/tests/fixtures/gsi/xml/FG-GML-5238-40-00-DEM5C-20211015.xml
+++ b/backend/tests/fixtures/gsi/xml/FG-GML-5238-40-00-DEM5C-20211015.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Dataset xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://fgd.gsi.go.jp/spec/2008/FGD_GMLSchema" xsi:schemaLocation="http://fgd.gsi.go.jp/spec/2008/FGD_GMLSchema FGD_GMLSchema.xsd" gml:id="Dataset1">
+ <gml:description>Test fixture for elevation tests</gml:description>
+ <gml:name>Test DEM Data</gml:name>
+<DEM gml:id="DEM001">
+ <fid>test-fixture-001</fid>
+ <type>5mメッシュ（標高）</type>
+ <mesh>test</mesh>
+ <coverage gml:id="DEM001-3">
+  <gml:boundedBy>
+   <gml:Envelope srsName="fguuid:jgd2024.bl">
+    <gml:lowerCorner>35.0 138.0</gml:lowerCorner>
+    <gml:upperCorner>35.01 138.01</gml:upperCorner>
+   </gml:Envelope>
+  </gml:boundedBy>
+  <gml:gridDomain>
+   <gml:Grid dimension="2" gml:id="DEM001-4">
+    <gml:limits>
+     <gml:GridEnvelope>
+      <gml:low>0 0</gml:low>
+      <gml:high>4 4</gml:high>
+     </gml:GridEnvelope>
+    </gml:limits>
+    <gml:axisLabels>x y</gml:axisLabels>
+   </gml:Grid>
+  </gml:gridDomain>
+  <gml:rangeSet>
+   <gml:DataBlock>
+    <gml:rangeParameters>
+     <gml:QuantityList uom="DEM構成点"></gml:QuantityList>
+    </gml:rangeParameters>
+<gml:tupleList>
+地表面,100.0
+地表面,101.0
+地表面,102.0
+地表面,103.0
+地表面,104.0
+地表面,110.0
+地表面,111.0
+地表面,112.0
+地表面,113.0
+地表面,114.0
+地表面,120.0
+地表面,121.0
+地表面,122.0
+地表面,123.0
+地表面,124.0
+地表面,130.0
+地表面,131.0
+地表面,132.0
+地表面,133.0
+地表面,134.0
+地表面,140.0
+地表面,141.0
+地表面,142.0
+地表面,143.0
+地表面,144.0
+</gml:tupleList>
+   </gml:DataBlock>
+  </gml:rangeSet>
+  <gml:coverageFunction>
+   <gml:GridFunction>
+    <gml:sequenceRule order="+x-y">Linear</gml:sequenceRule>
+    <gml:startPoint>0 0</gml:startPoint>
+   </gml:GridFunction>
+  </gml:coverageFunction>
+ </coverage>
+</DEM>
+</Dataset>


### PR DESCRIPTION
## Summary

- `ElevationProvider::new()` で同一メッシュコードに DEM5A / 5B / 5C が混在する場合、従来は glob 順次第で後勝ち insert され、低精度版 (5B/5C) が高精度版 (5A) を上書きしうる非決定的挙動だった
- 精度 (DEM5A=±0.3m > 5B=±0.7m > 5C=±1.4m) で常に高精度版を採用するよう index 構築を修正
- 同一種別内では glob 順による後勝ちを維持（既存挙動）
- 未知の DEM 種別は priority=0 で index（5x が無いメッシュではフォールバック採用、後方互換）

Closes #267

## 変更内容

- `extract_mesh_code(filename) -> Option<String>` を `extract_mesh_code_and_priority(filename) -> Option<(String, u8)>` に置換
- `new()` の index 構築ループで priority 比較し、新しい候補が既存より低精度なら挿入をスキップ
- fixture 追加: `FG-GML-5238-40-00-DEM5A-20211015.xml` / `FG-GML-5238-40-00-DEM5C-20211015.xml`（既存 `DEM5B` と同一メッシュ、同一内容）

## Test plan

- [x] `cargo test importer::elevation` — 10 tests pass（新規 3 件含む: `test_extract_mesh_code_and_priority_known_dem_types` / `_unknown_or_invalid` / `test_priority_selection_dem5a_wins_over_5b_5c`）
- [x] `cargo test`（backend 全体）— 133 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] RED 確認: 修正前は `got: FG-GML-5238-40-00-DEM5C-20211015.xml` で fail、修正後は DEM5A が選ばれて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)