### PR TITLE
chore: enrich-elevation Job を pipeline DAG に追加 (#257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ terraform apply   # 変更を適用
 
 ### DEM データ更新（年次運用、Cloud Run Jobs パイプライン）
 
-`enrich-elevation` Cloud Run Job は `gs://${project}-yj-raw/dem/{YYYYMMDD}/` 配下の GSI DEM XML を読み込んで Y 字路に標高を付与する。DEM5A は GSI 規約上自動取得不可のため、operator が年次で手動アップロードする：
+`enrich-elevation` Cloud Run Job は `gs://${PROJECT_ID}-yj-raw/dem/{YYYYMMDD}/` 配下の GSI DEM XML を読み込んで Y 字路に標高を付与する。DEM5A は GSI 規約上自動取得不可のため、operator が年次で手動アップロードする：
 
 ```bash
 # 1. 国土地理院から DEM5A を入手し ~/y-junctions-data/gsi/xml/ に展開（既存と同様）

--- a/README.md
+++ b/README.md
@@ -472,6 +472,37 @@ terraform apply   # 変更を適用
 
 新規地域のデータを追加して本番に反映するには `/add-region` スキルを使用してください。
 
+### DEM データ更新（年次運用、Cloud Run Jobs パイプライン）
+
+`enrich-elevation` Cloud Run Job は `gs://${project}-yj-raw/dem/{YYYYMMDD}/` 配下の GSI DEM XML を読み込んで Y 字路に標高を付与する。DEM5A は GSI 規約上自動取得不可のため、operator が年次で手動アップロードする：
+
+```bash
+# 1. 国土地理院から DEM5A を入手し ~/y-junctions-data/gsi/xml/ に展開（既存と同様）
+
+# 2. gzip で圧縮（~10:1 縮小、yj-raw Coldline と合わせて月額 $0.17 程度）。
+# -k で元の .xml を残す：upload リトライ時の再取得回避 + ローカルの
+# import-elevation CLI が引き続き同じディレクトリを使えるように。
+gzip -k ~/y-junctions-data/gsi/xml/*.xml
+
+# 3. 日付 prefix にアップロード（YYYYMMDD、enrich-elevation Job が辞書順
+# 最大の YYYYMMDD subdir を採用）
+gsutil cp ~/y-junctions-data/gsi/xml/*.xml.gz \
+  gs://${PROJECT_ID}-yj-raw/dem/$(date +%Y%m%d)/
+
+# 4. 月次パイプライン自走を待つか、refresh したい時は手動キック。
+# 引数は pipeline/datasets.json の該当 entry をコピペすればよい：
+gcloud workflows execute yj-pipeline \
+  --location=asia-northeast1 \
+  --data='{"dataset":"shikoku-latest","geofabrik_url":"https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf","bbox":"134.0,34.3,134.1,34.4","region":"japan"}'
+```
+
+DEM は `dem/` prefix が lifecycle 自動削除の対象外（terraform/pipeline.tf
+で `matches_prefix = ["osm/"]` 設定）。**古い DEM 日付 prefix の掃除は
+operator が新 DEM upload 時に手動で行う：**
+```bash
+gsutil -m rm -r gs://${PROJECT_ID}-yj-raw/dem/20250515/  # 一年前の DEM 例
+```
+
 ## ブランチ命名規則
 
 PRのマージ時にGitHub Releasesのドラフトが自動生成されます。ブランチ名によって自動的にラベルが付与されます：

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3750,6 +3750,7 @@ dependencies = [
  "clap",
  "dashmap",
  "dotenvy",
+ "flate2",
  "futures",
  "geo",
  "glob",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,6 +39,10 @@ path = "src/bin/pipeline_prepare_serving.rs"
 name = "pipeline-load-to-cockroach"
 path = "src/bin/pipeline_load_to_cockroach.rs"
 
+[[bin]]
+name = "pipeline-enrich-elevation"
+path = "src/bin/pipeline_enrich_elevation.rs"
+
 [dependencies]
 anyhow = "1"
 axum = "0.8"
@@ -49,6 +53,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json", "chro
 osmpbf = "0.3"
 geo = "0.33"
 glob = "0.3"
+flate2 = "1"
 roxmltree = "0.21"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/backend/src/bin/pipeline_enrich_elevation.rs
+++ b/backend/src/bin/pipeline_enrich_elevation.rs
@@ -1,0 +1,257 @@
+//! Enrich-stage Cloud Run Job (issue #257).
+//!
+//! Reads extracted-stage junctions (3-way or 2-way), computes DEM-based
+//! elevation enrichment per junction using the shared
+//! [`y_junction_backend::importer::compute_elevation_enrichment`] helper,
+//! and writes an `osm_node_id`-keyed side parquet to the enriched stage.
+//! Rows whose calculation fails (no DEM coverage, partial mesh, etc.) are
+//! simply absent from the output — `prepare-serving` reconstructs the
+//! "no enrichment" state via LEFT JOIN.
+//!
+//! DEM XML files are accessed through a Cloud Run gen2 GCS volume mount
+//! at the path supplied via `--dem-dir`; the underlying yj-raw bucket
+//! uses Coldline storage with gzip-compressed XML.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use bytes::Bytes;
+use clap::Parser;
+use rayon::prelude::*;
+
+use y_junction_backend::importer::compute_elevation_enrichment;
+use y_junction_backend::importer::elevation::ElevationProvider;
+use y_junction_backend::pipeline::parquet_io::{
+    read_parquet_bytes, write_parquet_bytes, ElevationParquetRecord, JunctionParquetRecord,
+};
+use y_junction_backend::pipeline::storage::{read_uri, write_uri};
+
+#[derive(Parser, Debug)]
+#[command(name = "pipeline-enrich-elevation")]
+#[command(
+    about = "Compute DEM-based elevation enrichment for extracted Y-junctions and write a side parquet keyed by osm_node_id"
+)]
+struct Args {
+    /// Extracted-stage Parquet URI — gs://...-yj-extracted/... or file://...
+    #[arg(long)]
+    input: String,
+
+    /// Enriched-stage output Parquet URI — gs://...-yj-enriched/elevations/... or file://...
+    #[arg(long)]
+    output: String,
+
+    /// Directory containing GSI DEM XML files. Two layouts are supported:
+    ///   - **direct**: `{dir}/*.xml{,.gz}` or `{dir}/xml/*.xml{,.gz}` —
+    ///     used in local dev / tests
+    ///   - **prefix-versioned**: `{dir}/{YYYYMMDD}/*.xml{,.gz}` — used by
+    ///     the Cloud Run gen2 GCS FUSE mount; the binary picks the
+    ///     lexicographically maximum subdirectory
+    #[arg(long)]
+    dem_dir: String,
+}
+
+/// Resolve `--dem-dir` to the directory the ElevationProvider should read.
+///
+/// Prefers a date-versioned subdirectory `{YYYYMMDD}/` when one is present,
+/// even if the base also has stray XML files or a legacy `xml/` subdir —
+/// the Cloud Run mount of yj-raw should never have direct XMLs at the
+/// mount root, so any direct match there is almost certainly a stray
+/// (operator one-off, partial cleanup) that would otherwise preempt the
+/// real DEM snapshot.
+///
+/// Only subdirs matching `^\d{8}$` are eligible to prevent non-date names
+/// (e.g. `staging/`, `tmp/`) from being lex-sorted ahead of real
+/// `YYYYMMDD/` entries — ASCII digits (0x30-0x39) sort lower than
+/// lowercase letters (0x61-0x7A), so a subdir like `staging/` would have
+/// silently won under a naive lex-max selection.
+fn resolve_dem_dir(base: &str) -> Result<PathBuf> {
+    let base_path = Path::new(base);
+
+    // First: pick lex-max YYYYMMDD subdir if any exists.
+    let mut date_subdirs: Vec<PathBuf> = std::fs::read_dir(base_path)
+        .with_context(|| format!("Failed to read DEM base dir: {}", base))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(is_yyyymmdd)
+                .unwrap_or(false)
+        })
+        .collect();
+    date_subdirs.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+    if let Some(latest) = date_subdirs.pop() {
+        return Ok(latest);
+    }
+
+    // Fallback for local-dev / tests: direct layout with XMLs at base level
+    // or under a legacy `xml/` subdir.
+    let direct_patterns = [
+        format!("{}/*.xml", base),
+        format!("{}/*.xml.gz", base),
+        format!("{}/xml/*.xml", base),
+        format!("{}/xml/*.xml.gz", base),
+    ];
+    for p in &direct_patterns {
+        if glob::glob(p)?.filter_map(|e| e.ok()).next().is_some() {
+            return Ok(base_path.to_path_buf());
+        }
+    }
+
+    Err(anyhow!(
+        "No DEM date-versioned subdir (YYYYMMDD/) nor direct XML files found under {}",
+        base
+    ))
+}
+
+fn is_yyyymmdd(s: &str) -> bool {
+    s.len() == 8 && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+    tracing::info!("enrich-elevation: {} -> {}", args.input, args.output);
+    tracing::info!("DEM base dir: {}", args.dem_dir);
+
+    let resolved = resolve_dem_dir(&args.dem_dir)?;
+    tracing::info!("Resolved DEM dir: {}", resolved.display());
+
+    let provider = ElevationProvider::new(
+        resolved
+            .to_str()
+            .ok_or_else(|| anyhow!("Non-UTF8 DEM path: {:?}", resolved))?,
+    )
+    .with_context(|| format!("Failed to initialize ElevationProvider from {:?}", resolved))?;
+
+    let bytes = read_uri(&args.input).await?;
+    tracing::info!("Read {} bytes of extracted Parquet", bytes.len());
+    let extracted: Vec<JunctionParquetRecord> = read_parquet_bytes(bytes)?;
+    tracing::info!("Decoded {} extracted records", extracted.len());
+
+    // Compute enrichment per junction in parallel; out-of-coverage rows
+    // (e.g. China, or partial DEM mesh) naturally return None and are
+    // dropped from the output — the row is then absent from the side
+    // table, which prepare-serving renders as "no enrichment" via LEFT JOIN.
+    let enriched: Vec<ElevationParquetRecord> = extracted
+        .par_iter()
+        .filter_map(|j| {
+            let bearings = [j.bearing_1, j.bearing_2, j.bearing_3];
+            let angles = [j.angle_1 as i16, j.angle_2 as i16, j.angle_3 as i16];
+            let e = compute_elevation_enrichment(&provider, j.lat, j.lon, &bearings, &angles)?;
+            Some(ElevationParquetRecord {
+                osm_node_id: j.osm_node_id,
+                elevation: e.elevation as f32,
+                neighbor_elevation_1: e.neighbor_elevations[0] as f32,
+                neighbor_elevation_2: e.neighbor_elevations[1] as f32,
+                neighbor_elevation_3: e.neighbor_elevations[2] as f32,
+                elevation_diff_1: e.elevation_diffs[0] as f32,
+                elevation_diff_2: e.elevation_diffs[1] as f32,
+                elevation_diff_3: e.elevation_diffs[2] as f32,
+                min_angle_index: e.min_angle_index as i32,
+                min_elevation_diff: e.min_elevation_diff as f32,
+                max_elevation_diff: e.max_elevation_diff as f32,
+            })
+        })
+        .collect();
+
+    tracing::info!(
+        "Computed enrichment for {} / {} junctions",
+        enriched.len(),
+        extracted.len()
+    );
+
+    let bytes_out = write_parquet_bytes(&enriched)?;
+    tracing::info!("Encoded {} bytes of enriched Parquet", bytes_out.len());
+
+    write_uri(&args.output, Bytes::from(bytes_out)).await?;
+    tracing::info!("Wrote enriched Parquet");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yyyymmdd_format_check() {
+        assert!(is_yyyymmdd("20260523"));
+        assert!(is_yyyymmdd("99991231"));
+        assert!(!is_yyyymmdd("2026-05-23"));
+        assert!(!is_yyyymmdd("staging"));
+        assert!(!is_yyyymmdd("tmp"));
+        assert!(!is_yyyymmdd("2026052")); // too short
+        assert!(!is_yyyymmdd("202605231")); // too long
+        assert!(!is_yyyymmdd(""));
+    }
+
+    #[test]
+    fn resolve_dem_dir_prefers_date_subdir_over_xml_subdir() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path();
+
+        // Stray legacy xml/ subdir with files — must NOT preempt the date subdir.
+        std::fs::create_dir_all(base.join("xml")).unwrap();
+        std::fs::write(base.join("xml/stray.xml"), b"<x/>").unwrap();
+
+        // Real date-versioned subdir.
+        let date_dir = base.join("20260523");
+        std::fs::create_dir_all(&date_dir).unwrap();
+        std::fs::write(date_dir.join("FG-GML-5238-40-00-DEM5B.xml.gz"), b"dummy").unwrap();
+
+        let resolved = resolve_dem_dir(base.to_str().unwrap()).unwrap();
+        assert_eq!(resolved, date_dir);
+    }
+
+    #[test]
+    fn resolve_dem_dir_picks_lex_max_of_date_subdirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path();
+        std::fs::create_dir_all(base.join("20260101")).unwrap();
+        std::fs::create_dir_all(base.join("20260901")).unwrap();
+        std::fs::create_dir_all(base.join("20260601")).unwrap();
+
+        let resolved = resolve_dem_dir(base.to_str().unwrap()).unwrap();
+        assert_eq!(resolved, base.join("20260901"));
+    }
+
+    #[test]
+    fn resolve_dem_dir_skips_non_date_subdirs() {
+        // The historical bug: `staging` would lex-sort AFTER `20260523`
+        // because lowercase letters (0x73) > digits (0x32). Ensure non-
+        // YYYYMMDD subdirs are excluded entirely.
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path();
+        std::fs::create_dir_all(base.join("20260523")).unwrap();
+        std::fs::create_dir_all(base.join("staging")).unwrap();
+        std::fs::create_dir_all(base.join("zzzz")).unwrap();
+
+        let resolved = resolve_dem_dir(base.to_str().unwrap()).unwrap();
+        assert_eq!(resolved, base.join("20260523"));
+    }
+
+    #[test]
+    fn resolve_dem_dir_falls_back_to_xml_subdir() {
+        // Local-dev layout: no date subdirs, files live under `xml/`.
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path();
+        let xml_dir = base.join("xml");
+        std::fs::create_dir_all(&xml_dir).unwrap();
+        std::fs::write(xml_dir.join("FG-GML-X.xml"), b"<x/>").unwrap();
+
+        let resolved = resolve_dem_dir(base.to_str().unwrap()).unwrap();
+        assert_eq!(resolved, base.to_path_buf());
+    }
+
+    #[test]
+    fn resolve_dem_dir_errors_when_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = resolve_dem_dir(temp.path().to_str().unwrap());
+        assert!(result.is_err(), "Empty base dir should be an error");
+    }
+}

