### PR TITLE
chore: google_streetview_coverage テーブルを追加 (#306)

### DIFF
--- a/backend/migrations/011_create_google_streetview_coverage.sql
+++ b/backend/migrations/011_create_google_streetview_coverage.sql
@@ -1,0 +1,18 @@
+-- Google Street View coverage cache, keyed by osm_node_id.
+-- Why a separate table instead of a y_junctions column: /deploy-data pushes to
+-- prod with IMPORT INTO (append-only, no UPDATE), so coverage for already
+-- deployed nodes can only be added as new rows in a table of its own. Keying on
+-- osm_node_id (stable across re-imports, unlike the auto-incremented
+-- y_junctions.id) keeps the cache from being orphaned.
+--
+-- Three states: row with has_coverage=true (panorama exists) / row with false
+-- (none -> excluded from the map) / no row at all (not queried yet -> shown).
+-- Only "queried successfully and confirmed absent" writes false.
+--
+-- No pano_id or panorama coordinates: Google Street View URLs are generated
+-- from the junction coordinates alone, so nothing else would ever be read.
+CREATE TABLE google_streetview_coverage (
+  osm_node_id BIGINT PRIMARY KEY,
+  has_coverage BOOLEAN NOT NULL,
+  queried_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/migrations/011_create_google_streetview_coverage.sql
+++ b/backend/migrations/011_create_google_streetview_coverage.sql
@@ -1,16 +1,9 @@
--- Google Street View coverage cache, keyed by osm_node_id.
--- Why a separate table instead of a y_junctions column: /deploy-data pushes to
--- prod with IMPORT INTO (append-only, no UPDATE), so coverage for already
--- deployed nodes can only be added as new rows in a table of its own. Keying on
--- osm_node_id (stable across re-imports, unlike the auto-incremented
--- y_junctions.id) keeps the cache from being orphaned.
+-- Google Street View coverage cache. See doc/streetview-coverage-filter.md.
 --
--- Three states: row with has_coverage=true (panorama exists) / row with false
--- (none -> excluded from the map) / no row at all (not queried yet -> shown).
--- Only "queried successfully and confirmed absent" writes false.
---
--- No pano_id or panorama coordinates: Google Street View URLs are generated
--- from the junction coordinates alone, so nothing else would ever be read.
+-- Three states: true = panorama exists, false = none (excluded from the map),
+-- no row at all = not queried yet (still shown).
+-- Keyed on osm_node_id, not y_junctions.id: ids churn on re-import and would
+-- orphan the cache (same reason as baidu_panoramas in migration 009).
 CREATE TABLE google_streetview_coverage (
   osm_node_id BIGINT PRIMARY KEY,
   has_coverage BOOLEAN NOT NULL,


### PR DESCRIPTION
Issue #306 / 設計書 `doc/streetview-coverage-filter.md` の **PR-1**。DDL のみで、参照するコードは PR-2 で入る。

## 変更
- `backend/migrations/011_create_google_streetview_coverage.sql`
  - `osm_node_id BIGINT PRIMARY KEY` / `has_coverage BOOLEAN NOT NULL` / `queried_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
  - 3状態: 行あり+true=カバレッジあり / 行あり+false=無し（除外対象） / 行なし=未照会（表示する）

## 設計上の判断
- **`y_junctions` への列追加ではなく別テーブル**: `/deploy-data` の本番反映は `IMPORT INTO`（追記のみ・UPDATE 不可）なので、既にデプロイ済みノードのカバレッジを後から入れるには別テーブルへの追記が必要。`baidu_panoramas` で実証済みの経路に乗る。
- **`osm_node_id` 主キー**: `y_junctions.id` は再採番されるためキャッシュが孤立する（migration 009 と同じ理由）。
- **`pano_id` / パノラマ座標は持たない**: Google の URL は座標だけから生成できるため、保存しても読む側がいない（YAGNI）。

## 検証
使い捨て DB に 001〜011 を適用して通ることと、テーブル定義を確認済み。

\`\`\`
$ DATABASE_URL=...mig_check_306 sqlx migrate run
Applied 11/migrate create google streetview coverage (20.457334ms)

$ SHOW CREATE TABLE google_streetview_coverage;
CREATE TABLE public.google_streetview_coverage (
  osm_node_id INT8 NOT NULL,
  has_coverage BOOL NOT NULL,
  queried_at TIMESTAMPTZ NOT NULL DEFAULT now():::TIMESTAMPTZ,
  CONSTRAINT google_streetview_coverage_pkey PRIMARY KEY (osm_node_id ASC)
);
\`\`\`

deploy 時は `backend-migrate` / `pipeline-staging-migrate` の両方に適用される。pipeline DB では使わないが `CREATE TABLE` は無害。

Refs #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Street View coverage tracking for map locations.
  * Coverage status now distinguishes available, unavailable, and not-yet-checked locations.
  * Records when each location’s coverage was last checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->