### PR TITLE
chore: Street View Static API 有効化とローカル enrich 用 API キーを Terraform 化 (#306)

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -44,3 +44,9 @@ output "cockroachdb_connection_uri" {
   value       = local.cockroachdb_connection_uri
   sensitive   = true
 }
+
+output "streetview_api_key" {
+  description = "Street View Static API key for the local enrich batch (paste into backend/.env as GOOGLE_MAPS_API_KEY)"
+  value       = google_apikeys_key.streetview_metadata.key_string
+  sensitive   = true
+}

--- a/terraform/streetview.tf
+++ b/terraform/streetview.tf
@@ -20,7 +20,16 @@ resource "google_apikeys_key" "streetview_metadata" {
   display_name = "Street View Metadata (local enrich, issue #306)"
   project      = var.project_id
 
-  # Street View Static API 以外には使えないキーにする（漏洩時の課金事故を防ぐ）。
+  # API 制限で Street View Static API 以外には使えないキーにする（least privilege）。
+  # ただしこれはサービス単位の制限で、Street View Static には無料の metadata と
+  # 課金対象の画像取得の両方が含まれるため、漏洩時の画像課金までは防げない。
+  # 追加の緩和として:
+  #  - IP 制限(server_key_restrictions.allowed_ips): enrich はローカルの動的 IP で
+  #    走るため不可。
+  #  - メソッド制限(api_targets.methods)で metadata 限定: Street View の metadata は
+  #    RPC メソッドではなく URL パスの違いで、絞れるメソッド識別子が無いため不可。
+  #  - 採用: enrich は metadata(無料)しか叩かないので、Cloud Console で画像リクエストの
+  #    日次クォータ上限を最小化し漏洩時の課金を頭打ちにする。詳細: doc/streetview-coverage-filter.md
   restrictions {
     api_targets {
       service = "street-view-image-backend.googleapis.com"

--- a/terraform/streetview.tf
+++ b/terraform/streetview.tf
@@ -28,8 +28,9 @@ resource "google_apikeys_key" "streetview_metadata" {
   #    走るため不可。
   #  - メソッド制限(api_targets.methods)で metadata 限定: Street View の metadata は
   #    RPC メソッドではなく URL パスの違いで、絞れるメソッド識別子が無いため不可。
-  #  - 採用: enrich は metadata(無料)しか叩かないので、Cloud Console で画像リクエストの
-  #    日次クォータ上限を最小化し漏洩時の課金を頭打ちにする。詳細: doc/streetview-coverage-filter.md
+  #  - 採用: enrich は metadata(無料・別メトリック)しか叩かないので、下記の
+  #    google_service_usage_consumer_quota_override で課金メトリックの日次上限を 0 にし、
+  #    漏洩時の画像課金を構造的に封じる。詳細: doc/streetview-coverage-filter.md
   restrictions {
     api_targets {
       service = "street-view-image-backend.googleapis.com"
@@ -40,4 +41,29 @@ resource "google_apikeys_key" "streetview_metadata" {
     google_project_service.streetview,
     google_project_service.apikeys,
   ]
+}
+
+# enrich は metadata(無料・別メトリック street_view_metadata)しか叩かないため、
+# 課金対象の画像リクエスト2メトリックの日次上限を 0 に絞る。これでキーが漏れても
+# 画像課金は発生し得ず、metadata の enrich には影響しない。指摘A(Qodo/CodeRabbit)対応。
+resource "google_service_usage_consumer_quota_override" "streetview_billable_default_daily" {
+  provider       = google-beta
+  service        = "street-view-image-backend.googleapis.com"
+  metric         = urlencode("street-view-image-backend.googleapis.com/billable_default")
+  limit          = urlencode("/d/project")
+  override_value = "0"
+  force          = true
+
+  depends_on = [google_project_service.streetview]
+}
+
+resource "google_service_usage_consumer_quota_override" "streetview_billable_unsigned_daily" {
+  provider       = google-beta
+  service        = "street-view-image-backend.googleapis.com"
+  metric         = urlencode("street-view-image-backend.googleapis.com/billable_unsignedbucket")
+  limit          = urlencode("/d/project")
+  override_value = "0"
+  force          = true
+
+  depends_on = [google_project_service.streetview]
 }

--- a/terraform/streetview.tf
+++ b/terraform/streetview.tf
@@ -1,0 +1,34 @@
+# Street View Static API metadata を叩くための API 有効化とキー発行。
+# キーはローカルの enrich バッチ（backend/src/bin, issue #306）が backend/.env
+# から読むために使う。サーバー（Cloud Run）には載せないので Secret Manager /
+# Cloud Run への配線は無い。キー値は output 経由でローカル .env に貼る。
+# 詳細設計: doc/streetview-coverage-filter.md
+
+resource "google_project_service" "streetview" {
+  service            = "street-view-image-backend.googleapis.com"
+  disable_on_destroy = false
+}
+
+# キーを Terraform で払い出すには API Keys API 自体の有効化が前提。
+resource "google_project_service" "apikeys" {
+  service            = "apikeys.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_apikeys_key" "streetview_metadata" {
+  name         = "streetview-metadata-local"
+  display_name = "Street View Metadata (local enrich, issue #306)"
+  project      = var.project_id
+
+  # Street View Static API 以外には使えないキーにする（漏洩時の課金事故を防ぐ）。
+  restrictions {
+    api_targets {
+      service = "street-view-image-backend.googleapis.com"
+    }
+  }
+
+  depends_on = [
+    google_project_service.streetview,
+    google_project_service.apikeys,
+  ]
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -14,6 +14,12 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
+    # google_service_usage_consumer_quota_override（Street View 課金クォータの
+    # 日次上限を 0 にする）は GA provider に無く beta のみ。
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
     neon = {
       source  = "kislerdm/neon"
       version = "~> 0.6"
@@ -26,6 +32,11 @@ terraform {
 }
 
 provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
   project = var.project_id
   region  = var.region
 }


### PR DESCRIPTION
## 概要

海外の無ストリートビューノード除外（#306）で使う Google Street View metadata 照会用に、GCP リソースを Terraform 化する。

- `google_project_service.streetview`（`street-view-image-backend.googleapis.com` 有効化）
- `google_project_service.apikeys`（`apikeys.googleapis.com` 有効化）
- `google_apikeys_key.streetview_metadata`（Street View に制限した API キー）
- output `streetview_api_key`（sensitive）

キーはローカルの enrich バッチが `backend/.env` から読むためのもの。**サーバー（Cloud Run）には載せない**ので Secret Manager / Cloud Run への配線は無い。値は `terraform output -raw streetview_api_key` からローカル `.env` へ。

## 適用状況

`-target` で**この3リソースだけを本番に apply 済み**（`3 added, 0 changed, 0 destroyed`）。標高 pipeline の既存ドリフトは巻き込んでいない。リソースが state に存在し config が未マージだと drift になるため、本 PR を早めに merge したい。

## 疎通確認

- キー有効・認証通過（`REQUEST_DENIED` にならない）
- `radius=10&source=outdoor` で `OK`/`ZERO_RESULTS` 判別 OK
- ローカル DB の実海外ノードで検証：8件中2件が `ZERO_RESULTS`（＝除外対象が実在）

## 設計

`doc/streetview-coverage-filter.md`

Refs #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Google Street View services for enrichment workflows.
  * Added a restricted Street View API key for local configuration.
  * Exposed the API key as a sensitive Terraform output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->