--- a/backend/src/bin/pipeline_load_to_cockroach.rs
+++ b/backend/src/bin/pipeline_load_to_cockroach.rs
@@ -9,7 +9,7 @@ use y_junction_backend::pipeline::storage::read_uri;
 
 #[derive(Parser, Debug)]
 #[command(name = "pipeline-load-to-cockroach")]
-#[command(about = "Load extracted Parquet records into CockroachDB", long_about = None)]
+#[command(about = "Load serving Parquet records into CockroachDB", long_about = None)]
 struct Args {
     /// Parquet source URI — gs://...-yj-serving/... or file://...
     #[arg(long)]

--- a/backend/src/bin/pipeline_load_to_cockroach.rs
+++ b/backend/src/bin/pipeline_load_to_cockroach.rs
@@ -4,7 +4,7 @@ use sqlx::postgres::PgPoolOptions;
 
 use y_junction_backend::importer::detector::JunctionForInsert;
 use y_junction_backend::importer::inserter::insert_junctions;
-use y_junction_backend::pipeline::parquet_io::{read_parquet_bytes, JunctionParquetRecord};
+use y_junction_backend::pipeline::parquet_io::{read_parquet_bytes, ServingJunctionParquetRecord};
 use y_junction_backend::pipeline::storage::read_uri;
 
 #[derive(Parser, Debug)]
@@ -27,9 +27,12 @@ async fn main() -> Result<()> {
     let bytes = read_uri(&args.input).await?;
     tracing::info!("Read {} bytes of Parquet", bytes.len());
 
-    let records: Vec<JunctionParquetRecord> = read_parquet_bytes(bytes)?;
+    let records: Vec<ServingJunctionParquetRecord> = read_parquet_bytes(bytes)?;
     tracing::info!("Decoded {} records", records.len());
 
+    // ServingJunctionParquetRecord -> JunctionForInsert via From impl in
+    // pipeline::parquet_io, which unwraps the -9999.0 elevation sentinel
+    // back to None (issue #257).
     let junctions: Vec<JunctionForInsert> = records.into_iter().map(Into::into).collect();
 
     let database_url = std::env::var("DATABASE_URL")

--- a/backend/src/bin/pipeline_prepare_serving.rs
+++ b/backend/src/bin/pipeline_prepare_serving.rs
@@ -1,19 +1,43 @@
+//! Serving-stage Cloud Run Job.
+//!
+//! Reads N extracted-stage Parquet inputs (`--extracted`, one per
+//! extract variant like 3-way / 2-way) and 0..M enrichment-stage Parquet
+//! inputs (`--enrichment`, currently only elevation), LEFT JOINs the
+//! enrichments onto the extracted records by `osm_node_id`, and writes a
+//! single [`ServingJunctionParquetRecord`] Parquet file at `--output`.
+//!
+//! Extracted rows with no matching enrichment get `-9999.0` sentinel
+//! values in the elevation columns; the load-to-cockroach `From` impl
+//! maps these back to `None` (issue #257).
+
+use std::collections::HashMap;
+
 use anyhow::Result;
 use bytes::Bytes;
 use clap::Parser;
 
 use y_junction_backend::pipeline::parquet_io::{
-    read_parquet_bytes, write_parquet_bytes, JunctionParquetRecord,
+    read_parquet_bytes, write_parquet_bytes, ElevationParquetRecord, JunctionParquetRecord,
+    ServingJunctionParquetRecord,
 };
 use y_junction_backend::pipeline::storage::{read_uri, write_uri};
 
 #[derive(Parser, Debug)]
 #[command(name = "pipeline-prepare-serving")]
-#[command(about = "Merge extracted Parquet inputs into a single serving Parquet", long_about = None)]
+#[command(
+    about = "LEFT JOIN extracted Parquet inputs with optional enrichment Parquet inputs into a single serving Parquet"
+)]
 struct Args {
     /// Extracted-stage Parquet URI — repeat for each input (3-way / 2-way / ...)
-    #[arg(long = "input", required = true)]
-    inputs: Vec<String>,
+    #[arg(long = "extracted", required = true)]
+    extracted: Vec<String>,
+
+    /// Enrichment-stage Parquet URI — repeat for each enrichment source.
+    /// Currently only elevation. Joined by `osm_node_id` LEFT JOIN.
+    /// Workflows may pass empty strings when the region has no enrichment;
+    /// those are filtered before reading.
+    #[arg(long = "enrichment")]
+    enrichment: Vec<String>,
 
     /// Serving-stage Parquet URI — gs://...-yj-serving/... or file://...
     #[arg(long)]
@@ -26,24 +50,77 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let args = Args::parse();
+    let enrichment_uris: Vec<&str> = args
+        .enrichment
+        .iter()
+        .filter(|s| !s.is_empty())
+        .map(String::as_str)
+        .collect();
+
     tracing::info!(
-        "prepare-serving: {} inputs -> {}",
-        args.inputs.len(),
+        "prepare-serving: {} extracted + {} enrichment -> {}",
+        args.extracted.len(),
+        enrichment_uris.len(),
         args.output
     );
 
-    let mut merged: Vec<JunctionParquetRecord> = Vec::new();
-    for input in &args.inputs {
+    // Read all extracted records (concat across 3-way / 2-way / ...)
+    let mut extracted: Vec<JunctionParquetRecord> = Vec::new();
+    for input in &args.extracted {
         let body = read_uri(input).await?;
         tracing::info!("Read {} bytes from {}", body.len(), input);
-        let records = read_parquet_bytes(body)?;
-        tracing::info!("Decoded {} records from {}", records.len(), input);
-        merged.extend(records);
+        let records: Vec<JunctionParquetRecord> = read_parquet_bytes(body)?;
+        tracing::info!("Decoded {} extracted records from {}", records.len(), input);
+        extracted.extend(records);
     }
+    tracing::info!("Total {} extracted records", extracted.len());
 
-    tracing::info!("Merged {} total records", merged.len());
+    // Read all enrichments into a single osm_node_id -> ElevationParquetRecord
+    // map. Multiple enrichment files (e.g. 3-way + 2-way) share the same
+    // key space because osm_node_id is globally unique per junction; later
+    // writes win but collisions are not expected in practice.
+    let mut enrichment_map: HashMap<i64, ElevationParquetRecord> = HashMap::new();
+    for input in &enrichment_uris {
+        let body = read_uri(input).await?;
+        tracing::info!("Read {} bytes from {}", body.len(), input);
+        let records: Vec<ElevationParquetRecord> = read_parquet_bytes(body)?;
+        tracing::info!(
+            "Decoded {} enrichment records from {}",
+            records.len(),
+            input
+        );
+        for r in records {
+            enrichment_map.insert(r.osm_node_id, r);
+        }
+    }
+    tracing::info!(
+        "Total {} unique enrichment rows in lookup map",
+        enrichment_map.len()
+    );
 
-    let parquet_bytes = write_parquet_bytes(&merged)?;
+    // LEFT JOIN: every extracted row becomes a serving row; matching
+    // enrichment rows fill in elevation columns, others retain sentinel.
+    let mut joined_count = 0usize;
+    let serving: Vec<ServingJunctionParquetRecord> = extracted
+        .into_iter()
+        .map(|j| {
+            let osm_node_id = j.osm_node_id;
+            let base = ServingJunctionParquetRecord::from_extracted(j);
+            if let Some(e) = enrichment_map.get(&osm_node_id) {
+                joined_count += 1;
+                base.with_enrichment(e.clone())
+            } else {
+                base
+            }
+        })
+        .collect();
+    tracing::info!(
+        "LEFT JOIN: {} of {} extracted rows received enrichment",
+        joined_count,
+        serving.len()
+    );
+
+    let parquet_bytes = write_parquet_bytes(&serving)?;
     tracing::info!("Encoded {} bytes of serving Parquet", parquet_bytes.len());
 
     write_uri(&args.output, Bytes::from(parquet_bytes)).await?;

--- a/backend/src/importer/elevation.rs
+++ b/backend/src/importer/elevation.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
 use dashmap::DashMap;
+use flate2::read::GzDecoder;
 use glob::glob;
 use roxmltree::Document;
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -101,15 +103,31 @@ impl ElevationProvider {
     /// * `Ok(Self)` - Successfully initialized with elevation data files
     /// * `Err(...)` - No XML files found in the specified directory
     pub fn new(data_dir: &str) -> Result<Self> {
-        let pattern = format!("{}/xml/*.xml", data_dir);
-        let xml_files: Vec<PathBuf> = glob(&pattern)
-            .map(|paths| paths.filter_map(|p| p.ok()).collect())
-            .unwrap_or_default();
+        // Accept both layouts:
+        //   {data_dir}/xml/*.xml{,.gz}   — legacy local-dev convention
+        //   {data_dir}/*.xml{,.gz}       — flat layout used by the GCS FUSE
+        //                                   mount in pipeline-enrich-elevation
+        // Accept both `*.xml` (operator手順, legacy) and `*.xml.gz` (gzip
+        // 圧縮 — DEM 全体で ~10x 削減、issue #257 で gzip + Coldline 採用).
+        let patterns = [
+            format!("{}/xml/*.xml", data_dir),
+            format!("{}/xml/*.xml.gz", data_dir),
+            format!("{}/*.xml", data_dir),
+            format!("{}/*.xml.gz", data_dir),
+        ];
+        let xml_files: Vec<PathBuf> = patterns
+            .iter()
+            .flat_map(|p| {
+                glob(p)
+                    .map(|paths| paths.filter_map(|p| p.ok()).collect::<Vec<_>>())
+                    .unwrap_or_default()
+            })
+            .collect();
 
         anyhow::ensure!(
             !xml_files.is_empty(),
-            "No XML files found in {}. Cannot proceed with elevation import.",
-            pattern
+            "No XML files found in {} (looked for *.xml{{,.gz}} in {{,xml/}}). Cannot proceed with elevation import.",
+            data_dir
         );
 
         let mut mesh_to_file = HashMap::new();
@@ -151,8 +169,12 @@ impl ElevationProvider {
     ///
     /// # Returns
     /// * `Ok(Some(elevation))` - Elevation in meters
-    /// * `Ok(None)` - Valid coordinate but no data available (XML parse errors are logged and skipped)
-    /// * `Err(...)` - File read error
+    /// * `Ok(None)` - Valid coordinate but no data available (mesh not covered
+    ///   by the loaded DEM, or `-9999` "no data" marker in the grid)
+    /// * `Err(...)` - File read / XML parse / gzip decode error (i.e. the
+    ///   mesh IS supposed to be present, but the file failed to load).
+    ///   "Mesh not in mesh_to_file" returns `Ok(None)` rather than `Err`,
+    ///   so callers can distinguish "out of coverage" from real errors.
     pub fn get_elevation(&self, lat: f64, lon: f64) -> Result<Option<f64>> {
         let mesh_code = calculate_mesh_code(lat, lon);
 
@@ -162,13 +184,23 @@ impl ElevationProvider {
             return Ok(tile.get_elevation(lat, lon).filter(|&e| e != -9999.0));
         }
 
-        // Slow path: parse XML and insert atomically
+        // Out-of-coverage mesh is NOT an error condition — distinguish it
+        // from real I/O / parse errors by returning Ok(None) before the
+        // try-insert. Otherwise every out-of-Japan junction would surface
+        // as Err and noisy warnings (issue #257 review).
+        if !self.mesh_to_file.contains_key(&mesh_code) {
+            return Ok(None);
+        }
+
+        // Slow path: parse XML and insert atomically. The map.get inside
+        // the closure can no longer race-miss (we just confirmed presence)
+        // but `or_try_insert_with` requires returning Result so a defensive
+        // anyhow!() handles the impossible-in-practice case.
         let tile_ref = self.cache.entry(mesh_code.clone()).or_try_insert_with(
             || -> Result<Arc<GsiTile>> {
-                let xml_path = self
-                    .mesh_to_file
-                    .get(&mesh_code)
-                    .ok_or_else(|| anyhow::anyhow!("Mesh code not found: {}", mesh_code))?;
+                let xml_path = self.mesh_to_file.get(&mesh_code).ok_or_else(|| {
+                    anyhow::anyhow!("Mesh entry disappeared after check: {}", mesh_code)
+                })?;
                 let tile = Self::parse_xml_file(xml_path)?;
                 Ok(Arc::new(tile))
             },
@@ -182,9 +214,25 @@ impl ElevationProvider {
     }
 
     /// Parses a GSI JPGIS XML file and extracts elevation data
+    ///
+    /// Transparently handles `.xml.gz` via flate2 (issue #257). Detection is
+    /// extension-based: `.gz` suffix triggers gzip decoding, otherwise the
+    /// file is read as plain UTF-8.
     fn parse_xml_file(xml_path: &PathBuf) -> Result<GsiTile> {
-        let xml_content = std::fs::read_to_string(xml_path)
-            .context(format!("Failed to read XML file: {:?}", xml_path))?;
+        let is_gz = xml_path.extension().and_then(|s| s.to_str()) == Some("gz");
+        let xml_content = if is_gz {
+            let f = std::fs::File::open(xml_path)
+                .context(format!("Failed to open XML.gz file: {:?}", xml_path))?;
+            let mut decoder = GzDecoder::new(f);
+            let mut s = String::new();
+            decoder
+                .read_to_string(&mut s)
+                .context(format!("Failed to decode XML.gz file: {:?}", xml_path))?;
+            s
+        } else {
+            std::fs::read_to_string(xml_path)
+                .context(format!("Failed to read XML file: {:?}", xml_path))?
+        };
 
         let doc = Document::parse(&xml_content).context("Failed to parse XML")?;
 
@@ -419,6 +467,38 @@ mod tests {
 
         assert_eq!(files_1, files_2, "Cache size should not increase");
         assert!(files_1 > 0, "At least one file should be cached");
+    }
+
+    #[test]
+    fn test_gzipped_xml() {
+        // Verify .xml.gz is read transparently and produces the same result
+        // as the plain .xml fixture (issue #257 — gzip + Coldline storage).
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write as _;
+
+        // Stage a temp dir with the fixture XML re-encoded as .xml.gz
+        let temp = tempfile::tempdir().unwrap();
+        let xml_dir = temp.path().join("xml");
+        std::fs::create_dir_all(&xml_dir).unwrap();
+
+        let src = "tests/fixtures/gsi/xml/FG-GML-5238-40-00-DEM5B-20210115.xml";
+        let body = std::fs::read(src).expect("fixture XML must exist");
+
+        let gz_path = xml_dir.join("FG-GML-5238-40-00-DEM5B-20210115.xml.gz");
+        let f = std::fs::File::create(&gz_path).unwrap();
+        let mut encoder = GzEncoder::new(f, Compression::default());
+        encoder.write_all(&body).unwrap();
+        encoder.finish().unwrap();
+
+        let provider = ElevationProvider::new(temp.path().to_str().unwrap()).unwrap();
+        let result = provider.get_elevation(35.005, 138.005);
+        assert!(result.is_ok(), "Should successfully read .xml.gz fixture");
+        let elev = result.unwrap();
+        assert!(
+            elev.is_some(),
+            "Should return elevation from gzipped fixture"
+        );
     }
 
     #[test]

--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -56,6 +56,80 @@ pub async fn import_two_way_junctions(
     Ok(count)
 }
 
+/// Looks up DEM elevation, logging real errors but treating out-of-
+/// coverage as a silent `None`. ElevationProvider returns Ok(None) when
+/// the mesh isn't in mesh_to_file (e.g. non-Japan coordinates), and Err
+/// only on actual file I/O / parse / gzip failures — the latter are
+/// operational issues worth surfacing in logs.
+fn try_get_elevation(provider: &elevation::ElevationProvider, lat: f64, lon: f64) -> Option<f64> {
+    match provider.get_elevation(lat, lon) {
+        Ok(opt) => opt,
+        Err(e) => {
+            tracing::warn!("ElevationProvider error at ({lat}, {lon}): {e:#}");
+            None
+        }
+    }
+}
+
+/// Per-junction elevation enrichment payload — what
+/// [`compute_elevation_enrichment`] returns on success. All fields use
+/// f64 to match `ElevationProvider`'s native return type; downstream
+/// consumers (DB UPDATE, Parquet write) cast to f32 at their boundary.
+#[derive(Debug, Clone, Copy)]
+pub struct ElevationEnrichment {
+    pub elevation: f64,
+    pub neighbor_elevations: [f64; 3],
+    pub elevation_diffs: [f64; 3],
+    pub min_angle_index: i16,
+    pub min_elevation_diff: f64,
+    pub max_elevation_diff: f64,
+}
+
+/// Compute elevation enrichment for a single junction. Returns `None` if
+/// the junction's own coordinate OR any of the three 10m-neighbor
+/// coordinates has no DEM coverage. Out-of-coverage rows (e.g. China,
+/// edges of Japan) return `None` silently — the GSI DEM lookup
+/// distinguishes "mesh not present" (Ok(None)) from "mesh present but
+/// failed to read" (Err), and only the latter emits a warn log. No DB
+/// access. Shared by `import_elevation_data` (legacy DB-direct CLI) and
+/// `pipeline-enrich-elevation` (Cloud Run Job, issue #257).
+pub fn compute_elevation_enrichment(
+    provider: &elevation::ElevationProvider,
+    lat: f64,
+    lon: f64,
+    bearings: &[f64; 3],
+    angles: &[i16; 3],
+) -> Option<ElevationEnrichment> {
+    let junction_elev = try_get_elevation(provider, lat, lon)?;
+
+    let neighbor_coords = [
+        calculator::calculate_neighbor_coord(lat, lon, bearings[0], 10.0),
+        calculator::calculate_neighbor_coord(lat, lon, bearings[1], 10.0),
+        calculator::calculate_neighbor_coord(lat, lon, bearings[2], 10.0),
+    ];
+
+    let neighbor_elevations = [
+        try_get_elevation(provider, neighbor_coords[0].0, neighbor_coords[0].1)?,
+        try_get_elevation(provider, neighbor_coords[1].0, neighbor_coords[1].1)?,
+        try_get_elevation(provider, neighbor_coords[2].0, neighbor_coords[2].1)?,
+    ];
+
+    let elevation_diffs =
+        detector::JunctionForInsert::calculate_elevation_diffs(junction_elev, &neighbor_elevations);
+    let (min_elevation_diff, max_elevation_diff) =
+        detector::JunctionForInsert::calculate_min_max_diffs(&elevation_diffs);
+    let min_angle_index = detector::JunctionForInsert::calculate_min_angle_index(angles);
+
+    Some(ElevationEnrichment {
+        elevation: junction_elev,
+        neighbor_elevations,
+        elevation_diffs,
+        min_angle_index,
+        min_elevation_diff,
+        max_elevation_diff,
+    })
+}
+
 pub async fn import_elevation_data(pool: &PgPool, elevation_dir: &str) -> Result<usize> {
     tracing::info!("Starting elevation data import from: {}", elevation_dir);
 
@@ -74,75 +148,35 @@ pub async fn import_elevation_data(pool: &PgPool, elevation_dir: &str) -> Result
     let elevation_updates: Vec<crate::db::repository::ElevationUpdate> = junctions
         .par_iter()
         .filter_map(|junction| {
-            // Get junction elevation
-            let junction_elev = match elevation_provider.get_elevation(junction.lat, junction.lon) {
-                Ok(Some(elev)) => elev,
-                Ok(None) => {
-                    // No elevation data available
-                    return None;
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to get elevation for junction {} at ({}, {}): {}",
-                        junction.id,
-                        junction.lat,
-                        junction.lon,
-                        e
-                    );
-                    return None;
-                }
-            };
-
-            // Calculate neighbor coordinates (approximately 10m away)
-            let neighbor_coords: Vec<(f64, f64)> = junction
-                .bearings
-                .iter()
-                .map(|&bearing| {
-                    calculator::calculate_neighbor_coord(
-                        junction.lat,
-                        junction.lon,
-                        bearing as f64,
-                        10.0,
-                    )
-                })
-                .collect();
-
-            // Get neighbor elevations
-            let neighbor_elevs: Vec<Option<f64>> = neighbor_coords
-                .iter()
-                .map(|(lat, lon)| elevation_provider.get_elevation(*lat, *lon).ok().flatten())
-                .collect();
-
-            // Only update if all neighbor elevations are available
-            let [Some(n1), Some(n2), Some(n3)] =
-                [neighbor_elevs[0], neighbor_elevs[1], neighbor_elevs[2]]
-            else {
-                return None;
-            };
-
-            let neighbor_elevations = [n1, n2, n3];
+            let bearings = [
+                junction.bearings[0] as f64,
+                junction.bearings[1] as f64,
+                junction.bearings[2] as f64,
+            ];
             let angles = [junction.angle_1, junction.angle_2, junction.angle_3];
-
-            let elevation_diffs = detector::JunctionForInsert::calculate_elevation_diffs(
-                junction_elev,
-                &neighbor_elevations,
-            );
-            let (min_diff, max_diff) =
-                detector::JunctionForInsert::calculate_min_max_diffs(&elevation_diffs);
-            let min_angle_index = detector::JunctionForInsert::calculate_min_angle_index(&angles);
-
+            let enrich = compute_elevation_enrichment(
+                &elevation_provider,
+                junction.lat,
+                junction.lon,
+                &bearings,
+                &angles,
+            )?;
             Some(crate::db::repository::ElevationUpdate {
                 id: junction.id,
-                elevation: junction_elev as f32,
-                neighbor_elevations: [n1 as f32, n2 as f32, n3 as f32],
-                elevation_diffs: [
-                    elevation_diffs[0] as f32,
-                    elevation_diffs[1] as f32,
-                    elevation_diffs[2] as f32,
+                elevation: enrich.elevation as f32,
+                neighbor_elevations: [
+                    enrich.neighbor_elevations[0] as f32,
+                    enrich.neighbor_elevations[1] as f32,
+                    enrich.neighbor_elevations[2] as f32,
                 ],
-                min_angle_index,
-                min_elevation_diff: min_diff as f32,
-                max_elevation_diff: max_diff as f32,
+                elevation_diffs: [
+                    enrich.elevation_diffs[0] as f32,
+                    enrich.elevation_diffs[1] as f32,
+                    enrich.elevation_diffs[2] as f32,
+                ],
+                min_angle_index: enrich.min_angle_index,
+                min_elevation_diff: enrich.min_elevation_diff as f32,
+                max_elevation_diff: enrich.max_elevation_diff as f32,
             })
         })
         .collect();
@@ -288,4 +322,51 @@ async fn flush_baidu_chunk(
     missed_osm_node_ids.clear();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod compute_elevation_enrichment_tests {
+    use super::*;
+
+    /// Fixture covers (35.0–35.01, 138.0–138.01). compute_elevation_enrichment
+    /// against that coordinate exercises both the junction-lookup and the
+    /// 3-neighbor lookups in one call.
+    #[test]
+    fn returns_enrichment_for_fixture_coordinate() {
+        let provider = elevation::ElevationProvider::new("tests/fixtures/gsi").unwrap();
+        let bearings = [0.0_f64, 120.0, 240.0]; // 3 spread directions
+        let angles = [35_i16, 145, 180];
+
+        let result = compute_elevation_enrichment(&provider, 35.005, 138.005, &bearings, &angles);
+
+        let enrich = result.expect("fixture coordinate should yield enrichment");
+        assert!(
+            (100.0..=150.0).contains(&enrich.elevation),
+            "fixture elevation should fall in 100-150m range, got {}",
+            enrich.elevation
+        );
+        // All three neighbor lookups succeeded
+        for ne in enrich.neighbor_elevations {
+            assert!(
+                (100.0..=150.0).contains(&ne),
+                "neighbor elevation out of expected range: {}",
+                ne
+            );
+        }
+    }
+
+    #[test]
+    fn returns_none_for_out_of_coverage_coordinate() {
+        let provider = elevation::ElevationProvider::new("tests/fixtures/gsi").unwrap();
+        let bearings = [0.0_f64, 120.0, 240.0];
+        let angles = [35_i16, 145, 180];
+
+        // Beijing — far outside the fixture mesh (which is around 35N 138E)
+        let result = compute_elevation_enrichment(&provider, 39.9, 116.4, &bearings, &angles);
+
+        assert!(
+            result.is_none(),
+            "Out-of-coverage coordinate should return None, got Some"
+        );
+    }
 }

--- a/backend/src/pipeline/parquet_io.rs
+++ b/backend/src/pipeline/parquet_io.rs
@@ -12,15 +12,20 @@ use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};
 
 use crate::importer::detector::JunctionForInsert;
 
-/// Flat record format used between pipeline stages (extract → load).
-///
-/// Walking-skeleton scope: elevation/baidu enrichment columns are intentionally
-/// omitted because this pipeline path does not pass through enrich-elevation.
-/// `JunctionForInsert` consumers reconstruct those fields as `None`.
+/// Sentinel value for "elevation field is absent" in the serving Parquet
+/// stage. `parquet_derive` v58 does not support `Option<T>` scalars, so
+/// nullability is encoded by this sentinel and unwrapped to `None` at the
+/// load-to-cockroach boundary. Matches the existing GSI DEM convention
+/// (`backend/src/importer/elevation.rs:161,177` — `-9999` is GSI's own
+/// "no data" marker, so reusing the value avoids a second sentinel space).
+pub const ELEVATION_SENTINEL: f32 = -9999.0;
+
+/// Extracted-stage record. PBF-derived geometry + road metadata, no
+/// enrichment columns. Lives in `gs://...-yj-extracted/{three-way,two-way}/`.
 ///
 /// `i32` is used for angle/index fields because Parquet has no `i16` physical
 /// type. `parquet_derive::ParquetRecordReader` does not support `Option<T>`
-/// scalars in the v58 release, so all surviving columns are non-nullable.
+/// scalars in the v58 release, so all columns are non-nullable.
 #[derive(Debug, Clone, ParquetRecordWriter, ParquetRecordReader)]
 pub struct JunctionParquetRecord {
     pub osm_node_id: i64,
@@ -97,9 +102,173 @@ impl From<JunctionParquetRecord> for JunctionForInsert {
     }
 }
 
+/// Enrich-stage side table: DEM-derived elevation columns keyed by
+/// `osm_node_id`. Lives in `gs://...-yj-enriched/elevations/{three-way,two-way}/`.
+/// A row is only written when `enrich-elevation` successfully computed the
+/// junction's elevation AND all three neighbor elevations — so all columns are
+/// non-nullable. Rows whose calculation failed (no DEM coverage, partial mesh,
+/// etc.) are simply absent from the output.
+#[derive(Debug, Clone, ParquetRecordWriter, ParquetRecordReader)]
+pub struct ElevationParquetRecord {
+    pub osm_node_id: i64,
+    pub elevation: f32,
+    pub neighbor_elevation_1: f32,
+    pub neighbor_elevation_2: f32,
+    pub neighbor_elevation_3: f32,
+    pub elevation_diff_1: f32,
+    pub elevation_diff_2: f32,
+    pub elevation_diff_3: f32,
+    pub min_angle_index: i32,
+    pub min_elevation_diff: f32,
+    pub max_elevation_diff: f32,
+}
+
+/// Serving-stage record: extracted columns joined with optional elevation
+/// enrichment. Lives in `gs://...-yj-serving/`. Missing enrichment is
+/// represented by [`ELEVATION_SENTINEL`] on elevation columns and `-1` on
+/// `min_angle_index`. The load-to-cockroach `From` impl unwraps these to
+/// `None`.
+#[derive(Debug, Clone, ParquetRecordWriter, ParquetRecordReader)]
+pub struct ServingJunctionParquetRecord {
+    // --- Extracted columns (mirror JunctionParquetRecord) ---
+    pub osm_node_id: i64,
+    pub lat: f64,
+    pub lon: f64,
+    pub angle_1: i32,
+    pub angle_2: i32,
+    pub angle_3: i32,
+    pub bearing_1: f64,
+    pub bearing_2: f64,
+    pub bearing_3: f64,
+    pub way_1_bridge: bool,
+    pub way_1_tunnel: bool,
+    pub way_2_bridge: bool,
+    pub way_2_tunnel: bool,
+    pub way_3_bridge: bool,
+    pub way_3_tunnel: bool,
+    pub way_1_highway_type: String,
+    pub way_2_highway_type: String,
+    pub way_3_highway_type: String,
+    // --- Elevation enrichment (sentinel = absent) ---
+    pub elevation: f32,
+    pub neighbor_elevation_1: f32,
+    pub neighbor_elevation_2: f32,
+    pub neighbor_elevation_3: f32,
+    pub elevation_diff_1: f32,
+    pub elevation_diff_2: f32,
+    pub elevation_diff_3: f32,
+    pub min_angle_index: i32,
+    pub min_elevation_diff: f32,
+    pub max_elevation_diff: f32,
+}
+
+impl ServingJunctionParquetRecord {
+    /// Construct a serving record from an extracted record only (no
+    /// enrichment available). All elevation columns are filled with
+    /// [`ELEVATION_SENTINEL`] / `-1` and will round-trip to `None` at load
+    /// time.
+    pub fn from_extracted(j: JunctionParquetRecord) -> Self {
+        Self {
+            osm_node_id: j.osm_node_id,
+            lat: j.lat,
+            lon: j.lon,
+            angle_1: j.angle_1,
+            angle_2: j.angle_2,
+            angle_3: j.angle_3,
+            bearing_1: j.bearing_1,
+            bearing_2: j.bearing_2,
+            bearing_3: j.bearing_3,
+            way_1_bridge: j.way_1_bridge,
+            way_1_tunnel: j.way_1_tunnel,
+            way_2_bridge: j.way_2_bridge,
+            way_2_tunnel: j.way_2_tunnel,
+            way_3_bridge: j.way_3_bridge,
+            way_3_tunnel: j.way_3_tunnel,
+            way_1_highway_type: j.way_1_highway_type,
+            way_2_highway_type: j.way_2_highway_type,
+            way_3_highway_type: j.way_3_highway_type,
+            elevation: ELEVATION_SENTINEL,
+            neighbor_elevation_1: ELEVATION_SENTINEL,
+            neighbor_elevation_2: ELEVATION_SENTINEL,
+            neighbor_elevation_3: ELEVATION_SENTINEL,
+            elevation_diff_1: ELEVATION_SENTINEL,
+            elevation_diff_2: ELEVATION_SENTINEL,
+            elevation_diff_3: ELEVATION_SENTINEL,
+            min_angle_index: -1,
+            min_elevation_diff: ELEVATION_SENTINEL,
+            max_elevation_diff: ELEVATION_SENTINEL,
+        }
+    }
+
+    /// Overlay enrichment columns onto an extracted serving record. The
+    /// `osm_node_id` is asserted to match in debug builds.
+    pub fn with_enrichment(mut self, e: ElevationParquetRecord) -> Self {
+        debug_assert_eq!(self.osm_node_id, e.osm_node_id);
+        self.elevation = e.elevation;
+        self.neighbor_elevation_1 = e.neighbor_elevation_1;
+        self.neighbor_elevation_2 = e.neighbor_elevation_2;
+        self.neighbor_elevation_3 = e.neighbor_elevation_3;
+        self.elevation_diff_1 = e.elevation_diff_1;
+        self.elevation_diff_2 = e.elevation_diff_2;
+        self.elevation_diff_3 = e.elevation_diff_3;
+        self.min_angle_index = e.min_angle_index;
+        self.min_elevation_diff = e.min_elevation_diff;
+        self.max_elevation_diff = e.max_elevation_diff;
+        self
+    }
+}
+
+impl From<ServingJunctionParquetRecord> for JunctionForInsert {
+    fn from(r: ServingJunctionParquetRecord) -> Self {
+        // f32 in the Parquet column to keep serving size small; widened back
+        // to f64 here because JunctionForInsert / DB columns are f64. The
+        // existing import_elevation_data flow (importer/mod.rs:136-145) does
+        // the same f64 → f32 truncation at the repository boundary.
+        let has_enrichment = r.elevation != ELEVATION_SENTINEL;
+        Self {
+            osm_node_id: r.osm_node_id,
+            lat: r.lat,
+            lon: r.lon,
+            angle_1: r.angle_1 as i16,
+            angle_2: r.angle_2 as i16,
+            angle_3: r.angle_3 as i16,
+            bearings: [r.bearing_1, r.bearing_2, r.bearing_3],
+            elevation: has_enrichment.then_some(r.elevation as f64),
+            neighbor_elevations: has_enrichment.then_some([
+                r.neighbor_elevation_1 as f64,
+                r.neighbor_elevation_2 as f64,
+                r.neighbor_elevation_3 as f64,
+            ]),
+            elevation_diffs: has_enrichment.then_some([
+                r.elevation_diff_1 as f64,
+                r.elevation_diff_2 as f64,
+                r.elevation_diff_3 as f64,
+            ]),
+            min_angle_index: has_enrichment.then_some(r.min_angle_index as i16),
+            min_elevation_diff: has_enrichment.then_some(r.min_elevation_diff as f64),
+            max_elevation_diff: has_enrichment.then_some(r.max_elevation_diff as f64),
+            way_1_bridge: r.way_1_bridge,
+            way_1_tunnel: r.way_1_tunnel,
+            way_2_bridge: r.way_2_bridge,
+            way_2_tunnel: r.way_2_tunnel,
+            way_3_bridge: r.way_3_bridge,
+            way_3_tunnel: r.way_3_tunnel,
+            way_1_highway_type: r.way_1_highway_type,
+            way_2_highway_type: r.way_2_highway_type,
+            way_3_highway_type: r.way_3_highway_type,
+        }
+    }
+}
+
 /// Serialize a slice of records as a single-row-group Snappy-compressed
-/// Parquet file in memory.
-pub fn write_parquet_bytes(records: &[JunctionParquetRecord]) -> Result<Vec<u8>> {
+/// Parquet file in memory. Generic over any type that derives
+/// `ParquetRecordWriter` so the same helper covers all pipeline-stage
+/// record types ([`JunctionParquetRecord`], [`ElevationParquetRecord`],
+/// [`ServingJunctionParquetRecord`]).
+pub fn write_parquet_bytes<T>(records: &[T]) -> Result<Vec<u8>>
+where
+    for<'a> &'a [T]: RecordWriter<T>,
+{
     let schema = records.schema()?;
     let props = Arc::new(
         WriterProperties::builder()
@@ -117,11 +286,15 @@ pub fn write_parquet_bytes(records: &[JunctionParquetRecord]) -> Result<Vec<u8>>
     Ok(buffer)
 }
 
-/// Deserialize a Parquet file (any number of row groups) from an in-memory buffer.
-pub fn read_parquet_bytes(bytes: Bytes) -> Result<Vec<JunctionParquetRecord>> {
+/// Deserialize a Parquet file (any number of row groups) from an in-memory
+/// buffer. Generic over any type that derives `ParquetRecordReader`.
+pub fn read_parquet_bytes<T>(bytes: Bytes) -> Result<Vec<T>>
+where
+    Vec<T>: RecordReader<T>,
+{
     let reader = SerializedFileReader::new(bytes)?;
     let metadata = reader.metadata();
-    let mut records: Vec<JunctionParquetRecord> = Vec::new();
+    let mut records: Vec<T> = Vec::new();
 
     for i in 0..metadata.num_row_groups() {
         let num_rows = metadata.row_group(i).num_rows() as usize;
@@ -208,7 +381,7 @@ mod tests {
         let bytes = write_parquet_bytes(&originals).unwrap();
         assert!(!bytes.is_empty());
 
-        let restored = read_parquet_bytes(Bytes::from(bytes)).unwrap();
+        let restored: Vec<JunctionParquetRecord> = read_parquet_bytes(Bytes::from(bytes)).unwrap();
         assert_eq!(restored.len(), originals.len());
         for (a, b) in originals.iter().zip(restored.iter()) {
             assert_eq!(a.osm_node_id, b.osm_node_id);
@@ -239,15 +412,151 @@ mod tests {
         let three_way_bytes = write_parquet_bytes(&three_way).unwrap();
         let two_way_bytes = write_parquet_bytes(&two_way).unwrap();
 
-        let mut merged = read_parquet_bytes(Bytes::from(three_way_bytes)).unwrap();
-        merged.extend(read_parquet_bytes(Bytes::from(two_way_bytes)).unwrap());
+        let mut merged: Vec<JunctionParquetRecord> =
+            read_parquet_bytes(Bytes::from(three_way_bytes)).unwrap();
+        merged.extend(
+            read_parquet_bytes::<JunctionParquetRecord>(Bytes::from(two_way_bytes)).unwrap(),
+        );
 
         let serving_bytes = write_parquet_bytes(&merged).unwrap();
-        let restored = read_parquet_bytes(Bytes::from(serving_bytes)).unwrap();
+        let restored: Vec<JunctionParquetRecord> =
+            read_parquet_bytes(Bytes::from(serving_bytes)).unwrap();
 
         assert_eq!(restored.len(), 12);
         let ids: Vec<i64> = restored.iter().map(|r| r.osm_node_id).collect();
         assert!((1000..1005).all(|i| ids.contains(&i)));
         assert!((2000..2007).all(|i| ids.contains(&i)));
+    }
+
+    // ---- ElevationParquetRecord / ServingJunctionParquetRecord (issue #257) ----
+
+    fn sample_elevation(osm_node_id: i64) -> ElevationParquetRecord {
+        ElevationParquetRecord {
+            osm_node_id,
+            elevation: 123.5,
+            neighbor_elevation_1: 122.0,
+            neighbor_elevation_2: 124.5,
+            neighbor_elevation_3: 121.0,
+            elevation_diff_1: -1.5,
+            elevation_diff_2: 1.0,
+            elevation_diff_3: -2.5,
+            min_angle_index: 0,
+            min_elevation_diff: -2.5,
+            max_elevation_diff: 1.0,
+        }
+    }
+
+    #[test]
+    fn elevation_record_roundtrip() {
+        let originals: Vec<ElevationParquetRecord> =
+            (0..5).map(|i| sample_elevation(1000 + i)).collect();
+        let bytes = write_parquet_bytes(&originals).unwrap();
+        let restored: Vec<ElevationParquetRecord> = read_parquet_bytes(Bytes::from(bytes)).unwrap();
+
+        assert_eq!(restored.len(), originals.len());
+        for (a, b) in originals.iter().zip(restored.iter()) {
+            assert_eq!(a.osm_node_id, b.osm_node_id);
+            assert_eq!(a.elevation, b.elevation);
+            assert_eq!(a.neighbor_elevation_2, b.neighbor_elevation_2);
+            assert_eq!(a.min_angle_index, b.min_angle_index);
+            assert_eq!(a.max_elevation_diff, b.max_elevation_diff);
+        }
+    }
+
+    #[test]
+    fn serving_from_extracted_uses_sentinel() {
+        let extracted: JunctionParquetRecord = sample().into();
+        let serving = ServingJunctionParquetRecord::from_extracted(extracted);
+
+        // Extracted columns preserved
+        assert_eq!(serving.osm_node_id, 42);
+        assert_eq!(serving.angle_1, 35);
+        assert_eq!(serving.way_1_highway_type, "primary");
+
+        // Enrichment columns all sentinel
+        assert_eq!(serving.elevation, ELEVATION_SENTINEL);
+        assert_eq!(serving.neighbor_elevation_1, ELEVATION_SENTINEL);
+        assert_eq!(serving.neighbor_elevation_3, ELEVATION_SENTINEL);
+        assert_eq!(serving.elevation_diff_2, ELEVATION_SENTINEL);
+        assert_eq!(serving.min_angle_index, -1);
+        assert_eq!(serving.min_elevation_diff, ELEVATION_SENTINEL);
+        assert_eq!(serving.max_elevation_diff, ELEVATION_SENTINEL);
+    }
+
+    #[test]
+    fn serving_with_enrichment_overlays_elevation() {
+        let extracted: JunctionParquetRecord = sample().into();
+        let base = ServingJunctionParquetRecord::from_extracted(extracted);
+        let enriched = base.with_enrichment(sample_elevation(42));
+
+        // Extracted columns still preserved
+        assert_eq!(enriched.osm_node_id, 42);
+        assert_eq!(enriched.angle_1, 35);
+        assert_eq!(enriched.way_1_highway_type, "primary");
+
+        // Enrichment columns now populated
+        assert_eq!(enriched.elevation, 123.5);
+        assert_eq!(enriched.neighbor_elevation_1, 122.0);
+        assert_eq!(enriched.elevation_diff_1, -1.5);
+        assert_eq!(enriched.min_angle_index, 0);
+        assert_eq!(enriched.min_elevation_diff, -2.5);
+        assert_eq!(enriched.max_elevation_diff, 1.0);
+    }
+
+    #[test]
+    fn serving_to_junction_for_insert_sentinel_to_none() {
+        // Sentinel-only row should map to all-None enrichment fields.
+        let extracted: JunctionParquetRecord = sample().into();
+        let serving = ServingJunctionParquetRecord::from_extracted(extracted);
+        let restored: JunctionForInsert = serving.into();
+
+        assert_eq!(restored.osm_node_id, 42);
+        assert!(restored.elevation.is_none());
+        assert!(restored.neighbor_elevations.is_none());
+        assert!(restored.elevation_diffs.is_none());
+        assert!(restored.min_angle_index.is_none());
+        assert!(restored.min_elevation_diff.is_none());
+        assert!(restored.max_elevation_diff.is_none());
+    }
+
+    #[test]
+    fn serving_to_junction_for_insert_unwraps_enrichment() {
+        let extracted: JunctionParquetRecord = sample().into();
+        let serving = ServingJunctionParquetRecord::from_extracted(extracted)
+            .with_enrichment(sample_elevation(42));
+        let restored: JunctionForInsert = serving.into();
+
+        assert_eq!(restored.osm_node_id, 42);
+        assert_eq!(restored.elevation, Some(123.5));
+        assert_eq!(restored.neighbor_elevations, Some([122.0, 124.5, 121.0]));
+        assert_eq!(restored.elevation_diffs, Some([-1.5, 1.0, -2.5]));
+        assert_eq!(restored.min_angle_index, Some(0));
+        assert_eq!(restored.min_elevation_diff, Some(-2.5));
+        assert_eq!(restored.max_elevation_diff, Some(1.0));
+    }
+
+    #[test]
+    fn serving_record_roundtrip_mixed() {
+        // Two extracted records, only one with enrichment. Roundtrip through
+        // Parquet preserves sentinel/non-sentinel distinction → load-side
+        // From impl recovers None/Some correctly.
+        let extracted_1: JunctionParquetRecord = sample().into();
+        let mut extracted_2: JunctionParquetRecord = sample().into();
+        extracted_2.osm_node_id = 99;
+
+        let serving_1 = ServingJunctionParquetRecord::from_extracted(extracted_1)
+            .with_enrichment(sample_elevation(42));
+        let serving_2 = ServingJunctionParquetRecord::from_extracted(extracted_2);
+
+        let bytes = write_parquet_bytes(&[serving_1, serving_2]).unwrap();
+        let restored: Vec<ServingJunctionParquetRecord> =
+            read_parquet_bytes(Bytes::from(bytes)).unwrap();
+        assert_eq!(restored.len(), 2);
+
+        let inserts: Vec<JunctionForInsert> = restored.into_iter().map(Into::into).collect();
+        assert_eq!(inserts[0].osm_node_id, 42);
+        assert_eq!(inserts[0].elevation, Some(123.5));
+        assert_eq!(inserts[1].osm_node_id, 99);
+        assert!(inserts[1].elevation.is_none());
     }
 }

--- a/doc/enrich-elevation.md
+++ b/doc/enrich-elevation.md
@@ -146,7 +146,7 @@ gsutil -m rm -r gs://${PROJECT_ID}-yj-raw/dem/20250515/
 
 ## 10. Code Review 結果と対応
 
-extra-high 効ort review で 15 件 surface。
+extra-high effort review で 15 件 surface。
 
 ### 直したもの（quick wins）
 

--- a/doc/enrich-elevation.md
+++ b/doc/enrich-elevation.md
@@ -1,0 +1,225 @@
+# issue #257: enrich-elevation Job 対応概要
+
+ブランチ: `chore/257-enrich-elevation`
+worktree: `/Users/sasakitakashinanji/code/y-junctions-worktrees/chore-257-enrich-elevation`
+
+OSM インポートを Cloud Run Jobs 化する meta issue #220 の最後の主要 step。
+月次パイプラインに DEM 標高エンリッチを組み込み、load 時点で `y_junctions.elevation` 列が埋まるようにする。
+
+---
+
+## 1. 設計方針（要点）
+
+- **DAG 内に enrich-elevation を組み込む**（Baidu #258 の post-DAG パターンは採用しない — 月次パイプラインの強整合性を保つ）
+- **side-table 設計** — extracted と elevation は別 Parquet で持つ（PBF 月次更新と DEM 年次更新のライフサイクル分離）
+- **stage = bucket、内容は path で区別** — 既存 yj-raw / yj-extracted / yj-serving の規約を踏襲し、新規 `yj-enriched/elevations/...` を追加
+- **将来 enricher 追加時** — `yj-enriched/baidu-panoids/...` のように同バケット内で path 分離（傘語ではなく "enrich stage" の意味）
+- **欠損 sentinel: `-9999.0`**（既存 ElevationProvider 慣行と一致、parquet_derive v58 の `Option<T>` 非対応回避）
+- **region 判定** — catalog の `region` フィールドで Workflows YAML が switch、`japan` 以外は enrich を skip（catalog 駆動、座標ベース判定なし）
+
+---
+
+## 2. バケット / path レイアウト
+
+```
+gs://...-yj-raw/                          (download / 投入 stage)
+  osm/{date}/{dataset}.osm.pbf            既存（lifecycle 90d delete）
+  dem/{YYYYMMDD}/*.xml.gz                 新規 path — operator 年次手動投入（lifecycle 対象外）
+
+gs://...-yj-extracted/                    (extract stage、既存変更なし)
+  three-way/{date}/{dataset}.parquet
+  two-way/{date}/{dataset}.parquet
+
+gs://...-yj-enriched/                     (enrich stage、新規)
+  elevations/three-way/{date}/{dataset}.parquet
+  elevations/two-way/{date}/{dataset}.parquet
+
+gs://...-yj-serving/                      (serving stage、書く schema が変わる)
+  {date}/{dataset}.parquet
+```
+
+`yj-raw` は Storage Class = `COLDLINE`、lifecycle delete は `matches_prefix = ["osm/"]` で `osm/` のみ scope。
+
+---
+
+## 3. Parquet record 3 種（`backend/src/pipeline/parquet_io.rs`）
+
+| 既存/新規 | struct | 用途 |
+|---|---|---|
+| 既存 | `JunctionParquetRecord` | extracted stage、enrichment 列なし、変更なし |
+| **新規** | `ElevationParquetRecord` | enrich stage、`osm_node_id` + elevation 10 列（薄い side table、欠損行は出さないので全 non-nullable で OK）|
+| **新規** | `ServingJunctionParquetRecord` | serving stage、extracted 18 列 + elevation 10 列。**`-9999.0` を欠損 sentinel**、`min_angle_index` は `-1` |
+
+**変換**
+- `From<ServingJunctionParquetRecord> for JunctionForInsert` で sentinel → `None` mapping
+- `write_parquet_bytes` / `read_parquet_bytes` を `T: ParquetRecordWriter/Reader` で generic 化
+
+---
+
+## 4. Binary 変更
+
+| binary | 改修 |
+|---|---|
+| `pipeline-extract-three-way` / `-two-way` | **変更なし** |
+| `pipeline-enrich-elevation`（**新規** `backend/src/bin/pipeline_enrich_elevation.rs`） | `--input` extracted parquet / `--output` enriched parquet / `--dem-dir` (FUSE mount path)。 `resolve_dem_dir` で `^\d{8}$` 形式の subdir を優先、無ければ direct layout fallback。 `compute_elevation_enrichment` を rayon par_iter で適用、成功行のみ `ElevationParquetRecord` で write |
+| `pipeline-prepare-serving` | concat → osm_node_id LEFT JOIN に改修。引数を `--input` → `--extracted` + 任意の `--enrichment`（複数可、空文字列は filter）に再設計 |
+| `pipeline-load-to-cockroach` | 読込 record 型を `ServingJunctionParquetRecord` に変更、`From` 実装が sentinel → None mapping を担う |
+
+`Cargo.toml` に `pipeline-enrich-elevation` の `[[bin]]` と `flate2` dependency を追加。
+
+---
+
+## 5. 共通ロジック（`backend/src/importer/`）
+
+**`compute_elevation_enrichment`**（`mod.rs`）— 純関数として新規 pub。引数 `(provider, lat, lon, bearings, angles)`、戻り値 `Option<ElevationEnrichment>`。
+- `try_get_elevation` ヘルパで実エラー（I/O / parse / gzip 失敗）は `tracing::warn!`、 `Ok(None)`（out-of-coverage）は silent
+- legacy `import_elevation_data` もこの helper を共有するように refactor
+
+**ElevationProvider 拡張**（`elevation.rs`）
+- `.xml.gz` 透過読み（`flate2::read::GzDecoder` で拡張子判定 → 自動 decode）
+- glob を 4 pattern（`xml/*.xml`, `xml/*.xml.gz`, `*.xml`, `*.xml.gz`）で flat / xml/ 両 layout 対応
+- `get_elevation` で "mesh not in mesh_to_file" を Err → **`Ok(None)`** に変更（out-of-coverage を first-class に）
+
+---
+
+## 6. Terraform（`terraform/pipeline.tf`）
+
+**バケット / Storage Class**
+- `yj_enriched` バケット新規（lifecycle 90d、yj_extracted と同形、Standard）
+- 既存 `yj_raw` に `storage_class = "COLDLINE"` 追加
+- `yj_raw` の lifecycle_rule に `matches_prefix = ["osm/"]` 追加 — **DEM (`dem/` prefix) は自動削除されない**
+
+**SA / IAM**
+- `sa-pipeline-enrich-elevation` 新規
+- IAM 3 件: read yj-extracted / read yj-raw / write yj-enriched
+- prepare-serving SA に read yj-enriched 追加
+- workflow_acts_as_enrich_elevation 追加
+
+**Cloud Run Job**
+- `pipeline-enrich-elevation`（mem 8Gi、cpu 2、timeout 30min、max_retries 1）
+- `execution_environment = "EXECUTION_ENVIRONMENT_GEN2"` 明示
+- `volumes.gcs { bucket = yj_raw, read_only = true }` を `/mnt/dem` にマウント（FUSE）
+
+**Workflows YAML**（インライン HEREDOC）
+- `init` step で `region`（missing / 空文字列 → `unknown` フォールバック）、 `enriched_*_uri`、 `prepare_serving_args` (no-enrichment 形のデフォルト) を宣言
+- `extract` の後に `enrich:` switch step を挿入：
+  - `condition: region == "japan"` → 3-way / 2-way 並列で `pipeline-enrich-elevation` 起動、`prepare_serving_args` を `--enrichment` 付きに再代入
+  - `condition: true` → no-op、`prepare_serving_args` を `--extracted` のみに再代入
+- `prepare_serving` step は `args: ${prepare_serving_args}` で動的に list 受け取り
+
+---
+
+## 7. catalog（`pipeline/datasets.json`）
+
+shikoku-latest / chugoku-latest の 2 entry に `"region": "japan"` 追加。dispatcher は entry 全体を `json.encode_to_string(ds)` で workflow に渡しているので dispatcher 側改修不要。
+
+---
+
+## 8. operator手順（`README.md` に追記）
+
+年次 DEM 更新フロー：
+```bash
+# 1. 国土地理院から DEM5A 取得し ~/y-junctions-data/gsi/xml/ に展開
+
+# 2. gzip 圧縮（-k で元 .xml を残す → upload リトライ時 / ローカル CLI 用）
+gzip -k ~/y-junctions-data/gsi/xml/*.xml
+
+# 3. 日付 prefix にアップロード
+gsutil cp ~/y-junctions-data/gsi/xml/*.xml.gz \
+  gs://${PROJECT_ID}-yj-raw/dem/$(date +%Y%m%d)/
+
+# 4. refresh したい時は手動キック（real な値は pipeline/datasets.json から）
+gcloud workflows execute yj-pipeline --location=asia-northeast1 \
+  --data='{"dataset":"shikoku-latest","geofabrik_url":"https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf","bbox":"134.0,34.3,134.1,34.4","region":"japan"}'
+
+# 古い DEM 掃除（operator が新 DEM upload 時に手動）
+gsutil -m rm -r gs://${PROJECT_ID}-yj-raw/dem/20250515/
+```
+
+---
+
+## 9. Dockerfile（`pipeline/Dockerfile`）
+
+`pipeline-enrich-elevation` を `cargo build --bin` リストと container COPY 双方に追加。
+
+---
+
+## 10. Code Review 結果と対応
+
+extra-high 効ort review で 15 件 surface。
+
+### 直したもの（quick wins）
+
+| # | 内容 | 修正 |
+|---|------|------|
+| #1 | Dockerfile に新 binary 漏れ | `--bin pipeline-enrich-elevation` + COPY 追加 |
+| #2 | yj-raw 90 日 lifecycle が DEM を巻き込む | `matches_prefix = ["osm/"]` で osm/ のみ scope |
+| #3 + #10 | resolve_dem_dir が非日付 subdir / xml/ short-circuit | `^\d{8}$` regex 検証 + date-subdir 優先、unit tests 6 件追加 |
+| #4 | Workflow `prepare_serving_args` の switch-out scope 依存 | `init` で default 配列宣言（no-enrichment 形） |
+| #5 | region 空文字列が "japan" 比較で silent skip | `if(region_raw == "", "unknown", region_raw)` |
+| #6 | README `gzip` destructive | `gzip -k` 推奨に変更 |
+| #7 | README workflow execute 例が literal `...` | datasets.json の real 値に置換 + 古い DEM 掃除手順追加 |
+| #8 | compute_elevation_enrichment が Err と Ok(None) を区別なく drop | `try_get_elevation` ヘルパで Err のみ warn、ElevationProvider で mesh-not-found を Ok(None) 化 |
+
+### 残し（PR description / follow-up issue）
+
+- **#9 旧 schema serving Parquet の再 load 不可** — apply 後の transient 期間のみ影響、recovery には extract から再走
+- **#11 Coldline + PBF 同 path 上書き early-deletion fee** — cost 注意、operator 認知のみ
+- **#13 DEM 不在時の fail-loud** — 設計上正しい挙動として受容、alert 整備は別 issue
+- **#14 空 Parquet write/read 未検証** — 実用上発生しにくい edge case
+- **#15 ELEVATION_SENTINEL 衝突の latent footgun** — 将来別 DEM source 統合時に再評価、コメント済み
+
+---
+
+## 11. apply 前の確認事項
+
+- **DEM volume mount の terraform schema 検証** — `google_cloud_run_v2_job` の volumes/volume_mounts ブロック（gen2 FUSE）の正確な書式
+- **Workflows DSL の `map.get` / `default` / `if` 関数の実在確認** — apply 前に公式 reference で確認（[[feedback_verify_dsl_before_apply]]）
+- **既存 yj-raw 上の無圧縮 XML / Standard クラスオブジェクト** — apply 後、operator が `gsutil rewrite` または次回 DEM 更新時に gzip 上書きで順次反映
+
+---
+
+## 12. Verification
+
+- **cargo test**: 92 lib + 6 binary（resolve_dem_dir）+ 47 integration = **145 PASS**
+- **cargo fmt --check**: PASS
+- **cargo clippy -D warnings**: PASS
+- **terraform fmt -check**: PASS
+
+---
+
+## 13. 変更ファイル一覧
+
+```
+M  README.md                                       (operator 手順 + 古い DEM 掃除)
+M  backend/Cargo.lock
+M  backend/Cargo.toml                              (+ flate2, + [[bin]])
+M  backend/src/bin/pipeline_load_to_cockroach.rs   (型差し替え + sentinel mapping)
+M  backend/src/bin/pipeline_prepare_serving.rs     (LEFT JOIN + --extracted/--enrichment)
+M  backend/src/importer/elevation.rs               (.xml.gz, mesh-not-found → Ok(None), glob 4 pattern)
+M  backend/src/importer/mod.rs                     (compute_elevation_enrichment + try_get_elevation)
+M  backend/src/pipeline/parquet_io.rs              (2 新規 struct + generic + From impl + tests)
+M  pipeline/Dockerfile                             (pipeline-enrich-elevation を build + COPY に追加)
+M  pipeline/datasets.json                          ("region": "japan")
+M  terraform/backend.tf                            (fmt のみ)
+M  terraform/pipeline.tf                           (yj-raw COLDLINE+matches_prefix / yj-enriched
+                                                    バケット / SA / IAM / Cloud Run Job (FUSE) /
+                                                    Workflows YAML region switch)
+?? backend/src/bin/pipeline_enrich_elevation.rs    (新規、resolve_dem_dir 含む)
+?? doc/enrich-elevation.md                         (本ドキュメント)
+```
+
+---
+
+## 14. issue 本文との差分
+
+issue #257 本文の "却下した選択肢" / "リスク" を、設計討論の過程で以下のように decide:
+
+| 論点 | 本文時点 | 確定 |
+|------|---------|------|
+| Parquet schema | append 列 or 検討中 | **side table** (`ElevationParquetRecord` + `ServingJunctionParquetRecord`) |
+| DEM access | FUSE / on-demand fetch / pre-download | **gzip + Coldline + GCS FUSE volume mount** |
+| Sentinel | NaN / -9999.0 | **-9999.0** (ElevationProvider 慣行と一致) |
+| 失敗時 | abort / 行欠損 | **行欠損許容** + 実 I/O エラーは warn |
+| Region 判定 | 座標ベース vs catalog | **catalog 駆動**（dispatcher が `json.encode_to_string` で entry 全体を渡すので追加コスト無し） |
+| 月額 cost | issue 試算 ~$1 未満 | gzip + Coldline で月 **~$0.18** (Standard比 ~95% 削減) |

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -17,6 +17,7 @@ RUN cargo build --release \
       --bin pipeline-download-osm \
       --bin pipeline-extract-three-way \
       --bin pipeline-extract-two-way \
+      --bin pipeline-enrich-elevation \
       --bin pipeline-prepare-serving \
       --bin pipeline-load-to-cockroach \
       --bin import-baidu-panoid
@@ -30,6 +31,7 @@ RUN apt-get update \
 COPY --from=builder /app/backend/target/release/pipeline-download-osm /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-extract-three-way /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-extract-two-way /usr/local/bin/
+COPY --from=builder /app/backend/target/release/pipeline-enrich-elevation /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-prepare-serving /usr/local/bin/
 COPY --from=builder /app/backend/target/release/pipeline-load-to-cockroach /usr/local/bin/
 COPY --from=builder /app/backend/target/release/import-baidu-panoid /usr/local/bin/

--- a/pipeline/datasets.json
+++ b/pipeline/datasets.json
@@ -3,12 +3,14 @@
     "dataset": "shikoku-latest",
     "geofabrik_url": "https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf",
     "bbox": "134.0,34.3,134.1,34.4",
+    "region": "japan",
     "schedule": "monthly"
   },
   {
     "dataset": "chugoku-latest",
     "geofabrik_url": "https://download.geofabrik.de/asia/japan/chugoku-latest.osm.pbf",
     "bbox": "132.45,34.38,132.48,34.41",
+    "region": "japan",
     "schedule": "monthly"
   }
 ]

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -26,8 +26,8 @@ resource "google_artifact_registry_repository" "main" {
 
 # Cloud Run service for backend API
 resource "google_cloud_run_v2_service" "backend" {
-  name               = var.backend_service_name
-  location           = var.region
+  name                = var.backend_service_name
+  location            = var.region
   deletion_protection = true
 
   template {

--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -44,9 +44,26 @@ resource "google_storage_bucket" "yj_raw" {
   public_access_prevention    = "enforced"
   force_destroy               = true
 
+  # Coldline for DEM/PBF storage: ~$0.004/GB-month vs Standard's $0.020.
+  # DEM is touched once monthly by enrich-elevation; PBFs once a month by
+  # extract. Per-op Class B reads are ~$0.05/1000 (Standard $0.0004/1000)
+  # but volume is negligible. See issue #257 — gzip + Coldline drives the
+  # DEM monthly cost from ~$3.75 to ~$0.17. Newly-created objects inherit
+  # this class; existing objects must be migrated via `gsutil rewrite -s
+  # coldline`.
+  storage_class = "COLDLINE"
+
+  # Lifecycle rules are prefix-scoped because the two data kinds in this
+  # bucket have very different refresh cadences:
+  #   - osm/  → monthly PBF, safe to delete at 90d (next month's run regenerates)
+  #   - dem/  → annual GSI DEM upload, NOT auto-deleted (a 90d sweep would
+  #             remove the DEM 9 months out of every 12 and break enrich-
+  #             elevation for the rest of the year — operator manually
+  #             removes outdated date prefixes when uploading a new DEM).
   lifecycle_rule {
     condition {
-      age = 90
+      age            = 90
+      matches_prefix = ["osm/"]
     }
     action {
       type = "Delete"
@@ -77,6 +94,30 @@ resource "google_storage_bucket" "yj_extracted" {
 
 resource "google_storage_bucket" "yj_serving" {
   name                        = "${var.project_id}-yj-serving"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  force_destroy               = true
+
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  depends_on = [google_project_service.storage]
+}
+
+# Enrich stage outputs (issue #257). Currently only the `elevations/`
+# prefix for DEM-derived side tables; if Baidu panoid is later moved into
+# Parquet, it would live alongside as `baidu-panoids/` rather than a
+# separate bucket. Bucket name conveys the pipeline stage; the prefix
+# conveys the enrichment kind.
+resource "google_storage_bucket" "yj_enriched" {
+  name                        = "${var.project_id}-yj-enriched"
   location                    = var.region
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
@@ -198,6 +239,13 @@ resource "google_service_account" "pipeline_dispatcher" {
   depends_on = [google_project_service.iam]
 }
 
+resource "google_service_account" "pipeline_enrich_elevation" {
+  account_id   = "sa-pipeline-enrich-elevation"
+  display_name = "Pipeline: enrich-elevation (issue #257)"
+
+  depends_on = [google_project_service.iam]
+}
+
 # ---------- IAM: per-bucket access ------------------------------------------
 
 # download-osm: write to yj-raw
@@ -243,6 +291,34 @@ resource "google_storage_bucket_iam_member" "prepare_serving_reads_extracted" {
 resource "google_storage_bucket_iam_member" "prepare_serving_writes_serving" {
   bucket = google_storage_bucket.yj_serving.name
   role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.pipeline_prepare_serving.email}"
+}
+
+# enrich-elevation: read yj-extracted, read yj-raw (DEM XMLs via GCS FUSE),
+# write yj-enriched (issue #257).
+resource "google_storage_bucket_iam_member" "enrich_elevation_reads_extracted" {
+  bucket = google_storage_bucket.yj_extracted.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_enrich_elevation.email}"
+}
+
+resource "google_storage_bucket_iam_member" "enrich_elevation_reads_raw" {
+  bucket = google_storage_bucket.yj_raw.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_enrich_elevation.email}"
+}
+
+resource "google_storage_bucket_iam_member" "enrich_elevation_writes_enriched" {
+  bucket = google_storage_bucket.yj_enriched.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.pipeline_enrich_elevation.email}"
+}
+
+# prepare-serving also needs to read yj-enriched now that LEFT JOIN takes
+# enrichment inputs (issue #257).
+resource "google_storage_bucket_iam_member" "prepare_serving_reads_enriched" {
+  bucket = google_storage_bucket.yj_enriched.name
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.pipeline_prepare_serving.email}"
 }
 
@@ -380,6 +456,62 @@ resource "google_cloud_run_v2_job" "pipeline_prepare_serving" {
   depends_on = [google_project_service.run]
 }
 
+resource "google_cloud_run_v2_job" "pipeline_enrich_elevation" {
+  name     = "pipeline-enrich-elevation"
+  location = var.region
+
+  deletion_protection = false
+
+  template {
+    template {
+      service_account = google_service_account.pipeline_enrich_elevation.email
+      timeout         = "1800s"
+      max_retries     = 1
+
+      # gen2 is required for GCS volume mounts (Cloud Storage FUSE).
+      # Default for Cloud Run Jobs is already gen2, but pin explicitly so a
+      # future provider default flip doesn't silently break the DEM mount.
+      execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
+
+      # Mount yj-raw read-only at /mnt/dem so the binary can read DEM
+      # XML/XML.gz files via the local filesystem (issue #257). The binary's
+      # `--dem-dir /mnt/dem/dem` then resolves the lex-max {YYYYMMDD}/
+      # subdirectory to use the latest operator-uploaded DEM snapshot.
+      volumes {
+        name = "dem"
+        gcs {
+          bucket    = google_storage_bucket.yj_raw.name
+          read_only = true
+        }
+      }
+
+      containers {
+        image   = local.pipeline_image
+        command = ["pipeline-enrich-elevation"]
+
+        volume_mounts {
+          name       = "dem"
+          mount_path = "/mnt/dem"
+        }
+
+        resources {
+          limits = {
+            cpu    = "2"
+            memory = "8Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_storage_bucket_iam_member.enrich_elevation_reads_raw,
+    google_storage_bucket_iam_member.enrich_elevation_reads_extracted,
+    google_storage_bucket_iam_member.enrich_elevation_writes_enriched,
+  ]
+}
+
 resource "google_cloud_run_v2_job" "pipeline_load_to_cockroach" {
   name     = "pipeline-load-to-cockroach"
   location = var.region
@@ -459,6 +591,12 @@ resource "google_service_account_iam_member" "workflow_acts_as_load" {
   member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
 }
 
+resource "google_service_account_iam_member" "workflow_acts_as_enrich_elevation" {
+  service_account_id = google_service_account.pipeline_enrich_elevation.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.pipeline_workflow.email}"
+}
+
 # Workflow constructs per-job containerOverrides from caller-supplied args.
 # All of `dataset` / `geofabrik_url` / `bbox` are required — the dispatcher
 # (issue #237) sources them from `gs://...-yj-config/datasets.json`, ad-hoc
@@ -478,11 +616,34 @@ resource "google_workflows_workflow" "pipeline" {
               - dataset: $${args.dataset}
               - geofabrik_url: $${args.geofabrik_url}
               - bbox: $${args.bbox}
+              # region is optional in the catalog; default to "unknown" so
+              # the switch below routes through the no-enrichment branch.
+              # When set to "japan" the enrich-elevation step runs (issue
+              # #257). Both `missing key` and `empty string` collapse to
+              # "unknown" — a partial dispatcher serialization that strips
+              # region to "" must not silently skip enrichment for a
+              # genuine Japan dataset without flagging the misconfiguration.
+              - region_raw: $${default(map.get(args, "region"), "")}
+              - region: $${if(region_raw == "", "unknown", region_raw)}
               - run_date: $${text.substring(time.format(sys.now(), "Asia/Tokyo"), 0, 10)}
               - raw_uri: $${"gs://${google_storage_bucket.yj_raw.name}/osm/" + run_date + "/" + dataset + ".osm.pbf"}
               - extracted_three_way_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/three-way/" + run_date + "/" + dataset + ".parquet"}
               - extracted_two_way_uri: $${"gs://${google_storage_bucket.yj_extracted.name}/two-way/" + run_date + "/" + dataset + ".parquet"}
+              - enriched_three_way_uri: $${"gs://${google_storage_bucket.yj_enriched.name}/elevations/three-way/" + run_date + "/" + dataset + ".parquet"}
+              - enriched_two_way_uri: $${"gs://${google_storage_bucket.yj_enriched.name}/elevations/two-way/" + run_date + "/" + dataset + ".parquet"}
               - serving_uri: $${"gs://${google_storage_bucket.yj_serving.name}/" + run_date + "/" + dataset + ".parquet"}
+              # Default for `prepare_serving_args`: the no-enrichment form.
+              # Both switch arms reassign this to a kind-specific list, but
+              # defining it here at function scope prevents an undefined-
+              # symbol error if a future arm forgets to assign (defense-
+              # in-depth; current arms always assign).
+              - prepare_serving_args:
+                  - "--extracted"
+                  - $${extracted_three_way_uri}
+                  - "--extracted"
+                  - $${extracted_two_way_uri}
+                  - "--output"
+                  - $${serving_uri}
         - download:
             call: googleapis.run.v2.projects.locations.jobs.run
             args:
@@ -534,6 +695,74 @@ resource "google_workflows_workflow" "pipeline" {
                                       - $${extracted_two_way_uri}
                                       - "--bbox"
                                       - $${bbox}
+        # region-driven enrichment switch (issue #257). For region=japan the
+        # enrich-elevation Job runs in parallel for 3-way / 2-way, producing
+        # osm_node_id-keyed side parquets that prepare-serving LEFT JOINs
+        # back onto the extracted records. For other regions the branch is
+        # a no-op and prepare-serving runs without enrichment inputs.
+        - enrich:
+            switch:
+              - condition: $${region == "japan"}
+                steps:
+                  - run_enrich_parallel:
+                      parallel:
+                        branches:
+                          - enrich_three_way:
+                              steps:
+                                - run_enrich_elevation_3w:
+                                    call: googleapis.run.v2.projects.locations.jobs.run
+                                    args:
+                                      name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_enrich_elevation.name}
+                                      body:
+                                        overrides:
+                                          containerOverrides:
+                                            - args:
+                                                - "--input"
+                                                - $${extracted_three_way_uri}
+                                                - "--output"
+                                                - $${enriched_three_way_uri}
+                                                - "--dem-dir"
+                                                - "/mnt/dem/dem"
+                          - enrich_two_way:
+                              steps:
+                                - run_enrich_elevation_2w:
+                                    call: googleapis.run.v2.projects.locations.jobs.run
+                                    args:
+                                      name: projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.pipeline_enrich_elevation.name}
+                                      body:
+                                        overrides:
+                                          containerOverrides:
+                                            - args:
+                                                - "--input"
+                                                - $${extracted_two_way_uri}
+                                                - "--output"
+                                                - $${enriched_two_way_uri}
+                                                - "--dem-dir"
+                                                - "/mnt/dem/dem"
+                  - assign_serving_args_japan:
+                      assign:
+                        - prepare_serving_args:
+                            - "--extracted"
+                            - $${extracted_three_way_uri}
+                            - "--extracted"
+                            - $${extracted_two_way_uri}
+                            - "--enrichment"
+                            - $${enriched_three_way_uri}
+                            - "--enrichment"
+                            - $${enriched_two_way_uri}
+                            - "--output"
+                            - $${serving_uri}
+              - condition: true
+                steps:
+                  - assign_serving_args_other:
+                      assign:
+                        - prepare_serving_args:
+                            - "--extracted"
+                            - $${extracted_three_way_uri}
+                            - "--extracted"
+                            - $${extracted_two_way_uri}
+                            - "--output"
+                            - $${serving_uri}
         - prepare_serving:
             call: googleapis.run.v2.projects.locations.jobs.run
             args:
@@ -541,13 +770,7 @@ resource "google_workflows_workflow" "pipeline" {
               body:
                 overrides:
                   containerOverrides:
-                    - args:
-                        - "--input"
-                        - $${extracted_three_way_uri}
-                        - "--input"
-                        - $${extracted_two_way_uri}
-                        - "--output"
-                        - $${serving_uri}
+                    - args: $${prepare_serving_args}
             result: prepare_serving_result
         - load:
             call: googleapis.run.v2.projects.locations.jobs.run


### PR DESCRIPTION
## Summary

- 月次パイプラインに DEM 標高エンリッチを組み込み、region=japan の load 時点で `y_junctions.elevation` 列が埋まるようにする
- 新規 `pipeline-enrich-elevation` Cloud Run Job (gen2 + GCS FUSE で yj-raw を read-only マウント)、`yj-enriched` バケット、Workflows YAML に region switch を追加
- side-table 設計で extracted と elevation を別 parquet に分離 (PBF 月次更新 vs DEM 年次更新のライフサイクル分離)

設計討論・code review 対応含む詳細: [doc/enrich-elevation.md](./doc/enrich-elevation.md)

## 主な変更

| 領域 | 内容 |
|------|------|
| Cloud Run Job | `pipeline-enrich-elevation` 新規 (mem 8Gi、`--dem-dir /mnt/dem/dem` で lex-max YYYYMMDD subdir を選択) |
| GCS | `yj-enriched` バケット新規、`yj-raw` を Coldline 化 + lifecycle delete を `osm/` prefix だけに限定 (DEM 自動削除されない) |
| Parquet | `ElevationParquetRecord` (薄い side table) + `ServingJunctionParquetRecord` (extracted + elevation、`-9999.0` sentinel) を追加、`write/read_parquet_bytes` を generic 化 |
| Binary 改修 | prepare-serving を concat → osm_node_id LEFT JOIN (`--extracted`/`--enrichment`)、load-to-cockroach は ServingJunctionParquetRecord 経由に変更 |
| Workflows YAML | `region` 駆動 switch 追加 (catalog 駆動、missing/空文字列は `unknown` にフォールバック)、prepare_serving_args を init で default 宣言 |
| ElevationProvider | `.xml.gz` 透過読み (flate2)、glob を flat/xml/ 両 layout 対応、mesh-not-found を Err → Ok(None) (out-of-coverage を first-class に) |
| catalog | `pipeline/datasets.json` の各 entry に `\"region\": \"japan\"` 追加 |
| operator手順 | README に DEM 年次更新フロー (`gzip -k` + `gsutil cp` + 古い prefix 掃除) |

## terraform plan

```
Plan: 8 to add, 3 to change, 0 to destroy
```

新規作成 (8): enrich-elevation の Job / SA / IAM x4 / bucket / workflow_acts_as
変更 (本 PR、2): yj_raw (COLDLINE + matches_prefix)、yj-pipeline workflow (region switch)
変更 (本 PR 無関係、1): backend service の gcloud client メタデータ drift correction

## Test plan

- [x] cargo test (lib 92 + bin 6 + integration 47 = 145 PASS)
- [x] cargo fmt --check / cargo clippy -D warnings
- [x] terraform fmt -check / terraform plan (HCP Terraform 経由で schema 検証通過)
- [ ] apply 後、staging に gsutil cp で fixture-size DEM を投入し `gcloud workflows execute yj-pipeline --data='{...,\"region\":\"japan\"}'` で end-to-end smoke
- [ ] Workflows DSL の `default()` / `map.get()` / `if()` 関数が runtime に評価される確認 (plan 段階では検出不可)
- [ ] GCS FUSE volume mount が gen2 Job で実挙動する確認

## 残った確認点 (apply 前 / 別 issue 候補)

- 既存 yj-raw 上の Standard クラスオブジェクトは新規 upload で順次 Coldline 化、operator が `gsutil rewrite` で前倒し可能
- 旧 schema (`JunctionParquetRecord`) で書かれた serving parquet は新 load-to-cockroach で読めない (apply 後の transient 期間のみ影響、recovery には extract から再走)
- DEM 不在時は enrich-elevation Job が fail-loud、graceful fallback なし (operator alert 駆動が正しい設計として受容)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an elevation-enrichment pipeline and serving-stage support to include DEM-derived elevation in junction outputs (Japan region).
  * Serving rows now carry elevation fields with a sentinel for missing values; load path unwraps sentinels.

* **Infrastructure**
  * Workflow and pipeline staged for a Japan-only enrich step, new enriched storage bucket, service account, and job runtime packaging.

* **Documentation**
  * Added DEM annual update procedures and comprehensive elevation-enrichment implementation guide.

* **Tests**
  * Added unit tests covering gzipped DEM handling, enrichment logic, and parquet roundtrips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozy-corner/y-junctions/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->