### PR TITLE
chore: prod DB migration step を migration 変更時のみ実行する (#240)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       backend-deploy: ${{ steps.filter.outputs.backend-deploy }}
+      backend-migrate: ${{ steps.filter.outputs.backend-migrate }}
       frontend: ${{ steps.filter.outputs.frontend }}
       pipeline: ${{ steps.filter.outputs.pipeline }}
       pipeline-staging-migrate: ${{ steps.filter.outputs.pipeline-staging-migrate }}
@@ -60,6 +61,12 @@ jobs:
               - 'backend/src/domain/**'
               - 'backend/Cargo.toml'
               - 'backend/Cargo.lock'
+              - '.github/workflows/deploy.yml'
+            # backend-migrate: Gates the prod `sqlx migrate run` step inside
+            # backend-deploy. Without this, every backend code edit would run a
+            # no-op migration against prod (unnecessary auth + log noise).
+            backend-migrate:
+              - 'backend/migrations/**'
               - '.github/workflows/deploy.yml'
             # pipeline-staging-migrate: Triggers staging DB migrations only when
             # migration files (or this workflow) change. Kept narrow on purpose so
@@ -217,6 +224,7 @@ jobs:
         run: cargo install sqlx-cli --version "^0.8" --no-default-features --features postgres,rustls
 
       - name: Run database migrations
+        if: needs.changes.outputs.backend-migrate == 'true'
         working-directory: backend
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
## Summary
- `backend-deploy` Job の `sqlx migrate run` step が backend code 変更でも毎回実行され、prod CockroachDB への不要な接続・認証・ログノイズを発生させていた
- `changes` Job に `backend-migrate` filter (`backend/migrations/**`) を追加
- migration step に `if: needs.changes.outputs.backend-migrate == 'true'` を付与
- Job 構造は変えず差分 8 行のみ

Closes #240

## Test plan
- [ ] CI で `backend/src/**` のみ変更したコミットでは migration step が skip されることを確認（このPR自体も該当 — `.github/workflows/deploy.yml` 変更なので `backend-migrate` が true になり、migration が走る前提）
- [ ] migration ファイル変更を含む後続 PR で migration step が引き続き走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow to optimize database migration execution in production, ensuring migrations only run when migration-related changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->