### PR TITLE
chore(ci): pin sqlx-cli to "0.8" to avoid 0.9.0 breaking rustc 1.90 (#271)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install sqlx-cli
         run: |
           if ! command -v sqlx &> /dev/null; then
-            cargo install sqlx-cli --version "0.8" --no-default-features --features postgres
+            cargo install sqlx-cli --version "^0.8" --no-default-features --features postgres
           fi
 
       - name: Create test database

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install sqlx-cli
         run: |
           if ! command -v sqlx &> /dev/null; then
-            cargo install sqlx-cli --no-default-features --features postgres
+            cargo install sqlx-cli --version "0.8" --no-default-features --features postgres
           fi
 
       - name: Create test database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install SQLx CLI
         if: steps.cache-sqlx.outputs.cache-hit != 'true'
-        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
+        run: cargo install sqlx-cli --version "0.8" --no-default-features --features postgres,rustls
 
       - name: Run database migrations
         working-directory: backend
@@ -431,7 +431,7 @@ jobs:
 
       - name: Install SQLx CLI
         if: steps.cache-sqlx.outputs.cache-hit != 'true'
-        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
+        run: cargo install sqlx-cli --version "0.8" --no-default-features --features postgres,rustls
 
       - name: Run database migrations (pipeline staging)
         working-directory: backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install SQLx CLI
         if: steps.cache-sqlx.outputs.cache-hit != 'true'
-        run: cargo install sqlx-cli --version "0.8" --no-default-features --features postgres,rustls
+        run: cargo install sqlx-cli --version "^0.8" --no-default-features --features postgres,rustls
 
       - name: Run database migrations
         working-directory: backend
@@ -431,7 +431,7 @@ jobs:
 
       - name: Install SQLx CLI
         if: steps.cache-sqlx.outputs.cache-hit != 'true'
-        run: cargo install sqlx-cli --version "0.8" --no-default-features --features postgres,rustls
+        run: cargo install sqlx-cli --version "^0.8" --no-default-features --features postgres,rustls
 
       - name: Run database migrations (pipeline staging)
         working-directory: backend


### PR DESCRIPTION
## Summary
- `.github/workflows/backend-ci.yml` および `.github/workflows/deploy.yml` の `cargo install sqlx-cli` に `--version "0.8"` を追加（3箇所）。
- sqlx-cli 0.9.0 (2026-05-21 リリース) が rustc 1.94 を要求するため、CI の rustc 1.90 で fresh install が失敗していた。
- バージョン表記は `backend/Cargo.toml:48` の `sqlx = "0.8"` と揃えた（caret デフォルトで `>=0.8, <0.9`）。

## Why
- PR #270 で `Backend - Test` が install で fail。原因は version 未固定で crates.io 最新の 0.9.0 を引いたため。
- main がこれまで通っていたのは `actions/cache@v5` の cache hit で install が skip されていたから。cache 期限切れ (7日) や新規ブランチで再現する。

## Dependabot との関係
- `cargo` 更新で `sqlx 0.9` 系の PR が来ても CI red になり保護として機能（rustc 1.94 + workflow `--version` を同期 bump する人手作業が必要）。
- `0.8.x` のパッチ更新は通常通り auto-merge 可能。

## Test plan
- [ ] CI (`Backend - Test`) が緑になる
- [ ] cache miss の経路でも install が通る（必要なら別ブランチで cache key 変更を試す）

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration tooling version pinning in deployment pipelines to ensure consistency across CI/CD environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozy-corner/y-junctions/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->