### PR TITLE
fix: 香港・マカオの除外bboxをOSM実測境界に合わせる

### DIFF
--- a/backend/src/domain/china.rs
+++ b/backend/src/domain/china.rs
@@ -20,12 +20,14 @@ pub fn is_in_china_mainland(lng: f64, lat: f64) -> bool {
         return false;
     }
 
-    // Hong Kong
-    if (113.8..=114.5).contains(&lng) && (22.1..=22.6).contains(&lat) {
+    // Hong Kong (OSM R913110: lng 113.817-114.502, lat 22.137-22.568)
+    if (113.8..=114.51).contains(&lng) && (22.1..=22.6).contains(&lat) {
         return false;
     }
-    // Macao
-    if (113.5..=113.6).contains(&lng) && (22.1..=22.2).contains(&lat) {
+    // Macao (OSM R1867188: lng 113.528-113.630, lat 22.077-22.217)。北辺 22.22 は
+    // 珠海拱北を数百m巻き込むが、マカオ半島北部を本土扱いして街景リンクを落とすより
+    // 副作用が小さい。
+    if (113.52..=113.64).contains(&lng) && (22.07..=22.22).contains(&lat) {
         return false;
     }
     // Taiwan (上限 122.1 で基隆北東沿岸・棉花嶼/彭佳嶼 をカバー)
@@ -349,6 +351,28 @@ mod tests {
         assert!(!is_in_china_mainland(114.1694, 22.3193)); // Hong Kong
         assert!(!is_in_china_mainland(113.5439, 22.1987)); // Macao
         assert!(!is_in_china_mainland(121.5654, 25.0330)); // Taipei
+    }
+
+    #[test]
+    fn macao_edges_are_excluded() {
+        // 旧 bbox (113.5-113.6 / 22.1-22.2) から漏れていた縁。
+        assert!(!is_in_china_mainland(113.5490, 22.2130)); // 關閘 (半島北端)
+        assert!(!is_in_china_mainland(113.5680, 22.2100)); // 黑沙環 (北東部)
+        assert!(!is_in_china_mainland(113.6100, 22.1400)); // 路氹東岸 (lng > 113.6)
+        assert!(!is_in_china_mainland(113.5580, 22.0900)); // 路環南部
+    }
+
+    #[test]
+    fn hong_kong_eastern_edge_is_excluded() {
+        assert!(!is_in_china_mainland(114.5020, 22.5400)); // 東平洲付近 (lng > 114.5)
+    }
+
+    #[test]
+    fn zhuhai_stays_china_mainland() {
+        // マカオ bbox を広げた分の regression guard。
+        // 深圳は既存の香港 bbox (lat 上限 22.6) に元から含まれるのでここでは扱わない。
+        assert!(is_in_china_mainland(113.5767, 22.2707)); // 珠海 (拱北の北)
+        assert!(is_in_china_mainland(113.7518, 23.0207)); // 東莞
     }
 
     #[test]


### PR DESCRIPTION
## 背景

香港・マカオのY字路データ追加を検討する中で、`is_in_china_mainland()` の除外ボックスが実際の行政境界より狭いことが判明した。

`is_in_china_mainland()` が true になると、`streetview_enricher.rs` は百度パノラマIDを要求し、無い場合は**マーカーごとレスポンスから除外**する。つまり除外ボックスの欠けは「その範囲のY字路が地図から消える」ことを意味する。

## 実測値との比較

OSM の公式境界リレーションを Nominatim で確認した。

| | 実際の範囲 | 修正前 | 修正後 |
|---|---|---|---|
| マカオ (R1867188) | lng 113.528–113.630 / lat 22.077–22.217 | 113.5–113.6 / 22.1–22.2 | 113.52–113.64 / 22.07–22.22 |
| 香港 (R913110) | lng 113.817–114.502 / lat 22.137–22.568 | 113.8–114.5 / 22.1–22.6 | 113.8–114.51 / 22.1–22.6 |

マカオは欠けが大きく、半島北部（關閘）・路氹東岸・路環南部が本土扱いだった。香港は東端が 114.5 ちょうどで切れていた。

## トレードオフ

マカオ北辺を 22.22 にすると珠海拱北を数百m巻き込む。ただし巻き込まれた側は「Googleリンクは付くが街景が無い可能性がある」だけなのに対し、逆方向の誤りはマーカー消失なので、こちらを選んだ。既存コメントの "Edge cases on the border degrade gracefully" と同じ方針。

## テスト

- `macao_edges_are_excluded` — 旧boxから漏れていた4点
- `hong_kong_eastern_edge_is_excluded` — 東平洲付近
- `zhuhai_stays_china_mainland` — 拡張分の regression guard（珠海・東莞）

`cargo test` 全件パス（151 tests）、clippy/fmt クリーン。

## 補足（本PRでは対応しない）

深圳は既存の香港box (lat 上限 22.6) に元から含まれており本土判定されない。現状プロダクションに深圳のデータは無いため実害は無いが、将来 広東省 を追加する際は別途対応が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mainland China geographic boundary detection around Hong Kong and Macao.
  * Corrected classification for nearby mainland locations, including Zhuhai and Dongguan.
  * Added coverage for edge coordinates to improve location accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->