### PR TITLE
chore: /deploy-data に google_streetview_coverage の反映を追加 (#306)

### DIFF
--- a/.claude/commands/deploy-data.md
+++ b/.claude/commands/deploy-data.md
@@ -15,8 +15,10 @@ IMPORT INTO が失敗する。新規地域は非重複 bbox を選ぶこと。
 手動で TRUNCATE + 全件 IMPORT INTO を実施する。
 
 Step 4 以降で失敗した場合は userfile が残るので、手動で
-`cockroach userfile delete junctions.csv --url "$PROD_CRDB_URI"` と
-`cockroach userfile delete baidu_panoramas.csv --url "$PROD_CRDB_URI"` で掃除する。
+`cockroach userfile delete junctions.csv --url "$PROD_CRDB_URI"`、
+`cockroach userfile delete baidu_panoramas.csv --url "$PROD_CRDB_URI"`、
+`cockroach userfile delete google_streetview_coverage.csv --url "$PROD_CRDB_URI"`
+で掃除する。
 
 ## Step 1: bbox の検証と本番DB接続情報の取得
 
@@ -83,6 +85,19 @@ docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
 
 BAIDU_COUNT=$(wc -l < ~/y-junctions-data/baidu_panoramas.csv)
 echo "exported $BAIDU_COUNT baidu_panoramas rows"
+
+# bbox 内の junction に紐付く google_streetview_coverage 行も書き出す
+docker run --rm -v ~/y-junctions-data:/data postgres:15-alpine \
+  psql "postgresql://root@host.docker.internal:26257/y_junction?sslmode=disable" -c "\copy (
+    SELECT g.osm_node_id, g.has_coverage, g.queried_at
+    FROM google_streetview_coverage g
+    JOIN y_junctions y ON y.osm_node_id = g.osm_node_id
+    WHERE y.lon BETWEEN $MIN_LON AND $MAX_LON
+      AND y.lat BETWEEN $MIN_LAT AND $MAX_LAT
+  ) TO '/data/google_streetview_coverage.csv' WITH CSV"
+
+GOOGLE_COUNT=$(wc -l < ~/y-junctions-data/google_streetview_coverage.csv)
+echo "exported $GOOGLE_COUNT google_streetview_coverage rows"
 ```
 
 ## Step 3: userfile に CSV をアップロード
@@ -100,6 +115,9 @@ cockroach userfile upload ~/y-junctions-data/junctions.csv \
 
 cockroach userfile upload ~/y-junctions-data/baidu_panoramas.csv \
   baidu_panoramas.csv --url "$PROD_CRDB_URI"
+
+cockroach userfile upload ~/y-junctions-data/google_streetview_coverage.csv \
+  google_streetview_coverage.csv --url "$PROD_CRDB_URI"
 ```
 
 ## Step 4: 本番DBに差分追加（IMPORT INTO、TRUNCATE なし）
@@ -124,6 +142,12 @@ cockroach sql --url "$PROD_CRDB_URI" -e "IMPORT INTO y_junctions (
 cockroach sql --url "$PROD_CRDB_URI" -e "IMPORT INTO baidu_panoramas (
   osm_node_id, panoid, pano_mc_x, pano_mc_y, queried_at
 ) CSV DATA ('userfile:///baidu_panoramas.csv');"
+
+# 新規 osm_node_id の追記専用。既にある行の has_coverage 訂正（--refresh の
+# false→true など）はこの経路では反映できない（PK 衝突する）。
+cockroach sql --url "$PROD_CRDB_URI" -e "IMPORT INTO google_streetview_coverage (
+  osm_node_id, has_coverage, queried_at
+) CSV DATA ('userfile:///google_streetview_coverage.csv');"
 ```
 
 出力に `status: succeeded` と投入件数が出ていることを確認する。
@@ -150,4 +174,5 @@ cockroach sql --url "$PROD_CRDB_URI" -e "
 cockroach sql --url "$PROD_CRDB_URI" -e "SELECT COUNT(*) FROM y_junctions;"
 cockroach userfile delete junctions.csv --url "$PROD_CRDB_URI"
 cockroach userfile delete baidu_panoramas.csv --url "$PROD_CRDB_URI"
+cockroach userfile delete google_streetview_coverage.csv --url "$PROD_CRDB_URI"
 ```


### PR DESCRIPTION
## 概要

Issue #306 の PR-3。設計書 `doc/streetview-coverage-filter.md` §6 に従い、`/deploy-data` skill に `google_streetview_coverage` テーブルの本番反映を追加する。

`baidu_panoramas` とまったく同じ経路に乗せる:
- Step 2: bbox 内 junction と JOIN して CSV export
- Step 3: userfile upload
- Step 4: `IMPORT INTO google_streetview_coverage (osm_node_id, has_coverage, queried_at)`
- Step 5 / 冒頭の注意書き: userfile 削除

## 検証

ローカル CockroachDB (`y_junction_test`) で CSV ラウンドトリップを実施:
- 追加した `\copy` クエリがそのまま通り、psql は BOOL を `t` / `f` で出力
- その CSV を `IMPORT INTO google_streetview_coverage` に流して `status: succeeded`、`has_coverage` が `t`/`f` として正しく格納されることを確認（検証用の行と userfile は削除済み）

## 制約（コメントとして明記）

この差分 IMPORT は**新規 `osm_node_id` の追記専用**。既存行の `has_coverage` 訂正（`--refresh` の false→true など）はこの経路では反映できず、手動 TRUNCATE + 全件 IMPORT が必要。`baidu_panoramas` と同じ非対称。

## 次のステップ

- ops: ローカルで enrich 実行 → `/deploy-data` で本番反映
- PR-4: enricher の除外ロジック有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Street View coverage data is now included in deployment workflows.
  * Coverage data is exported, uploaded, imported, and cleaned up alongside existing panorama data.
  * Imports add only new map node coverage records and preserve existing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->