### PR TITLE
feat: Street View カバレッジ照会バッチを追加 (#306)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,7 @@
 # CockroachDB (local development via docker-compose)
 DATABASE_URL=postgresql://root@localhost:26257/y_junction?sslmode=disable
 TEST_DATABASE_URL=postgresql://root@localhost:26257/y_junction_test?sslmode=disable
+
+# Street View Static API key — only the import-google-streetview batch reads
+# this. Fetch with: terraform output -raw streetview_api_key
+GOOGLE_MAPS_API_KEY=

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,6 +20,10 @@ name = "import-baidu-panoid"
 path = "src/bin/import_baidu_panoid.rs"
 
 [[bin]]
+name = "import-google-streetview"
+path = "src/bin/import_google_streetview.rs"
+
+[[bin]]
 name = "pipeline-download-osm"
 path = "src/bin/pipeline_download_osm.rs"
 

--- a/backend/src/bin/import_google_streetview.rs
+++ b/backend/src/bin/import_google_streetview.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use clap::Parser;
+use sqlx::postgres::PgPoolOptions;
+
+#[derive(Parser, Debug)]
+#[command(name = "import-google-streetview")]
+#[command(about = "Query Google Street View coverage for non-China Y-junctions")]
+struct Args {
+    /// Also re-query junctions already recorded as uncovered. Google adds
+    /// imagery over time, so `has_coverage = false` is not permanent.
+    #[arg(long)]
+    refresh: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    dotenvy::dotenv().ok();
+
+    let args = Args::parse();
+
+    tracing::info!(
+        "Starting Street View coverage lookup (refresh={})",
+        args.refresh
+    );
+
+    let database_url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set in environment or .env file");
+
+    tracing::info!("Connecting to database...");
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
+
+    tracing::info!("Database connection established");
+
+    let count =
+        y_junction_backend::importer::import_google_coverage_data(&pool, args.refresh).await?;
+
+    tracing::info!(
+        "Street View coverage lookup complete: {} rows written",
+        count
+    );
+
+    Ok(())
+}

--- a/backend/src/db/google_repository.rs
+++ b/backend/src/db/google_repository.rs
@@ -44,21 +44,15 @@ pub async fn find_uncovered_nodes(
     pool: &PgPool,
     refresh: bool,
 ) -> Result<Vec<CoverageCandidate>, sqlx::Error> {
-    // Two literals rather than an interpolated WHERE clause: sqlx only accepts
-    // 'static SQL strings (SqlSafeStr).
-    let sql = if refresh {
+    let rows: Vec<CoverageCandidate> = sqlx::query_as(
         "SELECT y.osm_node_id, y.lon, y.lat \
          FROM y_junctions y \
          LEFT JOIN google_streetview_coverage g ON g.osm_node_id = y.osm_node_id \
-         WHERE g.osm_node_id IS NULL OR g.has_coverage = false"
-    } else {
-        "SELECT y.osm_node_id, y.lon, y.lat \
-         FROM y_junctions y \
-         LEFT JOIN google_streetview_coverage g ON g.osm_node_id = y.osm_node_id \
-         WHERE g.osm_node_id IS NULL"
-    };
-
-    let rows: Vec<CoverageCandidate> = sqlx::query_as(sql).fetch_all(pool).await?;
+         WHERE g.osm_node_id IS NULL OR ($1 AND g.has_coverage = false)",
+    )
+    .bind(refresh)
+    .fetch_all(pool)
+    .await?;
 
     Ok(rows)
 }

--- a/backend/src/db/google_repository.rs
+++ b/backend/src/db/google_repository.rs
@@ -1,0 +1,107 @@
+use sqlx::{FromRow, PgPool, QueryBuilder};
+use std::collections::HashMap;
+
+/// A junction awaiting (or due for re-)coverage lookup. Only the fields the
+/// enrich batch needs: the id to key the cache on and the coordinate to query
+/// and to run the China check against.
+#[derive(Debug, FromRow, PartialEq)]
+pub struct CoverageCandidate {
+    pub osm_node_id: i64,
+    pub lon: f64,
+    pub lat: f64,
+}
+
+/// Look up cached coverage for the given OSM node ids. A missing key means
+/// "never queried" — distinct from a present `false`, which means Google
+/// confirmed there is no panorama.
+pub async fn find_coverage_by_osm_node_ids(
+    pool: &PgPool,
+    osm_node_ids: &[i64],
+) -> Result<HashMap<i64, bool>, sqlx::Error> {
+    if osm_node_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows: Vec<(i64, bool)> = sqlx::query_as(
+        "SELECT osm_node_id, has_coverage \
+         FROM google_streetview_coverage \
+         WHERE osm_node_id = ANY($1)",
+    )
+    .bind(osm_node_ids)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().collect())
+}
+
+/// Junctions to query: never-queried ones, plus (when `refresh`) the ones
+/// previously recorded as uncovered, since Google's coverage grows over time.
+///
+/// Returns every region — the mainland-China check lives only in
+/// `domain::china::is_in_china_mainland` (hand-written bboxes in Rust) and
+/// `y_junctions` has no region column, so the caller filters in-process.
+pub async fn find_uncovered_nodes(
+    pool: &PgPool,
+    refresh: bool,
+) -> Result<Vec<CoverageCandidate>, sqlx::Error> {
+    // Two literals rather than an interpolated WHERE clause: sqlx only accepts
+    // 'static SQL strings (SqlSafeStr).
+    let sql = if refresh {
+        "SELECT y.osm_node_id, y.lon, y.lat \
+         FROM y_junctions y \
+         LEFT JOIN google_streetview_coverage g ON g.osm_node_id = y.osm_node_id \
+         WHERE g.osm_node_id IS NULL OR g.has_coverage = false"
+    } else {
+        "SELECT y.osm_node_id, y.lon, y.lat \
+         FROM y_junctions y \
+         LEFT JOIN google_streetview_coverage g ON g.osm_node_id = y.osm_node_id \
+         WHERE g.osm_node_id IS NULL"
+    };
+
+    let rows: Vec<CoverageCandidate> = sqlx::query_as(sql).fetch_all(pool).await?;
+
+    Ok(rows)
+}
+
+/// Upsert coverage results keyed by `osm_node_id`. Existing rows are
+/// overwritten because a `--refresh` run can flip `false` to `true` once
+/// Google adds imagery.
+pub async fn upsert_coverage(pool: &PgPool, rows: &[(i64, bool)]) -> Result<usize, sqlx::Error> {
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let mut tx = pool.begin().await?;
+    // Keeps each statement well under PostgreSQL's parameter limit.
+    const BATCH_SIZE: usize = 1000;
+    let mut total = 0;
+
+    for chunk in rows.chunks(BATCH_SIZE) {
+        let mut qb = QueryBuilder::new(
+            "INSERT INTO google_streetview_coverage (osm_node_id, has_coverage, queried_at) VALUES ",
+        );
+
+        for (i, (osm_node_id, has_coverage)) in chunk.iter().enumerate() {
+            if i > 0 {
+                qb.push(", ");
+            }
+            qb.push("(");
+            qb.push_bind(*osm_node_id);
+            qb.push(", ");
+            qb.push_bind(*has_coverage);
+            qb.push(", NOW())");
+        }
+
+        qb.push(
+            " ON CONFLICT (osm_node_id) DO UPDATE SET \
+             has_coverage = EXCLUDED.has_coverage, \
+             queried_at = NOW()",
+        );
+
+        let result = qb.build().execute(&mut *tx).await?;
+        total += result.rows_affected() as usize;
+    }
+
+    tx.commit().await?;
+    Ok(total)
+}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod baidu_repository;
+pub mod google_repository;
 pub mod repository;
 
 use sqlx::postgres::PgPoolOptions;

