### PR TITLE
perf: Street View カバレッジ照会を並列化 (#306)

### DIFF
--- a/backend/src/importer/google.rs
+++ b/backend/src/importer/google.rs
@@ -18,9 +18,16 @@ const TRANSIENT_RETRY_SLEEP: Duration = Duration::from_millis(500);
 const DEFAULT_RATE_LIMIT_SLEEP: Duration = Duration::from_secs(5);
 const MAX_RATE_LIMIT_SLEEP: Duration = Duration::from_secs(60);
 
-// Sequential requests already cap out at a few per second, well under the
-// metadata QPS limit; this is just a courtesy floor between calls.
+// Rate budget. The documented ceiling is 30,000 queries per minute (= 500 QPS)
+// for the Street View Static API. Metadata requests are free and consume no
+// image quota, but the per-second limit still applies — hence OVER_QUERY_LIMIT.
+//
+// Each in-flight worker sleeps PACING before its own request, so one worker
+// issues at most 1/PACING = 20 req/s. REQUEST_CONCURRENCY workers therefore
+// cannot exceed 20 * 24 = 480 QPS however fast Google answers: a structural
+// ceiling below the limit, with the OVER_QUERY_LIMIT backoff as the fallback.
 const PACING: Duration = Duration::from_millis(50);
+pub const REQUEST_CONCURRENCY: usize = 24;
 
 #[derive(Debug)]
 enum FetchError {
@@ -118,8 +125,10 @@ pub fn build_client() -> Result<Client> {
     Ok(Client::builder().timeout(Duration::from_secs(10)).build()?)
 }
 
-/// Sleep between successive `fetch_coverage` calls (not before the first).
-pub async fn pace_next_request() {
+/// Throttle one worker ahead of its own `fetch_coverage` call. Called per
+/// request rather than between requests, so the rate ceiling holds no matter
+/// how the concurrent lookups interleave.
+pub async fn pace_request() {
     tokio::time::sleep(PACING).await;
 }
 

--- a/backend/src/importer/mod.rs
+++ b/backend/src/importer/mod.rs
@@ -7,6 +7,7 @@ pub mod inserter;
 pub mod parser;
 
 use anyhow::Result;
+use futures::StreamExt;
 use rayon::prelude::*;
 use sqlx::PgPool;
 use std::sync::Arc;
@@ -367,12 +368,28 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
     // here is a signal that the 10 m rule needs another look.
     let mut total_too_far: usize = 0;
 
-    for (idx, target) in targets.iter().enumerate() {
-        if idx > 0 {
-            google::pace_next_request().await;
-        }
+    // Lookups are independent and network-bound, so they run concurrently;
+    // google::REQUEST_CONCURRENCY carries the rate-limit reasoning. Unordered
+    // because nothing downstream cares about ordering — rows are keyed by
+    // osm_node_id — and one slow request should not hold up the rest.
+    let mut lookups = futures::stream::iter(targets.iter())
+        .map(|target| {
+            let client = &client;
+            let api_key = &api_key;
+            async move {
+                google::pace_request().await;
+                let result = google::fetch_coverage(client, api_key, target.lon, target.lat).await;
+                (target, result)
+            }
+        })
+        .buffer_unordered(google::REQUEST_CONCURRENCY);
 
-        match google::fetch_coverage(&client, &api_key, target.lon, target.lat).await {
+    let mut completed: usize = 0;
+
+    while let Some((target, result)) = lookups.next().await {
+        completed += 1;
+
+        match result {
             Ok(coverage) => {
                 match &coverage {
                     google::Coverage::Covered => total_covered += 1,
@@ -392,7 +409,9 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
                 // Persist what already succeeded before giving up: otherwise a
                 // failure that recurs within the first CHUNK_SIZE lookups makes
                 // every re-run re-query the same nodes and die again, never
-                // banking any progress.
+                // banking any progress. Lookups still in flight are dropped
+                // with the stream; those nodes stay unqueried and come back on
+                // the next run.
                 crate::db::google_repository::upsert_coverage(pool, &buffer).await?;
                 return Err(anyhow::anyhow!(
                     "Street View metadata failed for junction osm_node_id={} ({}, {}): {:#}",
@@ -410,7 +429,7 @@ pub async fn import_google_coverage_data(pool: &PgPool, refresh: bool) -> Result
 
             tracing::info!(
                 "Progress: {}/{} (written={}, covered={})",
-                idx + 1,
+                completed,
                 targets.len(),
                 total_written,
                 total_covered

--- a/doc/streetview-coverage-filter.md
+++ b/doc/streetview-coverage-filter.md
@@ -73,7 +73,7 @@ CREATE TABLE google_streetview_coverage (
   - `"NOT_FOUND"`（"the address string provided in the `location` parameter couldn't be found"）→ **中断**。座標しか送らない本バッチでは起き得ないため、無しと誤記録して固定化させない
   - `"REQUEST_DENIED"`・`"INVALID_REQUEST"`・未知の値 → **hard stop でバッチ全体を中断**（キー不正・権限不足を「無し」と誤記録し `has_coverage=false` を大量に書く事故を防ぐ）
 - 除外の内訳（Google が無しと言ったのか、距離チェックで落としたのか）は完了ログに出す。距離チェックの発火が多い場合は 10m という基準自体を見直すシグナルになる。
-- レート制御・リトライ・ペーシングは `backend/src/importer/baidu.rs` の機構を踏襲。API キーは env `GOOGLE_MAPS_API_KEY` から読む。未設定なら明示エラーで停止（サイレントに全ノード「無し」判定しない）。
+- リトライ・バックオフは `backend/src/importer/baidu.rs` の機構を踏襲。**ペーシングは踏襲しない**（後述「並列度の根拠」）。API キーは env `GOOGLE_MAPS_API_KEY` から読む。未設定なら明示エラーで停止（サイレントに全ノード「無し」判定しない）。
 
 ### 2. 照会処理 — `backend/src/importer/mod.rs`（変更）
 
@@ -82,6 +82,22 @@ CREATE TABLE google_streetview_coverage (
 **非中国の判定は Rust 側で行う**（SQL では不可）。地域判定は `china::is_in_china_mainland(lng, lat)`（`backend/src/domain/china.rs:18`、手書き bbox 群の Rust 関数）だけが根拠で、`y_junctions` に地域列は無い。よって Baidu と同じ構造にする（`mod.rs:224-227`）：リポジトリは uncovered 候補を**全件**返し、この関数内で `!china::is_in_china_mainland(j.lon, j.lat)` でフィルタしてから照会する。
 
 照会 → `google_streetview_coverage` に upsert。照会失敗はそのノードを未照会のまま残す（`mod.rs:249` の Baidu と同じ abort-on-error）。ただし**中断する前に取得済みバッファを flush する**：さもないと最初の 100 件以内で再発する障害では毎回同じノードを引き直して flush 前に落ち、進捗が永久に残らない（Baidu 側は未対応）。API キーの検証は全件スキャンより前に行う。
+
+### 並列度の根拠
+
+照会は `futures::stream::buffer_unordered` で **`REQUEST_CONCURRENCY = 24` 本の並列**で走らせる。当初は Baidu を踏襲して逐次＋50ms ペーシングだったが、これは Baidu 固有の事情に由来するもので Google には当てはまらない。
+
+| | Baidu (`baidu.rs`) | Google (`google.rs`) |
+| --- | --- | --- |
+| エンドポイント | `mapsv0.bdimg.com/`（**非公式**・ブラウザ UA 偽装） | 公式 Street View Static metadata（API キー認証） |
+| 上限 | 不明。控えめに叩くしかない | **30,000 QPM = 500 QPS**（[usage and billing](https://developers.google.com/maps/documentation/streetview/usage-and-billing)） |
+| ペーシング | 80〜150ms ジッタ付き＝人間らしく見せる意図 | ジッタ不要。上限内で並列に叩くのが正常な使い方 |
+
+metadata は「no charge」かつ「No quota is consumed」だが、`OVER_QUERY_LIMIT` が status に定義されている以上、秒間制限は metadata にも適用されると読む（[metadata](https://developers.google.com/maps/documentation/streetview/metadata)）。
+
+**上限を構造的に超えない設計**：各ワーカーは自分のリクエスト前に `PACING`（50ms）だけ sleep する。1 ワーカーの上限は 1/50ms = 20 req/s なので、Google がどれだけ速く応答しても全体は `20 × 24 = 480 QPS` を超えられない。500 QPS の内側に構造的に収まり、`OVER_QUERY_LIMIT` バックオフはその保険として残る。
+
+逐次実装のままだと初回 backfill（非中国 約 89.6 万件）に 20〜40 時間かかり、公式上限の 25〜50 分の 1 しか使わない計算だった。
 
 ## 10m 判定の根拠と実測
 
@@ -186,7 +202,7 @@ API キーの制限は**サービス単位**（`api_targets.service`）で、Str
 
 ## エラーハンドリング・非機能
 
-- **クォータ／レート**：metadata は無料だが QPS 制限あり。`baidu.rs` のペーシング／リトライを踏襲。`OVER_QUERY_LIMIT` はバックオフ。
+- **クォータ／レート**：metadata は無料（quota 非消費）だが QPS 制限（30,000 QPM）あり。並列度とペーシングで 480 QPS の構造的上限を敷き、`OVER_QUERY_LIMIT` はバックオフ（「並列度の根拠」節）。
 - **API キー欠如**：env 未設定なら enrich を明示エラーで停止。
 - **API 障害時**：照会失敗は「無し」にせず未照会のまま（次回再試行で回復）。`has_coverage=false` を書くのは「照会に成功し無しと確定」した場合のみ。
 


### PR DESCRIPTION
## 背景

issue #306 の ops ステップ（ローカルで enrich 実行）を進めようとしたところ、`import_google_coverage_data` が完全に逐次実装（`for` ループ内で 1 件ずつ `fetch_coverage().await`）で、実効 10〜20 req/s しか出ないことが判明した。非中国ノード 990,315 件の初回 backfill に **20〜40 時間**かかる見込みだった。

この逐次実装は設計書で「レート制御・リトライ・ペーシングは `baidu.rs` の機構を踏襲」とされていたものだが、踏襲の根拠は Google には当てはまらない。

| | Baidu (`baidu.rs`) | Google (`google.rs`) |
| --- | --- | --- |
| エンドポイント | `mapsv0.bdimg.com/`（**非公式**・ブラウザ UA 偽装） | 公式 Street View Static metadata（API キー認証） |
| 上限 | 不明。控えめに叩くしかない | **30,000 QPM = 500 QPS**（公式ドキュメント） |
| ペーシング | 80〜150ms ジッタ付き＝人間らしく見せる意図 | ジッタ不要。上限内で並列に叩くのが正常な使い方 |

Baidu が逐次＋ジッタなのは非公式エンドポイントを静かに叩くためで、公式 API かつレート上限が文書化されている Google に継承する理由がない。

## 変更内容

- `google.rs`: `REQUEST_CONCURRENCY = 24` を追加。`pace_next_request` → `pace_request` に改名し、「リクエスト間」ではなく「各ワーカーが自分のリクエスト前」に sleep する意味に変更
- `mod.rs`: 逐次 `for` ループを `futures::stream::buffer_unordered(24)` に置換
- `doc/streetview-coverage-filter.md`: 「並列度の根拠」節を追加し、Baidu 踏襲としていた記述を訂正

エラー時の flush-then-abort、進捗ログ、covered / too_far カウンタの挙動は維持している。

## レート上限を構造的に超えない設計

各ワーカーは自分のリクエスト前に `PACING`（50ms）だけ sleep する。1 ワーカーの上限は 1/50ms = 20 req/s なので、Google がどれだけ速く応答しても全体は `20 × 24 = 480 QPS` を超えられない。文書化された上限 500 QPS の内側に構造的に収まり、`OVER_QUERY_LIMIT` バックオフはその保険として残る。

なお metadata リクエストは無料かつ quota 非消費だが、`OVER_QUERY_LIMIT` が status に定義されている以上、秒間制限は metadata にも適用されると読んでいる。

## 検証

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` / `cargo test`（172 件、DB 統合テスト 54 件を含む）すべて通過
- **実 API で全件 backfill を完走**（990,315 件）。約 155〜163 req/s で安定し、`OVER_QUERY_LIMIT` およびバックオフの発生は **0 件**。逐次時の想定 20〜40 時間に対し、実処理時間は約 2 時間（後述の中断分を除く）

結果:

| 国・地域 | 照会数 | あり率 |
| --- | ---: | ---: |
| 日本 | 879,591 | 72.10% |
| 台湾 | 74,277 | 88.23% |
| 香港 | 17,045 | 54.22% |
| シンガポール | 16,208 | 70.02% |
| マカオ | 3,194 | 42.33% |
| 合計 | 990,315 | 72.87% |

距離チェック（10m 超のパノラマ）による除外は全体の 1% 未満で、設計時の実測（30 件中 0 件）と整合。

## 補足: 実行中の中断について

backfill 中にローカル CockroachDB が数回ストールし（`remote wall time is too far ahead` / `pool timed out`）、バッチが中断した。原因は Docker Desktop VM 側で、ホストのスリープに起因するクロックジャンプが CockroachDB のログに記録されている（ディスク 3% 使用、メモリ 21% でリソース枯渇ではない）。DB への upsert は従来どおり単一タスクからの逐次実行であり、本 PR の並列化とは無関係。

照会結果は 100 件ごとに flush されるため中断分は失われず、未照会ノードのみを対象とする設計により毎回続きから再開できた。

Closes なし（#306 の ops ステップ用。除外ロジック有効化は PR-4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Google Street View coverage lookups now run with bounded concurrency, improving processing speed while respecting service limits.
  - Progress reporting reflects completed requests more accurately.

- **Reliability**
  - Successfully completed results are preserved when later requests encounter errors.
  - Requests are throttled to help avoid exceeding Google’s query limits.

- **Documentation**
  - Updated guidance explains request pacing, quota handling, temporary failures, and missing API key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->