--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -181,7 +181,10 @@ fn classify_status(status: &str) -> Classification {
     match status {
         "OK" => Classification::Covered,
         "ZERO_RESULTS" | "NOT_FOUND" => Classification::Absent,
-        "OVER_QUERY_LIMIT" => Classification::Transient,
+        // Documented as "exceeded your daily quota or per-second quota" and
+        // "couldn't be processed due to a server error" — both worth a retry,
+        // and neither ever writes has_coverage = false.
+        "OVER_QUERY_LIMIT" | "UNKNOWN_ERROR" => Classification::Transient,
         // REQUEST_DENIED / INVALID_REQUEST and anything undocumented: never
         // guess "no coverage" from a status we do not understand.
         _ => Classification::Fatal,
@@ -211,18 +214,18 @@ mod tests {
     }
 
     #[test]
-    fn over_query_limit_is_transient() {
+    fn quota_and_server_errors_are_transient() {
         assert_eq!(
             classify_status("OVER_QUERY_LIMIT"),
             Classification::Transient
         );
+        assert_eq!(classify_status("UNKNOWN_ERROR"), Classification::Transient);
     }
 
     #[test]
-    fn denied_and_unknown_statuses_are_fatal() {
+    fn denied_and_undocumented_statuses_are_fatal() {
         assert_eq!(classify_status("REQUEST_DENIED"), Classification::Fatal);
         assert_eq!(classify_status("INVALID_REQUEST"), Classification::Fatal);
-        assert_eq!(classify_status("UNKNOWN_ERROR"), Classification::Fatal);
         assert_eq!(classify_status(""), Classification::Fatal);
         // Lower-case is not a documented spelling; must not read as absent.
         assert_eq!(classify_status("zero_results"), Classification::Fatal);

--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -27,6 +27,11 @@ enum FetchError {
     RateLimited {
         retry_after: Option<Duration>,
     },
+    /// HTTP 5xx or `UNKNOWN_ERROR`: retryable like a rate limit, but named
+    /// separately so the operator isn't sent to check quotas over an outage.
+    ServerError {
+        status: Option<StatusCode>,
+    },
     /// Bad key, missing permission, malformed request — retrying cannot help
     /// and treating it as "no coverage" would write false for every node, so
     /// abort the batch immediately.
@@ -35,6 +40,17 @@ enum FetchError {
 }
 
 impl FetchError {
+    /// How long to wait before the next attempt. Honours `Retry-After` when
+    /// Google sent one, capped so a hostile value can't stall the batch.
+    fn backoff_sleep(&self) -> Duration {
+        match self {
+            Self::RateLimited { retry_after } => retry_after
+                .unwrap_or(DEFAULT_RATE_LIMIT_SLEEP)
+                .min(MAX_RATE_LIMIT_SLEEP),
+            _ => DEFAULT_RATE_LIMIT_SLEEP,
+        }
+    }
+
     fn into_anyhow(self) -> anyhow::Error {
         match self {
             Self::RateLimited { retry_after } => anyhow::anyhow!(
@@ -42,6 +58,12 @@ impl FetchError {
                 retry_after
                     .map(|d| format!("{}s", d.as_secs()))
                     .unwrap_or_else(|| "unspecified".to_string())
+            ),
+            Self::ServerError { status } => anyhow::anyhow!(
+                "Street View metadata server error ({}); retry once Google recovers",
+                status
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "status=UNKNOWN_ERROR".to_string())
             ),
             Self::Fatal(e) | Self::Transient(e) => e,
         }
@@ -105,21 +127,20 @@ pub async fn fetch_coverage(client: &Client, api_key: &str, lng: f64, lat: f64) 
         match request_metadata(client, api_key, lng, lat).await {
             Ok(covered) => return Ok(covered),
             Err(FetchError::Fatal(e)) => return Err(e),
-            Err(FetchError::RateLimited { retry_after }) => {
+            Err(err @ (FetchError::RateLimited { .. } | FetchError::ServerError { .. })) => {
                 if attempt + 1 == MAX_ATTEMPTS {
-                    return Err(FetchError::RateLimited { retry_after }.into_anyhow());
+                    return Err(err.into_anyhow());
                 }
-                let sleep_dur = retry_after
-                    .unwrap_or(DEFAULT_RATE_LIMIT_SLEEP)
-                    .min(MAX_RATE_LIMIT_SLEEP);
+                let sleep_dur = err.backoff_sleep();
                 tracing::warn!(
-                    "Street View metadata rate-limited; sleeping {:?} before retry {}/{}",
+                    "{:?}; sleeping {:?} before retry {}/{}",
+                    err,
                     sleep_dur,
                     attempt + 2,
                     MAX_ATTEMPTS
                 );
                 tokio::time::sleep(sleep_dur).await;
-                last_err = Some(FetchError::RateLimited { retry_after });
+                last_err = Some(err);
             }
             Err(FetchError::Transient(e)) => {
                 last_err = Some(FetchError::Transient(e));
@@ -155,13 +176,18 @@ async fn request_metadata(
         .map_err(|e| FetchError::Transient(e.without_url().into()))?;
 
     let status = resp.status();
-    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+    if status == StatusCode::TOO_MANY_REQUESTS {
         let retry_after = resp
             .headers()
             .get(header::RETRY_AFTER)
             .and_then(|v| v.to_str().ok())
             .and_then(parse_retry_after);
         return Err(FetchError::RateLimited { retry_after });
+    }
+    if status.is_server_error() {
+        return Err(FetchError::ServerError {
+            status: Some(status),
+        });
     }
     if let Err(e) = resp.error_for_status_ref() {
         return Err(FetchError::Fatal(
@@ -198,7 +224,10 @@ async fn request_metadata(
             Ok(true)
         }
         Classification::Absent => Ok(false),
-        Classification::Transient => Err(FetchError::RateLimited { retry_after: None }),
+        Classification::Transient if body.status == "OVER_QUERY_LIMIT" => {
+            Err(FetchError::RateLimited { retry_after: None })
+        }
+        Classification::Transient => Err(FetchError::ServerError { status: None }),
         Classification::Fatal => Err(FetchError::Fatal(anyhow::anyhow!(
             "Street View metadata returned status={} — check {API_KEY_ENV} and API enablement",
             body.status

--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -11,7 +11,7 @@ const API_KEY_ENV: &str = "GOOGLE_MAPS_API_KEY";
 // not a hard cap (see `request_metadata`), so COVERAGE_LIMIT_METERS enforces
 // the real distance rule on the returned panorama.
 const SEARCH_RADIUS_METERS: u32 = 10;
-const COVERAGE_LIMIT_METERS: f64 = 10.0;
+pub const COVERAGE_LIMIT_METERS: f64 = 10.0;
 
 const MAX_ATTEMPTS: usize = 3;
 const TRANSIENT_RETRY_SLEEP: Duration = Duration::from_millis(500);
@@ -123,17 +123,42 @@ pub async fn pace_next_request() {
     tokio::time::sleep(PACING).await;
 }
 
+/// Coverage verdict for one junction. `Absent` and `TooFar` both mean
+/// `has_coverage = false`; they are kept apart so the batch can report how
+/// often our own distance rule — rather than Google — did the excluding.
+#[derive(Debug, PartialEq)]
+pub enum Coverage {
+    Covered,
+    /// Google reported no panorama near the coordinate.
+    Absent,
+    /// Google returned a panorama, but farther than `COVERAGE_LIMIT_METERS`.
+    TooFar {
+        distance_meters: f64,
+    },
+}
+
+impl Coverage {
+    pub fn has_coverage(&self) -> bool {
+        matches!(self, Self::Covered)
+    }
+}
+
 /// Ask the Street View Static metadata endpoint whether a panorama exists
 /// within 10 m of the coordinate. Metadata requests are free — no imagery is
 /// fetched. Retries transient failures up to `MAX_ATTEMPTS`, backs off on
 /// `OVER_QUERY_LIMIT`/429/5xx, and fails fast on `REQUEST_DENIED` so a broken
 /// key never gets recorded as "no coverage".
-pub async fn fetch_coverage(client: &Client, api_key: &str, lng: f64, lat: f64) -> Result<bool> {
+pub async fn fetch_coverage(
+    client: &Client,
+    api_key: &str,
+    lng: f64,
+    lat: f64,
+) -> Result<Coverage> {
     let mut last_err: Option<FetchError> = None;
 
     for attempt in 0..MAX_ATTEMPTS {
         match request_metadata(client, api_key, lng, lat).await {
-            Ok(covered) => return Ok(covered),
+            Ok(coverage) => return Ok(coverage),
             Err(FetchError::Fatal(e)) => return Err(e),
             Err(err @ (FetchError::RateLimited { .. } | FetchError::ServerError { .. })) => {
                 if attempt + 1 == MAX_ATTEMPTS {
@@ -167,7 +192,7 @@ async fn request_metadata(
     api_key: &str,
     lng: f64,
     lat: f64,
-) -> std::result::Result<bool, FetchError> {
+) -> std::result::Result<Coverage, FetchError> {
     let resp = client
         .get(ENDPOINT)
         .query(&[
@@ -222,16 +247,13 @@ async fn request_metadata(
             };
             let distance = ground_distance_meters(lat, lng, loc.lat, loc.lng);
             if distance > COVERAGE_LIMIT_METERS {
-                tracing::debug!(
-                    "nearest panorama is {:.1} m away (> {} m); treating as uncovered",
-                    distance,
-                    COVERAGE_LIMIT_METERS
-                );
-                return Ok(false);
+                return Ok(Coverage::TooFar {
+                    distance_meters: distance,
+                });
             }
-            Ok(true)
+            Ok(Coverage::Covered)
         }
-        Classification::Absent => Ok(false),
+        Classification::Absent => Ok(Coverage::Absent),
         Classification::Transient if body.status == "OVER_QUERY_LIMIT" => {
             Err(FetchError::RateLimited { retry_after: None })
         }
@@ -369,6 +391,16 @@ mod tests {
         assert_eq!(parse_retry_after(""), None);
         assert_eq!(parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT"), None);
         assert_eq!(parse_retry_after("-5"), None);
+    }
+
+    #[test]
+    fn only_covered_counts_as_coverage() {
+        assert!(Coverage::Covered.has_coverage());
+        assert!(!Coverage::Absent.has_coverage());
+        assert!(!Coverage::TooFar {
+            distance_meters: 483.2
+        }
+        .has_coverage());
     }
 
     #[test]

--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -98,12 +98,20 @@ enum Classification {
 /// keyless requests, which come back `REQUEST_DENIED`) keeps a forgotten
 /// `.env` from looking like a genuine coverage answer.
 pub fn api_key_from_env() -> Result<String> {
-    let key = std::env::var(API_KEY_ENV)
+    let raw = std::env::var(API_KEY_ENV)
         .map_err(|_| anyhow::anyhow!("{API_KEY_ENV} must be set in environment or .env file"))?;
-    if key.trim().is_empty() {
+    validate_api_key(&raw)
+}
+
+/// Returns the key with surrounding whitespace removed. A stray newline from
+/// pasting `terraform output` would otherwise be sent percent-encoded and come
+/// back as `REQUEST_DENIED`, which reads like a permissions problem.
+fn validate_api_key(raw: &str) -> Result<String> {
+    let key = raw.trim();
+    if key.is_empty() {
         anyhow::bail!("{API_KEY_ENV} is set but empty");
     }
-    Ok(key)
+    Ok(key.to_string())
 }
 
 pub fn build_client() -> Result<Client> {
@@ -364,22 +372,16 @@ mod tests {
     }
 
     #[test]
-    fn api_key_from_env_rejects_missing_and_empty() {
-        // Serialized within this test only: no other test touches this var.
-        let saved = std::env::var(API_KEY_ENV).ok();
+    fn api_key_rejects_blank_values() {
+        assert!(validate_api_key("").is_err());
+        assert!(validate_api_key("   ").is_err());
+        assert!(validate_api_key("\n").is_err());
+    }
 
-        std::env::remove_var(API_KEY_ENV);
-        assert!(api_key_from_env().is_err(), "missing key must error");
-
-        std::env::set_var(API_KEY_ENV, "   ");
-        assert!(api_key_from_env().is_err(), "blank key must error");
-
-        std::env::set_var(API_KEY_ENV, "test-key");
-        assert_eq!(api_key_from_env().unwrap(), "test-key");
-
-        match saved {
-            Some(v) => std::env::set_var(API_KEY_ENV, v),
-            None => std::env::remove_var(API_KEY_ENV),
-        }
+    #[test]
+    fn api_key_is_trimmed() {
+        // Pasting `terraform output` easily brings a trailing newline along.
+        assert_eq!(validate_api_key("AIza-test\n").unwrap(), "AIza-test");
+        assert_eq!(validate_api_key("  AIza-test  ").unwrap(), "AIza-test");
     }
 }

--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -180,7 +180,12 @@ async fn request_metadata(
 fn classify_status(status: &str) -> Classification {
     match status {
         "OK" => Classification::Covered,
-        "ZERO_RESULTS" | "NOT_FOUND" => Classification::Absent,
+        // The only status that means "no panorama here": documented as "no
+        // panorama could be found near the provided location". NOT_FOUND is
+        // *not* a synonym — it means the address string in `location` couldn't
+        // be found, which cannot happen when we only ever send coordinates, so
+        // it falls through to Fatal rather than writing a sticky false.
+        "ZERO_RESULTS" => Classification::Absent,
         // Documented as "exceeded your daily quota or per-second quota" and
         // "couldn't be processed due to a server error" — both worth a retry,
         // and neither ever writes has_coverage = false.
@@ -208,9 +213,11 @@ mod tests {
     }
 
     #[test]
-    fn zero_results_and_not_found_mean_absent() {
+    fn only_zero_results_means_absent() {
         assert_eq!(classify_status("ZERO_RESULTS"), Classification::Absent);
-        assert_eq!(classify_status("NOT_FOUND"), Classification::Absent);
+        // NOT_FOUND is about an unresolvable address string, which this batch
+        // never sends; recording it as "no coverage" would be a sticky lie.
+        assert_eq!(classify_status("NOT_FOUND"), Classification::Fatal);
     }
 
     #[test]

--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -1,0 +1,280 @@
+use anyhow::Result;
+use reqwest::{header, Client, StatusCode};
+use serde::Deserialize;
+use std::time::Duration;
+
+const ENDPOINT: &str = "https://maps.googleapis.com/maps/api/streetview/metadata";
+const API_KEY_ENV: &str = "GOOGLE_MAPS_API_KEY";
+
+// The default search radius is 50 m, which reports OK for a panorama on the
+// next street over. 10 m makes `OK` mean "there is a panorama at this
+// junction", which is what the map needs.
+const SEARCH_RADIUS_METERS: u32 = 10;
+
+const MAX_ATTEMPTS: usize = 3;
+const TRANSIENT_RETRY_SLEEP: Duration = Duration::from_millis(500);
+const DEFAULT_RATE_LIMIT_SLEEP: Duration = Duration::from_secs(5);
+const MAX_RATE_LIMIT_SLEEP: Duration = Duration::from_secs(60);
+
+// Sequential requests already cap out at a few per second, well under the
+// metadata QPS limit; this is just a courtesy floor between calls.
+const PACING: Duration = Duration::from_millis(50);
+
+#[derive(Debug)]
+enum FetchError {
+    RateLimited {
+        retry_after: Option<Duration>,
+    },
+    /// Bad key, missing permission, malformed request — retrying cannot help
+    /// and treating it as "no coverage" would write false for every node, so
+    /// abort the batch immediately.
+    Fatal(anyhow::Error),
+    Transient(anyhow::Error),
+}
+
+impl FetchError {
+    fn into_anyhow(self) -> anyhow::Error {
+        match self {
+            Self::RateLimited { retry_after } => anyhow::anyhow!(
+                "Street View metadata rate-limited (retry-after={}); back off before retrying the batch",
+                retry_after
+                    .map(|d| format!("{}s", d.as_secs()))
+                    .unwrap_or_else(|| "unspecified".to_string())
+            ),
+            Self::Fatal(e) | Self::Transient(e) => e,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataResponse {
+    status: String,
+}
+
+/// What a `status` value means for the coverage cache.
+#[derive(Debug, PartialEq, Eq)]
+enum Classification {
+    /// A panorama exists within `SEARCH_RADIUS_METERS`.
+    Covered,
+    /// Queried successfully, no panorama nearby. Only this writes `false`.
+    Absent,
+    Transient,
+    Fatal,
+}
+
+/// Read the Street View API key. Erroring out here (rather than sending
+/// keyless requests, which come back `REQUEST_DENIED`) keeps a forgotten
+/// `.env` from looking like a genuine coverage answer.
+pub fn api_key_from_env() -> Result<String> {
+    let key = std::env::var(API_KEY_ENV)
+        .map_err(|_| anyhow::anyhow!("{API_KEY_ENV} must be set in environment or .env file"))?;
+    if key.trim().is_empty() {
+        anyhow::bail!("{API_KEY_ENV} is set but empty");
+    }
+    Ok(key)
+}
+
+pub fn build_client() -> Result<Client> {
+    Ok(Client::builder().timeout(Duration::from_secs(10)).build()?)
+}
+
+/// Sleep between successive `fetch_coverage` calls (not before the first).
+pub async fn pace_next_request() {
+    tokio::time::sleep(PACING).await;
+}
+
+/// Ask the Street View Static metadata endpoint whether a panorama exists
+/// within 10 m of the coordinate. Metadata requests are free — no imagery is
+/// fetched. Retries transient failures up to `MAX_ATTEMPTS`, backs off on
+/// `OVER_QUERY_LIMIT`/429/5xx, and fails fast on `REQUEST_DENIED` so a broken
+/// key never gets recorded as "no coverage".
+pub async fn fetch_coverage(client: &Client, api_key: &str, lng: f64, lat: f64) -> Result<bool> {
+    let mut last_err: Option<FetchError> = None;
+
+    for attempt in 0..MAX_ATTEMPTS {
+        match request_metadata(client, api_key, lng, lat).await {
+            Ok(covered) => return Ok(covered),
+            Err(FetchError::Fatal(e)) => return Err(e),
+            Err(FetchError::RateLimited { retry_after }) => {
+                if attempt + 1 == MAX_ATTEMPTS {
+                    return Err(FetchError::RateLimited { retry_after }.into_anyhow());
+                }
+                let sleep_dur = retry_after
+                    .unwrap_or(DEFAULT_RATE_LIMIT_SLEEP)
+                    .min(MAX_RATE_LIMIT_SLEEP);
+                tracing::warn!(
+                    "Street View metadata rate-limited; sleeping {:?} before retry {}/{}",
+                    sleep_dur,
+                    attempt + 2,
+                    MAX_ATTEMPTS
+                );
+                tokio::time::sleep(sleep_dur).await;
+                last_err = Some(FetchError::RateLimited { retry_after });
+            }
+            Err(FetchError::Transient(e)) => {
+                last_err = Some(FetchError::Transient(e));
+                if attempt + 1 < MAX_ATTEMPTS {
+                    tokio::time::sleep(TRANSIENT_RETRY_SLEEP).await;
+                }
+            }
+        }
+    }
+
+    Err(last_err.unwrap().into_anyhow())
+}
+
+async fn request_metadata(
+    client: &Client,
+    api_key: &str,
+    lng: f64,
+    lat: f64,
+) -> std::result::Result<bool, FetchError> {
+    let resp = client
+        .get(ENDPOINT)
+        .query(&[
+            ("location", format!("{lat},{lng}")),
+            ("radius", SEARCH_RADIUS_METERS.to_string()),
+            // Skip indoor collections; only street-level panoramas count.
+            ("source", "outdoor".to_string()),
+            ("key", api_key.to_string()),
+        ])
+        .send()
+        .await
+        // Errors carry the request URL, which holds the API key — strip it
+        // before it reaches a log line.
+        .map_err(|e| FetchError::Transient(e.without_url().into()))?;
+
+    let status = resp.status();
+    if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        let retry_after = resp
+            .headers()
+            .get(header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_retry_after);
+        return Err(FetchError::RateLimited { retry_after });
+    }
+    if let Err(e) = resp.error_for_status_ref() {
+        return Err(FetchError::Fatal(
+            anyhow::Error::new(e.without_url()).context("Street View metadata request rejected"),
+        ));
+    }
+
+    let body: MetadataResponse = resp
+        .json()
+        .await
+        .map_err(|e| FetchError::Transient(e.without_url().into()))?;
+
+    match classify_status(&body.status) {
+        Classification::Covered => Ok(true),
+        Classification::Absent => Ok(false),
+        Classification::Transient => Err(FetchError::RateLimited { retry_after: None }),
+        Classification::Fatal => Err(FetchError::Fatal(anyhow::anyhow!(
+            "Street View metadata returned status={} — check {API_KEY_ENV} and API enablement",
+            body.status
+        ))),
+    }
+}
+
+/// Map a documented `status` value onto a cache decision.
+/// <https://developers.google.com/maps/documentation/streetview/metadata>
+fn classify_status(status: &str) -> Classification {
+    match status {
+        "OK" => Classification::Covered,
+        "ZERO_RESULTS" | "NOT_FOUND" => Classification::Absent,
+        "OVER_QUERY_LIMIT" => Classification::Transient,
+        // REQUEST_DENIED / INVALID_REQUEST and anything undocumented: never
+        // guess "no coverage" from a status we do not understand.
+        _ => Classification::Fatal,
+    }
+}
+
+/// Parse the `delta-seconds` form of `Retry-After` (e.g. `"30"`). The
+/// HTTP-date form is intentionally unhandled; callers fall back to
+/// `DEFAULT_RATE_LIMIT_SLEEP` on None.
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ok_means_covered() {
+        assert_eq!(classify_status("OK"), Classification::Covered);
+    }
+
+    #[test]
+    fn zero_results_and_not_found_mean_absent() {
+        assert_eq!(classify_status("ZERO_RESULTS"), Classification::Absent);
+        assert_eq!(classify_status("NOT_FOUND"), Classification::Absent);
+    }
+
+    #[test]
+    fn over_query_limit_is_transient() {
+        assert_eq!(
+            classify_status("OVER_QUERY_LIMIT"),
+            Classification::Transient
+        );
+    }
+
+    #[test]
+    fn denied_and_unknown_statuses_are_fatal() {
+        assert_eq!(classify_status("REQUEST_DENIED"), Classification::Fatal);
+        assert_eq!(classify_status("INVALID_REQUEST"), Classification::Fatal);
+        assert_eq!(classify_status("UNKNOWN_ERROR"), Classification::Fatal);
+        assert_eq!(classify_status(""), Classification::Fatal);
+        // Lower-case is not a documented spelling; must not read as absent.
+        assert_eq!(classify_status("zero_results"), Classification::Fatal);
+    }
+
+    #[test]
+    fn status_parses_from_metadata_json() {
+        let body: MetadataResponse = serde_json::from_str(
+            r#"{"copyright":"© Google","date":"2021-05","location":{"lat":35.0,"lng":139.0},
+                "pano_id":"abc","status":"OK"}"#,
+        )
+        .expect("metadata body should deserialize");
+        assert_eq!(classify_status(&body.status), Classification::Covered);
+    }
+
+    #[test]
+    fn zero_results_body_has_only_status() {
+        let body: MetadataResponse =
+            serde_json::from_str(r#"{"status":"ZERO_RESULTS"}"#).expect("should deserialize");
+        assert_eq!(classify_status(&body.status), Classification::Absent);
+    }
+
+    #[test]
+    fn retry_after_parses_integer_seconds() {
+        assert_eq!(parse_retry_after("30"), Some(Duration::from_secs(30)));
+        assert_eq!(parse_retry_after("  15  "), Some(Duration::from_secs(15)));
+    }
+
+    #[test]
+    fn retry_after_rejects_non_numeric() {
+        assert_eq!(parse_retry_after(""), None);
+        assert_eq!(parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT"), None);
+        assert_eq!(parse_retry_after("-5"), None);
+    }
+
+    #[test]
+    fn api_key_from_env_rejects_missing_and_empty() {
+        // Serialized within this test only: no other test touches this var.
+        let saved = std::env::var(API_KEY_ENV).ok();
+
+        std::env::remove_var(API_KEY_ENV);
+        assert!(api_key_from_env().is_err(), "missing key must error");
+
+        std::env::set_var(API_KEY_ENV, "   ");
+        assert!(api_key_from_env().is_err(), "blank key must error");
+
+        std::env::set_var(API_KEY_ENV, "test-key");
+        assert_eq!(api_key_from_env().unwrap(), "test-key");
+
+        match saved {
+            Some(v) => std::env::set_var(API_KEY_ENV, v),
+            None => std::env::remove_var(API_KEY_ENV),
+        }
+    }
+}

--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -7,9 +7,11 @@ const ENDPOINT: &str = "https://maps.googleapis.com/maps/api/streetview/metadata
 const API_KEY_ENV: &str = "GOOGLE_MAPS_API_KEY";
 
 // The default search radius is 50 m, which reports OK for a panorama on the
-// next street over. 10 m makes `OK` mean "there is a panorama at this
-// junction", which is what the map needs.
+// next street over. Narrowing to 10 m cuts most of those out — but `radius` is
+// not a hard cap (see `request_metadata`), so COVERAGE_LIMIT_METERS enforces
+// the real distance rule on the returned panorama.
 const SEARCH_RADIUS_METERS: u32 = 10;
+const COVERAGE_LIMIT_METERS: f64 = 10.0;
 
 const MAX_ATTEMPTS: usize = 3;
 const TRANSIENT_RETRY_SLEEP: Duration = Duration::from_millis(500);
@@ -49,12 +51,20 @@ impl FetchError {
 #[derive(Debug, Deserialize)]
 struct MetadataResponse {
     status: String,
+    /// Coordinate of the panorama Google actually picked. Present on `OK`.
+    location: Option<LatLng>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LatLng {
+    lat: f64,
+    lng: f64,
 }
 
 /// What a `status` value means for the coverage cache.
 #[derive(Debug, PartialEq, Eq)]
 enum Classification {
-    /// A panorama exists within `SEARCH_RADIUS_METERS`.
+    /// Google found a panorama. The caller still checks how far away it is.
     Covered,
     /// Queried successfully, no panorama nearby. Only this writes `false`.
     Absent,
@@ -165,7 +175,28 @@ async fn request_metadata(
         .map_err(|e| FetchError::Transient(e.without_url().into()))?;
 
     match classify_status(&body.status) {
-        Classification::Covered => Ok(true),
+        Classification::Covered => {
+            // `radius` narrows the search but is not a hard cap: measured
+            // against the live API, a query inside the Imperial Palace grounds
+            // returns OK at radius=10 with a panorama 483 m away. Re-check the
+            // distance ourselves so `true` really means "panorama at this
+            // junction" (same guard as baidu.rs).
+            let Some(loc) = body.location else {
+                return Err(FetchError::Fatal(anyhow::anyhow!(
+                    "Street View metadata returned OK without a location; cannot verify distance"
+                )));
+            };
+            let distance = ground_distance_meters(lat, lng, loc.lat, loc.lng);
+            if distance > COVERAGE_LIMIT_METERS {
+                tracing::debug!(
+                    "nearest panorama is {:.1} m away (> {} m); treating as uncovered",
+                    distance,
+                    COVERAGE_LIMIT_METERS
+                );
+                return Ok(false);
+            }
+            Ok(true)
+        }
         Classification::Absent => Ok(false),
         Classification::Transient => Err(FetchError::RateLimited { retry_after: None }),
         Classification::Fatal => Err(FetchError::Fatal(anyhow::anyhow!(
@@ -194,6 +225,15 @@ fn classify_status(status: &str) -> Classification {
         // guess "no coverage" from a status we do not understand.
         _ => Classification::Fatal,
     }
+}
+
+/// Flat-earth distance in metres between two nearby WGS84 coordinates. Good
+/// to well under a metre at the ~10 m scale this is compared against.
+fn ground_distance_meters(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
+    const METERS_PER_DEGREE: f64 = 111_320.0;
+    let dy = (lat2 - lat1) * METERS_PER_DEGREE;
+    let dx = (lng2 - lng1) * METERS_PER_DEGREE * lat1.to_radians().cos();
+    (dx * dx + dy * dy).sqrt()
 }
 
 /// Parse the `delta-seconds` form of `Retry-After` (e.g. `"30"`). The
@@ -253,6 +293,32 @@ mod tests {
         let body: MetadataResponse =
             serde_json::from_str(r#"{"status":"ZERO_RESULTS"}"#).expect("should deserialize");
         assert_eq!(classify_status(&body.status), Classification::Absent);
+    }
+
+    #[test]
+    fn distance_is_zero_for_identical_coordinates() {
+        assert!(ground_distance_meters(35.6595, 139.7005, 35.6595, 139.7005) < 1e-9);
+    }
+
+    #[test]
+    fn distance_matches_known_offsets() {
+        // 0.0001° of latitude ≈ 11.1 m anywhere.
+        let d = ground_distance_meters(35.6595, 139.7005, 35.6596, 139.7005);
+        assert!((11.0..=11.3).contains(&d), "got {d}");
+        // Same longitude delta shrinks by cos(lat) ≈ 0.813 at Tokyo.
+        let d = ground_distance_meters(35.6595, 139.7005, 35.6595, 139.7006);
+        assert!((8.9..=9.2).contains(&d), "got {d}");
+    }
+
+    #[test]
+    fn far_panorama_exceeds_the_coverage_limit() {
+        // The measured Imperial Palace case: OK at radius=10, panorama 483 m
+        // away. Must land on the uncovered side of the limit.
+        let d = ground_distance_meters(35.6852, 139.7528, 35.68095, 139.75);
+        assert!(
+            d > COVERAGE_LIMIT_METERS,
+            "expected far panorama to exceed limit, got {d}"
+        );
     }
 
     #[test]

--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -2,6 +2,7 @@ pub mod baidu;
 pub mod calculator;
 pub mod detector;
 pub mod elevation;
+pub mod google;
 pub mod inserter;
 pub mod parser;
 
@@ -322,6 +323,90 @@ async fn flush_baidu_chunk(
     missed_osm_node_ids.clear();
 
     Ok(())
+}
+
+/// Query Google Street View coverage for every non-China Y-junction that has
+/// no answer cached yet, and store the result in `google_streetview_coverage`.
+/// `refresh` also re-queries nodes previously recorded as uncovered (Google
+/// adds imagery over time, so `false` is not permanent).
+///
+/// Mainland-China junctions are skipped in-process — they use Baidu panoramas
+/// and Google has no coverage there. Metadata requests are free, so the cost
+/// of a full backfill is time, not money. Any query failure aborts the batch
+/// (rather than recording "no coverage") so a broken key or network outage
+/// cannot mass-delete junctions from the map; results already flushed stay in
+/// the DB, so a re-run resumes where it stopped.
+pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result<usize> {
+    /// Flush every 100 lookups, matching the progress-log cadence: worst-case
+    /// loss on abort is the in-flight partial chunk.
+    const CHUNK_SIZE: usize = 100;
+
+    let candidates = crate::db::google_repository::find_uncovered_nodes(pool, refresh).await?;
+
+    let targets: Vec<_> = candidates
+        .into_iter()
+        .filter(|c| !china::is_in_china_mainland(c.lon, c.lat))
+        .collect();
+
+    tracing::info!(
+        "Found {} non-China Y-junctions to query for Street View coverage",
+        targets.len()
+    );
+
+    let api_key = google::api_key_from_env()?;
+    let client = google::build_client()?;
+
+    let mut buffer: Vec<(i64, bool)> = Vec::with_capacity(CHUNK_SIZE);
+    let mut total_written: usize = 0;
+    let mut total_covered: usize = 0;
+
+    for (idx, target) in targets.iter().enumerate() {
+        if idx > 0 {
+            google::pace_next_request().await;
+        }
+
+        match google::fetch_coverage(&client, &api_key, target.lon, target.lat).await {
+            Ok(has_coverage) => {
+                if has_coverage {
+                    total_covered += 1;
+                }
+                buffer.push((target.osm_node_id, has_coverage));
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Street View metadata failed for junction osm_node_id={} ({}, {}): {}",
+                    target.osm_node_id,
+                    target.lat,
+                    target.lon,
+                    e
+                ));
+            }
+        }
+
+        if buffer.len() >= CHUNK_SIZE {
+            total_written += crate::db::google_repository::upsert_coverage(pool, &buffer).await?;
+            buffer.clear();
+
+            tracing::info!(
+                "Progress: {}/{} (written={}, covered={})",
+                idx + 1,
+                targets.len(),
+                total_written,
+                total_covered
+            );
+        }
+    }
+
+    total_written += crate::db::google_repository::upsert_coverage(pool, &buffer).await?;
+
+    tracing::info!(
+        "Street View coverage lookup complete: total={}, covered={}, uncovered={}",
+        targets.len(),
+        total_covered,
+        targets.len() - total_covered
+    );
+
+    Ok(total_written)
 }
 
 #[cfg(test)]

--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -341,6 +341,12 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
     /// loss on abort is the in-flight partial chunk.
     const CHUNK_SIZE: usize = 100;
 
+    // Check the key before the full-table scan: a worktree whose generated
+    // .env has no GOOGLE_MAPS_API_KEY should fail immediately, not after
+    // scanning every junction.
+    let api_key = google::api_key_from_env()?;
+    let client = google::build_client()?;
+
     let candidates = crate::db::google_repository::find_uncovered_nodes(pool, refresh).await?;
 
     let targets: Vec<_> = candidates
@@ -352,9 +358,6 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
         "Found {} non-China Y-junctions to query for Street View coverage",
         targets.len()
     );
-
-    let api_key = google::api_key_from_env()?;
-    let client = google::build_client()?;
 
     let mut buffer: Vec<(i64, bool)> = Vec::with_capacity(CHUNK_SIZE);
     let mut total_written: usize = 0;
@@ -373,8 +376,13 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
                 buffer.push((target.osm_node_id, has_coverage));
             }
             Err(e) => {
+                // Persist what already succeeded before giving up: otherwise a
+                // failure that recurs within the first CHUNK_SIZE lookups makes
+                // every re-run re-query the same nodes and die again, never
+                // banking any progress.
+                crate::db::google_repository::upsert_coverage(pool, &buffer).await?;
                 return Err(anyhow::anyhow!(
-                    "Street View metadata failed for junction osm_node_id={} ({}, {}): {}",
+                    "Street View metadata failed for junction osm_node_id={} ({}, {}): {:#}",
                     target.osm_node_id,
                     target.lat,
                     target.lon,

--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -362,6 +362,10 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
     let mut buffer: Vec<(i64, bool)> = Vec::with_capacity(CHUNK_SIZE);
     let mut total_written: usize = 0;
     let mut total_covered: usize = 0;
+    // Excluded by our own distance rule rather than by Google saying
+    // ZERO_RESULTS. Measured at 0/30 on real junctions, so a non-trivial count
+    // here is a signal that the 10 m rule needs another look.
+    let mut total_too_far: usize = 0;
 
     for (idx, target) in targets.iter().enumerate() {
         if idx > 0 {
@@ -369,11 +373,20 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
         }
 
         match google::fetch_coverage(&client, &api_key, target.lon, target.lat).await {
-            Ok(has_coverage) => {
-                if has_coverage {
-                    total_covered += 1;
+            Ok(coverage) => {
+                match &coverage {
+                    google::Coverage::Covered => total_covered += 1,
+                    google::Coverage::TooFar { distance_meters } => {
+                        total_too_far += 1;
+                        tracing::info!(
+                            "osm_node_id={}: nearest panorama is {:.1} m away; recording as uncovered",
+                            target.osm_node_id,
+                            distance_meters
+                        );
+                    }
+                    google::Coverage::Absent => {}
                 }
-                buffer.push((target.osm_node_id, has_coverage));
+                buffer.push((target.osm_node_id, coverage.has_coverage()));
             }
             Err(e) => {
                 // Persist what already succeeded before giving up: otherwise a
@@ -408,10 +421,14 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
     total_written += crate::db::google_repository::upsert_coverage(pool, &buffer).await?;
 
     tracing::info!(
-        "Street View coverage lookup complete: total={}, covered={}, uncovered={}",
+        "Street View coverage lookup complete: total={}, covered={}, uncovered={} \
+         (no panorama={}, panorama beyond {} m={})",
         targets.len(),
         total_covered,
-        targets.len() - total_covered
+        targets.len() - total_covered,
+        targets.len() - total_covered - total_too_far,
+        google::COVERAGE_LIMIT_METERS,
+        total_too_far
     );
 
     Ok(total_written)

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -80,6 +80,12 @@ async fn setup_test_db() -> PgPool {
         .await
         .expect("Failed to truncate baidu_panoramas");
 
+    // google_streetview_coverage も同じ理由で CASCADE の対象外
+    sqlx::query("TRUNCATE TABLE google_streetview_coverage")
+        .execute(&pool)
+        .await
+        .expect("Failed to truncate google_streetview_coverage");
+
     pool
 }
 
@@ -1480,4 +1486,166 @@ async fn test_non_china_junction_still_uses_google_url() {
         url.contains("google.com/maps"),
         "expected google URL, got: {url}"
     );
+}
+
+// ========== google_repository: coverage cache ==========
+
+use y_junction_backend::db::google_repository;
+
+#[tokio::test]
+#[serial]
+async fn test_google_find_coverage_empty_input() {
+    let pool = setup_test_db().await;
+    let result = google_repository::find_coverage_by_osm_node_ids(&pool, &[])
+        .await
+        .expect("query failed");
+    assert!(result.is_empty());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_google_find_coverage_distinguishes_three_states() {
+    let pool = setup_test_db().await;
+    let (_, osm_covered) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::sharp_type()).await;
+    let (_, osm_uncovered) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::normal_type()).await;
+    let (_, osm_unqueried) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::verysharp_type()).await;
+
+    google_repository::upsert_coverage(&pool, &[(osm_covered, true), (osm_uncovered, false)])
+        .await
+        .expect("upsert failed");
+
+    let result = google_repository::find_coverage_by_osm_node_ids(
+        &pool,
+        &[osm_covered, osm_uncovered, osm_unqueried],
+    )
+    .await
+    .expect("query failed");
+
+    assert_eq!(result.get(&osm_covered), Some(&true));
+    assert_eq!(result.get(&osm_uncovered), Some(&false));
+    assert_eq!(
+        result.get(&osm_unqueried),
+        None,
+        "never-queried node must be absent from the map, not false"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_google_upsert_empty_is_noop() {
+    let pool = setup_test_db().await;
+    let written = google_repository::upsert_coverage(&pool, &[])
+        .await
+        .expect("upsert failed");
+    assert_eq!(written, 0);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_google_upsert_overwrites_false_with_true() {
+    let pool = setup_test_db().await;
+    let (_, osm_node_id) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::sharp_type()).await;
+
+    google_repository::upsert_coverage(&pool, &[(osm_node_id, false)])
+        .await
+        .expect("first upsert failed");
+    google_repository::upsert_coverage(&pool, &[(osm_node_id, true)])
+        .await
+        .expect("second upsert failed");
+
+    let result = google_repository::find_coverage_by_osm_node_ids(&pool, &[osm_node_id])
+        .await
+        .expect("query failed");
+    assert_eq!(
+        result.get(&osm_node_id),
+        Some(&true),
+        "--refresh must be able to flip false to true"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_google_find_uncovered_nodes_skips_queried_nodes() {
+    let pool = setup_test_db().await;
+    let (_, osm_covered) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::sharp_type()).await;
+    let (_, osm_uncovered) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::normal_type()).await;
+    let (_, osm_unqueried) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::verysharp_type()).await;
+
+    google_repository::upsert_coverage(&pool, &[(osm_covered, true), (osm_uncovered, false)])
+        .await
+        .expect("upsert failed");
+
+    let pending = google_repository::find_uncovered_nodes(&pool, false)
+        .await
+        .expect("query failed");
+    let ids: Vec<i64> = pending.iter().map(|c| c.osm_node_id).collect();
+
+    assert!(ids.contains(&osm_unqueried));
+    assert!(!ids.contains(&osm_covered));
+    assert!(
+        !ids.contains(&osm_uncovered),
+        "without --refresh, confirmed-uncovered nodes must not be re-queried"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_google_find_uncovered_nodes_refresh_includes_false_rows() {
+    let pool = setup_test_db().await;
+    let (_, osm_covered) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::sharp_type()).await;
+    let (_, osm_uncovered) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::normal_type()).await;
+    let (_, osm_unqueried) =
+        insert_test_junction_with_ids(&pool, TestJunctionData::verysharp_type()).await;
+
+    google_repository::upsert_coverage(&pool, &[(osm_covered, true), (osm_uncovered, false)])
+        .await
+        .expect("upsert failed");
+
+    let pending = google_repository::find_uncovered_nodes(&pool, true)
+        .await
+        .expect("query failed");
+    let ids: Vec<i64> = pending.iter().map(|c| c.osm_node_id).collect();
+
+    assert!(
+        ids.contains(&osm_uncovered),
+        "--refresh must re-query false rows"
+    );
+    assert!(ids.contains(&osm_unqueried));
+    assert!(
+        !ids.contains(&osm_covered),
+        "--refresh must not re-query nodes already known to be covered"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_google_find_uncovered_nodes_returns_coordinates() {
+    // The China filter runs on these coordinates in-process, so they must
+    // survive the round trip.
+    let pool = setup_test_db().await;
+    let (_, osm_node_id) = insert_test_junction_with_ids(
+        &pool,
+        TestJunctionData::sharp_type().with_location(SHANGHAI_LAT, SHANGHAI_LON),
+    )
+    .await;
+
+    let pending = google_repository::find_uncovered_nodes(&pool, false)
+        .await
+        .expect("query failed");
+    let found = pending
+        .iter()
+        .find(|c| c.osm_node_id == osm_node_id)
+        .expect("inserted junction missing from candidates");
+
+    assert!((found.lat - SHANGHAI_LAT).abs() < 1e-9);
+    assert!((found.lon - SHANGHAI_LON).abs() < 1e-9);
 }

--- a/doc/streetview-coverage-filter.md
+++ b/doc/streetview-coverage-filter.md
@@ -25,7 +25,7 @@
 | --- | --- |
 | 照会対象 | 中国以外の全ノード（**日本を含む**）。地域で例外を作らず一律照会し、無ければ除外。 |
 | カバレッジ取得手段 | 公式 **Street View Static API の metadata エンドポイント**。IAM/OAuth 非対応で API キー必須（[公式](https://developers.google.com/maps/documentation/streetview/metadata)で確認済み）。metadata リクエストは無料。 |
-| 検索半径 | **`radius=10`（m）＋ `source=outdoor`** でリクエスト。既定 50m は緩すぎるため 10m に絞り、`OK` = 10m 以内にパノラマあり と直接判定。 |
+| 検索半径 | **`radius=10`（m）＋ `source=outdoor`** でリクエスト（既定 50m は緩すぎる）。ただし `radius` は「探索範囲」であって返却パノラマの距離上限ではないため、**レスポンスの `location` との距離を自分で測り 10m 超は uncovered とする**。詳細は「10m 判定の根拠と実測」節。 |
 | 保存先 | **専用テーブル `google_streetview_coverage`（`osm_node_id` 主キー）**。理由は後述（Baidu 模倣ではなく `/deploy-data` の追記モデル適合＋id churn 耐性）。 |
 | 照会の実行場所 | **ローカル DB に対して実行**（Baidu の `import_baidu_panoid` と同じ）。本番反映は `/deploy-data`。**Cloud Run / cron / Secret Manager は使わない**。 |
 | API キーの保管 | **API 有効化・キー発行は Terraform**（`google_project_service` ＋ `google_apikeys_key`、`y-junctions-prod`）。キー値は `terraform output` からローカル `backend/.env` の `GOOGLE_MAPS_API_KEY` へ貼るだけ。サーバーに載せないので Secret Manager/Cloud Run への配線は不要。 |
@@ -63,9 +63,16 @@ CREATE TABLE google_streetview_coverage (
 ### 1. カバレッジ照会モジュール — `backend/src/importer/google.rs`（新規）
 
 - Street View Static **metadata** エンドポイントを叩く（画像は取らない＝無料）。リクエストは `location`・`key`・**`radius=10`**・**`source=outdoor`**。
-  - `radius=10`：既定 50m では「50m 先にあるだけ」で `OK` になり使えない。10m に絞れば `OK` = 10m 以内、と直接判定。
+  - `radius=10`：既定 50m では「50m 先にあるだけ」で `OK` になり使えない。
   - `source=outdoor`：屋内コレクションを除外。
-- `status` で分岐：`"OK"` → カバレッジあり／`"ZERO_RESULTS"`・`"NOT_FOUND"` → 無し／`"OVER_QUERY_LIMIT"`・5xx → リトライ・バックオフ／**`"REQUEST_DENIED"`・`"INVALID_REQUEST"` → hard stop でバッチ全体を中断**（キー不正・権限不足を「無し」と誤記録しないため。`has_coverage=false` を大量に書く事故を防ぐ）。
+  - **`OK` だけでは 10m 以内と断定できない**ため、レスポンスの `location` と照会座標の距離を計算し、`COVERAGE_LIMIT_METERS`（10m）超なら uncovered として記録する（Baidu の `DISTANCE_LIMIT_METERS` と同じガード）。`OK` なのに `location` が無いレスポンスは距離を検証できないため中断。
+- `status` で分岐（[metadata の status 定義](https://developers.google.com/maps/documentation/streetview/metadata)に準拠）：
+  - `"OK"` → 距離チェックへ
+  - `"ZERO_RESULTS"`（"no panorama could be found near the provided location"）→ **無し。`has_coverage=false` を書くのはこれだけ**
+  - `"OVER_QUERY_LIMIT"`・429 → リトライ・バックオフ／`"UNKNOWN_ERROR"`・5xx → リトライ・バックオフ（"server error" で一時障害。運用者向けにレート制限とは別メッセージにする）
+  - `"NOT_FOUND"`（"the address string provided in the `location` parameter couldn't be found"）→ **中断**。座標しか送らない本バッチでは起き得ないため、無しと誤記録して固定化させない
+  - `"REQUEST_DENIED"`・`"INVALID_REQUEST"`・未知の値 → **hard stop でバッチ全体を中断**（キー不正・権限不足を「無し」と誤記録し `has_coverage=false` を大量に書く事故を防ぐ）
+- 除外の内訳（Google が無しと言ったのか、距離チェックで落としたのか）は完了ログに出す。距離チェックの発火が多い場合は 10m という基準自体を見直すシグナルになる。
 - レート制御・リトライ・ペーシングは `backend/src/importer/baidu.rs` の機構を踏襲。API キーは env `GOOGLE_MAPS_API_KEY` から読む。未設定なら明示エラーで停止（サイレントに全ノード「無し」判定しない）。
 
 ### 2. 照会処理 — `backend/src/importer/mod.rs`（変更）
@@ -74,12 +81,27 @@ CREATE TABLE google_streetview_coverage (
 
 **非中国の判定は Rust 側で行う**（SQL では不可）。地域判定は `china::is_in_china_mainland(lng, lat)`（`backend/src/domain/china.rs:18`、手書き bbox 群の Rust 関数）だけが根拠で、`y_junctions` に地域列は無い。よって Baidu と同じ構造にする（`mod.rs:224-227`）：リポジトリは uncovered 候補を**全件**返し、この関数内で `!china::is_in_china_mainland(j.lon, j.lat)` でフィルタしてから照会する。
 
-照会 → `google_streetview_coverage` に upsert。照会失敗はそのノードを未照会のまま残す（`mod.rs:249` の Baidu と同じ abort-on-error）。
+照会 → `google_streetview_coverage` に upsert。照会失敗はそのノードを未照会のまま残す（`mod.rs:249` の Baidu と同じ abort-on-error）。ただし**中断する前に取得済みバッファを flush する**：さもないと最初の 100 件以内で再発する障害では毎回同じノードを引き直して flush 前に落ち、進捗が永久に残らない（Baidu 側は未対応）。API キーの検証は全件スキャンより前に行う。
+
+## 10m 判定の根拠と実測
+
+`radius` は画像リクエスト側のパラメータ一覧で `sets a radius, specified in meters, in which to search for a panorama, centered on the given latitude and longitude`（既定 50）と定義されている。metadata のページには「imagery と同じ URL パラメータを受け付ける」旨と、無視される optional（`size`・`heading`・`fov`・`pitch`）の列挙があり、`radius`・`source` はその列挙に入っていない。
+
+実 API での計測（`scripts/verify_streetview_radius.py`）:
+
+| 観測 | 結果 |
+| --- | --- |
+| 皇居内の座標 | `radius=1` → `ZERO_RESULTS`、`radius=5/10/50` → いずれも `OK` だが返却パノラマは **483m 先**。**`radius` は返却パノラマの距離上限ではない** |
+| セントラルパーク内 | `radius=50` → `OK`（19.8m）、`radius=10` → `ZERO_RESULTS`（再実行しても同じ）。`radius` は探索範囲として機能している |
+| ローカル DB の非中国ノード30件（無作為） | `radius=10` で `ZERO_RESULTS` かつ `radius=50` で 10m 以内: **0件**（取りこぼし無し）。`radius=10` の `OK` はすべて 10m 以内（0.5〜7.2m）。両者 `OK` のときは常に同一パノラマ＝最近傍が返る挙動と整合。1件は `radius=10` → `ZERO_RESULTS`、`radius=50` → `OK`（31.5m）で、既定 50m のままなら誤って covered になっていた |
+
+したがって `radius=10` は一次フィルタとして維持し、返却座標との距離チェックを二次フィルタとして併用する。標本30件なので「取りこぼし 0件」は上限の保証ではない。
 
 ### 3. リポジトリ — `backend/src/db/google_repository.rs`（新規）
 
 - `find_coverage_by_osm_node_ids(pool, ids) -> HashMap<i64, bool>`：`osm_node_id → has_coverage`。キー無し＝未照会。enricher が使う。
-- `find_uncovered_nodes(pool, refresh) -> Vec<...>`：未照会（`refresh` 時は `has_coverage=false` も含む）の junction を**全件**返す（`find_without_baidu_panoid` に対応）。**非中国フィルタはここでは行わない**——地域判定は Rust の `china::is_in_china_mainland` のみで、SQL に持ち込めないため。呼び出し側（Component 2）が Rust で絞る。
+- `find_uncovered_nodes(pool, refresh) -> Vec<CoverageCandidate>`：未照会（`refresh` 時は `has_coverage=false` も含む）を**全件**返す（`find_without_baidu_panoid` に対応）。**非中国フィルタはここでは行わない**——地域判定は Rust の `china::is_in_china_mainland` のみで、SQL に持ち込めないため。呼び出し側（Component 2）が Rust で絞る。
+  - 戻り値は `Junction` ではなく `CoverageCandidate { osm_node_id, lon, lat }`。呼び出し側が使うのはこの3フィールドだけで、`Junction` を返すには `baidu_repository` の19列 `JunctionRow` を複製する必要があるため。
 - `upsert_coverage(pool, rows)`：`osm_node_id` で upsert（`ON CONFLICT ... DO UPDATE`。再照会で false→true に更新され得るため上書き）。
 
 ### 4. ローカル enrich コマンド — `backend/src/bin/import_google_streetview.rs`（新規）

--- a/scripts/verify_streetview_radius.py
+++ b/scripts/verify_streetview_radius.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Check whether radius=10 is too tight for the Street View coverage batch.
+
+The batch queries the metadata endpoint with radius=10 and then re-checks the
+distance to the returned panorama (importer/google.rs). That guard only covers
+the "OK but far away" direction — when radius=10 answers ZERO_RESULTS there is
+no location to measure, so a panorama that actually sits within 10 m would be
+recorded as uncovered and the junction dropped from the map (issue #306, PR-4).
+
+This script looks for that case: radius=10 -> ZERO_RESULTS while radius=50
+returns a panorama within 10 m. Metadata requests are free.
+
+Usage:
+    docker exec y-junctions-cockroachdb ./cockroach sql --insecure \
+        --database y_junction --format csv \
+        -e "SELECT osm_node_id, lat, lon FROM y_junctions \
+            WHERE NOT (lon BETWEEN 73 AND 135 AND lat BETWEEN 18 AND 54) \
+            ORDER BY random() LIMIT 30;" > sample.csv
+    GOOGLE_MAPS_API_KEY=... python3 scripts/verify_streetview_radius.py sample.csv
+"""
+
+import csv
+import json
+import math
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+ENDPOINT = "https://maps.googleapis.com/maps/api/streetview/metadata"
+LIMIT_METERS = 10.0
+
+
+def metadata(lat, lng, radius, key):
+    params = {
+        "location": f"{lat},{lng}",
+        "radius": radius,
+        "source": "outdoor",
+        "key": key,
+    }
+    url = f"{ENDPOINT}?{urllib.parse.urlencode(params)}"
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return json.load(resp)
+
+
+def distance_m(lat, lng, body):
+    loc = body.get("location")
+    if not loc:
+        return None
+    dy = (loc["lat"] - lat) * 111_320
+    dx = (loc["lng"] - lng) * 111_320 * math.cos(math.radians(lat))
+    return math.hypot(dx, dy)
+
+
+def main():
+    key = os.environ.get("GOOGLE_MAPS_API_KEY")
+    if not key:
+        sys.exit("GOOGLE_MAPS_API_KEY must be set")
+    if len(sys.argv) < 2:
+        sys.exit(f"usage: {sys.argv[0]} <sample.csv>")
+
+    with open(sys.argv[1], newline="") as f:
+        rows = [r for r in csv.DictReader(f)]
+
+    missed = []       # radius=10 says no, radius=50 finds one within 10 m
+    far_at_10 = []    # radius=10 says OK but the panorama is beyond 10 m
+    agree = 0
+
+    print(f"{'osm_node_id':>12}  {'radius=10':>20}  {'radius=50':>20}  verdict")
+    for row in rows:
+        nid, lat, lng = row["osm_node_id"], float(row["lat"]), float(row["lon"])
+        narrow = metadata(lat, lng, 10, key)
+        time.sleep(0.05)
+        wide = metadata(lat, lng, 50, key)
+        time.sleep(0.05)
+
+        dn, dw = distance_m(lat, lng, narrow), distance_m(lat, lng, wide)
+        sn = narrow["status"] + (f" {dn:6.1f}m" if dn is not None else "")
+        sw = wide["status"] + (f" {dw:6.1f}m" if dw is not None else "")
+
+        if narrow["status"] == "ZERO_RESULTS" and dw is not None and dw <= LIMIT_METERS:
+            verdict = "MISSED by radius=10"
+            missed.append((nid, dw))
+        elif narrow["status"] == "OK" and dn is not None and dn > LIMIT_METERS:
+            verdict = "far pano at radius=10 (distance check rejects)"
+            far_at_10.append((nid, dn))
+        else:
+            verdict = "consistent"
+            agree += 1
+        print(f"{nid:>12}  {sn:>20}  {sw:>20}  {verdict}")
+
+    print(f"\nsampled={len(rows)} consistent={agree} "
+          f"missed_by_radius10={len(missed)} far_pano_at_radius10={len(far_at_10)}")
+    if missed:
+        print("radius=10 is too tight for:", missed)
+    if far_at_10:
+        print("distance check earns its keep for:", far_at_10)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Issue #306 / 設計書 `doc/streetview-coverage-filter.md` の **PR-2**。照会と保存までで、地図からの除外は PR-4 で有効化する（データが揃う前に海外ノードが消える事故を防ぐため）。

## 変更

| ファイル | 内容 |
| --- | --- |
| `backend/src/importer/google.rs`（新規） | metadata エンドポイントへの照会。`radius=10&source=outdoor` |
| `backend/src/db/google_repository.rs`（新規） | 3状態の読み出し・未照会ノード抽出・upsert |
| `backend/src/importer/mod.rs` | `import_google_coverage_data(pool, refresh)` |
| `backend/src/bin/import_google_streetview.rs`（新規） | `--refresh` を取る薄い CLI |
| `backend/.env.example` | `GOOGLE_MAPS_API_KEY` の取得元をコメントで明記 |
| `backend/tests/api_tests.rs` | `google_streetview_coverage` の TRUNCATE ＋ リポジトリ統合テスト 7件 |

## status の扱い

| status | 扱い |
| --- | --- |
| `OK` | カバレッジあり（`has_coverage = true`） |
| `ZERO_RESULTS` / `NOT_FOUND` | 無し（`false` を書くのはここだけ） |
| `OVER_QUERY_LIMIT` / 429 / 5xx | バックオフして再試行（最大3回） |
| `REQUEST_DENIED` / `INVALID_REQUEST` / 未知の値 | **即中断**。キー不正・権限不足を「無し」と誤記録して大量除外する事故を防ぐ |

同じ理由で、`GOOGLE_MAPS_API_KEY` 未設定・空文字はリクエストを送る前にエラーで停止する。照会失敗したノードは未照会のまま残り、再実行で回復する。

reqwest のエラーはリクエスト URL（＝API キーを含む）を保持するため、`without_url()` で剥がしてからログ・エラーに載せている。

## 設計書との差分（1点）

`find_uncovered_nodes` の戻り値を `Vec<Junction>` ではなく `CoverageCandidate { osm_node_id, lon, lat }` にした。呼び出し側が使うのはこの3フィールドだけで、`Junction` を返すには `baidu_repository` の19列 `JunctionRow` を複製する必要があったため。

## 検証

**テスト**（ローカル CockroachDB 使用、スキップなし）
```
test result: ok. 107 passed; 0 failed   # unit（google.rs の status 分類 10件を追加）
test result: ok. 54 passed; 0 failed    # integration（google_repository 7件を追加）
```
`cargo clippy --all-targets --all-features -- -D warnings` も pass（pre-commit hook 経由）。

**実 API での確認**（`radius=10&source=outdoor`、実キー使用）
```
渋谷スクランブル交差点 (35.6595,139.7005) -> OK           keys: copyright,date,location,pano_id,status
富士山頂          (35.36,138.73)      -> ZERO_RESULTS   keys: status
大西洋上          (0,-30)             -> ZERO_RESULTS   keys: status
```
実レスポンスの形が単体テストの fixture と一致することを確認済み。

## 未実施

- ローカル DB への一括 enrich 実行（ops ステップ。PR-3 の `/deploy-data` 対応後）
- enricher の除外ロジック（PR-4）

ユーザーに見える変更はまだ無いので、マージ時に `skip-changelog` ラベルを付ける想定です。

Refs #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Google Street View coverage importing for eligible junctions.
  - Coverage checks identify nearby outdoor panoramas and cache results for future use.
  - Added optional refresh support to recheck previously uncovered locations.
  - Import processing includes request pacing, retries, progress reporting, and preservation of partial results.
  - Added configuration guidance for supplying a Google Maps API key.
  - Added a diagnostic tool for comparing Street View search radii.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->