### PR TITLE
feat: ストリートビュー非カバレッジノードを地図から除外 (#306)

### DIFF
--- a/backend/src/api/streetview_enricher.rs
+++ b/backend/src/api/streetview_enricher.rs
@@ -11,6 +11,14 @@ use sqlx::PgPool;
 /// junctions without a Baidu panorama, and elsewhere the ones Google's
 /// metadata reported as uncovered. Never-queried junctions stay on the map:
 /// absence of an answer is not an answer.
+///
+/// Note this runs *after* the `LIMIT` in `repository::find_by_bbox`, so a
+/// dense viewport returns fewer markers than the requested page size (~27% of
+/// the page is dropped at current coverage rates). Pushing the exclusion into
+/// the bbox query would fill the page, but measured 23ms → 95ms on that query
+/// because the anti-join has to run before the LIMIT. Accepted deliberately:
+/// the latency is paid on every map pan, the missing markers only matter when
+/// a viewport is already dense enough to hit the cap.
 pub async fn enrich_collection(
     pool: &PgPool,
     junctions: Vec<Junction>,

--- a/backend/src/api/streetview_enricher.rs
+++ b/backend/src/api/streetview_enricher.rs
@@ -1,13 +1,16 @@
-use crate::db::baidu_repository;
+use crate::db::{baidu_repository, google_repository};
 use crate::domain::china::{self, BaiduPanorama};
 use crate::domain::Junction;
 use sqlx::PgPool;
 
 /// Replace `streetview_url` on each feature with a region-appropriate URL.
 /// Junctions inside mainland China get a Baidu deep-link; everywhere else
-/// keeps the existing Google URL. Mainland-China junctions without a Baidu
-/// panorama are dropped from the response — map markers that open to a
-/// broken/empty link are worse than not showing the marker at all.
+/// keeps the existing Google URL. Junctions known to have no panorama are
+/// dropped from the response — map markers that open to a broken/empty link
+/// are worse than not showing the marker at all. That covers mainland-China
+/// junctions without a Baidu panorama, and elsewhere the ones Google's
+/// metadata reported as uncovered. Never-queried junctions stay on the map:
+/// absence of an answer is not an answer.
 pub async fn enrich_collection(
     pool: &PgPool,
     junctions: Vec<Junction>,
@@ -15,16 +18,31 @@ pub async fn enrich_collection(
     let osm_node_ids: Vec<i64> = junctions.iter().map(|j| j.osm_node_id).collect();
     let baidu_map = baidu_repository::find_by_osm_node_ids(pool, &osm_node_ids).await?;
 
+    // Only non-China junctions consult the Google cache: inside the mainland
+    // the Baidu panorama decides, and no coverage row is ever written there.
+    let google_ids: Vec<i64> = junctions
+        .iter()
+        .filter(|j| !china::is_in_china_mainland(j.lon, j.lat))
+        .map(|j| j.osm_node_id)
+        .collect();
+    let coverage_map = google_repository::find_coverage_by_osm_node_ids(pool, &google_ids).await?;
+
     let features: Vec<serde_json::Value> = junctions
         .iter()
         .filter_map(|j| {
             let baidu = baidu_map.get(&j.osm_node_id);
-            if china::is_in_china_mainland(j.lon, j.lat) && baidu.is_none() {
+            let coverage = coverage_map.get(&j.osm_node_id).copied();
+            let confirmed_no_panorama = if china::is_in_china_mainland(j.lon, j.lat) {
+                baidu.is_none()
+            } else {
+                coverage == Some(false)
+            };
+            if confirmed_no_panorama {
                 return None;
             }
             let mut feature = j.to_feature();
             feature["properties"]["streetview_url"] =
-                serde_json::Value::String(build_url(j, baidu));
+                serde_json::Value::String(build_url(j, baidu, coverage));
             Some(feature)
         })
         .collect();
@@ -38,24 +56,51 @@ pub async fn enrich_collection(
 
 /// Single-feature variant used by the `/junctions/:id` and
 /// `/junctions/node/:osm_node_id` endpoints.
+///
+/// Unlike the collection, an uncovered junction is still returned — these
+/// endpoints back direct links, so 404-ing a junction that genuinely exists
+/// would be wrong. It comes back with an empty `streetview_url` instead, which
+/// the popup already treats as "no button" (`JunctionPopup.tsx`).
 pub async fn enrich_feature(
     pool: &PgPool,
     junction: Junction,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let baidu_map = baidu_repository::find_by_osm_node_ids(pool, &[junction.osm_node_id]).await?;
+    let coverage = if china::is_in_china_mainland(junction.lon, junction.lat) {
+        None
+    } else {
+        google_repository::find_coverage_by_osm_node_ids(pool, &[junction.osm_node_id])
+            .await?
+            .get(&junction.osm_node_id)
+            .copied()
+    };
     let mut feature = junction.to_feature();
-    feature["properties"]["streetview_url"] =
-        serde_json::Value::String(build_url(&junction, baidu_map.get(&junction.osm_node_id)));
+    feature["properties"]["streetview_url"] = serde_json::Value::String(build_url(
+        &junction,
+        baidu_map.get(&junction.osm_node_id),
+        coverage,
+    ));
     Ok(feature)
 }
 
 /// The single branching point between Google / Baidu / empty. Every other
 /// file in this crate stays agnostic to the region policy.
-fn build_url(junction: &Junction, baidu: Option<&BaiduPanorama>) -> String {
+///
+/// `google_coverage` is the cached metadata answer for non-China junctions:
+/// `Some(false)` means Google confirmed there is no panorama, so emit an empty
+/// URL rather than a link that opens onto nothing. `None` (never queried) and
+/// `Some(true)` both keep the generated Google URL.
+fn build_url(
+    junction: &Junction,
+    baidu: Option<&BaiduPanorama>,
+    google_coverage: Option<bool>,
+) -> String {
     if china::is_in_china_mainland(junction.lon, junction.lat) {
         baidu
             .map(|b| china::baidu_panorama_url(b, junction))
             .unwrap_or_default()
+    } else if google_coverage == Some(false) {
+        String::new()
     } else {
         junction.streetview_url()
     }
@@ -93,15 +138,40 @@ mod tests {
     #[test]
     fn non_china_uses_google_url() {
         let j = mk_junction(1, 35.6812, 139.7671);
-        let url = build_url(&j, None);
+        let url = build_url(&j, None, None);
         assert!(url.contains("google.com/maps"));
     }
 
     #[test]
     fn china_without_panorama_is_empty() {
         let j = mk_junction(2, 31.2304, 121.4737);
-        let url = build_url(&j, None);
+        let url = build_url(&j, None, None);
         assert_eq!(url, "");
+    }
+
+    #[test]
+    fn non_china_uncovered_is_empty() {
+        let j = mk_junction(4, 35.6812, 139.7671);
+        assert_eq!(build_url(&j, None, Some(false)), "");
+    }
+
+    #[test]
+    fn non_china_covered_uses_google_url() {
+        let j = mk_junction(5, 35.6812, 139.7671);
+        assert!(build_url(&j, None, Some(true)).contains("google.com/maps"));
+    }
+
+    #[test]
+    fn china_ignores_google_coverage() {
+        // A coverage row must never reach a mainland junction, but if one did,
+        // the Baidu branch still owns the decision.
+        let j = mk_junction(6, 31.2304, 121.4737);
+        let pano = BaiduPanorama {
+            panoid: "PANO_TEST".to_string(),
+            pano_mc_x: 13_523_770.0,
+            pano_mc_y: 3_640_859.0,
+        };
+        assert!(build_url(&j, Some(&pano), Some(false)).contains("map.baidu.com"));
     }
 
     #[test]
@@ -112,7 +182,7 @@ mod tests {
             pano_mc_x: 13_523_770.0,
             pano_mc_y: 3_640_859.0,
         };
-        let url = build_url(&j, Some(&pano));
+        let url = build_url(&j, Some(&pano), None);
         assert!(url.contains("map.baidu.com"));
         assert!(url.contains("PANO_TEST"));
     }

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -1649,3 +1649,175 @@ async fn test_google_find_uncovered_nodes_returns_coordinates() {
     assert!((found.lat - SHANGHAI_LAT).abs() < 1e-9);
     assert!((found.lon - SHANGHAI_LON).abs() < 1e-9);
 }
+
+// ========== streetview_enricher: Google coverage exclusion ==========
+
+use y_junction_backend::api::streetview_enricher;
+use y_junction_backend::domain::Junction;
+
+const TOKYO_LAT: f64 = 35.6812;
+const TOKYO_LON: f64 = 139.7671;
+
+fn mk_enricher_junction(osm_node_id: i64, lat: f64, lon: f64) -> Junction {
+    Junction {
+        id: osm_node_id,
+        osm_node_id,
+        lat,
+        lon,
+        angle_1: 35,
+        angle_2: 145,
+        angle_3: 180,
+        bearings: vec![10.0, 45.0, 190.0],
+        created_at: chrono::Utc::now(),
+        elevation: None,
+        min_elevation_diff: None,
+        max_elevation_diff: None,
+        min_angle_elevation_diff: None,
+        way_1_highway_type: None,
+        way_2_highway_type: None,
+        way_3_highway_type: None,
+        way_1_category: None,
+        way_2_category: None,
+        way_3_category: None,
+    }
+}
+
+fn feature_ids(collection: &Value) -> Vec<i64> {
+    collection["features"]
+        .as_array()
+        .expect("features array")
+        .iter()
+        .map(|f| {
+            f["properties"]["osm_node_id"]
+                .as_i64()
+                .expect("osm_node_id")
+        })
+        .collect()
+}
+
+#[tokio::test]
+#[serial]
+async fn test_enrich_collection_drops_only_uncovered_non_china() {
+    let pool = setup_test_db().await;
+
+    let uncovered = TEST_OSM_NODE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let covered = TEST_OSM_NODE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let unqueried = TEST_OSM_NODE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+    google_repository::upsert_coverage(&pool, &[(uncovered, false), (covered, true)])
+        .await
+        .expect("upsert failed");
+
+    let junctions = vec![
+        mk_enricher_junction(uncovered, TOKYO_LAT, TOKYO_LON),
+        mk_enricher_junction(covered, TOKYO_LAT, TOKYO_LON),
+        mk_enricher_junction(unqueried, TOKYO_LAT, TOKYO_LON),
+    ];
+
+    let result = streetview_enricher::enrich_collection(&pool, junctions)
+        .await
+        .expect("enrich failed");
+
+    let ids = feature_ids(&result);
+    assert!(
+        !ids.contains(&uncovered),
+        "uncovered junction should be dropped, got {ids:?}"
+    );
+    // A junction we never asked Google about is not the same as one Google
+    // said no to; keeping it is the whole point of the 3-state cache.
+    assert!(
+        ids.contains(&covered) && ids.contains(&unqueried),
+        "{ids:?}"
+    );
+    assert_eq!(result["total_count"].as_i64(), Some(2));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_enrich_collection_keeps_china_junction_regardless_of_coverage() {
+    let pool = setup_test_db().await;
+
+    let osm_node_id = TEST_OSM_NODE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    // A stray coverage row for a mainland junction must not exclude it — the
+    // Baidu panorama owns that decision.
+    google_repository::upsert_coverage(&pool, &[(osm_node_id, false)])
+        .await
+        .expect("upsert failed");
+    baidu_repository::bulk_update_baidu(
+        &pool,
+        &[(
+            osm_node_id,
+            y_junction_backend::domain::china::BaiduPanorama {
+                panoid: "PANO_TEST".to_string(),
+                pano_mc_x: 13_523_770.0,
+                pano_mc_y: 3_640_859.0,
+            },
+        )],
+    )
+    .await
+    .expect("baidu upsert failed");
+
+    let junctions = vec![mk_enricher_junction(
+        osm_node_id,
+        SHANGHAI_LAT,
+        SHANGHAI_LON,
+    )];
+
+    let result = streetview_enricher::enrich_collection(&pool, junctions)
+        .await
+        .expect("enrich failed");
+
+    assert_eq!(feature_ids(&result), vec![osm_node_id]);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_enrich_feature_returns_uncovered_junction_with_empty_url() {
+    let pool = setup_test_db().await;
+
+    let osm_node_id = TEST_OSM_NODE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    google_repository::upsert_coverage(&pool, &[(osm_node_id, false)])
+        .await
+        .expect("upsert failed");
+
+    let feature = streetview_enricher::enrich_feature(
+        &pool,
+        mk_enricher_junction(osm_node_id, TOKYO_LAT, TOKYO_LON),
+    )
+    .await
+    .expect("enrich failed");
+
+    // Direct links must not 404 a junction that exists; the empty URL is what
+    // suppresses the popup button.
+    assert_eq!(
+        feature["properties"]["osm_node_id"].as_i64(),
+        Some(osm_node_id)
+    );
+    assert_eq!(feature["properties"]["streetview_url"].as_str(), Some(""));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_enrich_feature_covered_and_unqueried_keep_google_url() {
+    let pool = setup_test_db().await;
+
+    let covered = TEST_OSM_NODE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let unqueried = TEST_OSM_NODE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    google_repository::upsert_coverage(&pool, &[(covered, true)])
+        .await
+        .expect("upsert failed");
+
+    for osm_node_id in [covered, unqueried] {
+        let feature = streetview_enricher::enrich_feature(
+            &pool,
+            mk_enricher_junction(osm_node_id, TOKYO_LAT, TOKYO_LON),
+        )
+        .await
+        .expect("enrich failed");
+
+        let url = feature["properties"]["streetview_url"]
+            .as_str()
+            .expect("streetview_url");
+        assert!(url.contains("google.com/maps"), "{osm_node_id}: {url}");
+    }
+}


### PR DESCRIPTION
issue #306 の PR-4（最終ステップ）。設計書 `doc/streetview-coverage-filter.md` §5「除外ロジック」の実装。

本番 DB に `google_streetview_coverage` の全 990,315 行を投入済みなので、除外を有効化する。

## 変更内容（`backend/src/api/streetview_enricher.rs` のみ）

- **`enrich_collection`** — 非中国ノードについてカバレッジを引き、**「非中国かつ `has_coverage=false`」を応答から除外**。covered と未照会（行なし）はどちらも残す
- **`enrich_feature`** — 直リンク用エンドポイントなので feature 自体は返し、`false` のときだけ `streetview_url` を空にする
- **`build_url`** — 非中国のカバレッジ真偽を受け取る第3引数 `google_coverage: Option<bool>` を追加

フロントエンドは変更なし。空 URL は `JunctionPopup.tsx` の `{streetview_url && ...}` が既にボタンを抑止する。

## 設計上の判断

**未照会は除外しない。** 「まだ聞いていない」は「無いと確認した」と同じではないため、3 状態キャッシュ（行あり+true / 行あり+false / 行なし）の区別をそのまま除外条件に反映している。これにより、未照会の地域を新規追加してもマーカーが消えない。

**単一 feature は 404 にしない。** 実在する Y字路への直リンクを 404 にするのは誤りなので、feature は返して URL だけ空にする。中国の tombstone が同じ挙動（`build_url` が `""` を返す）なのと揃えた。

## 影響範囲

除外されるのは **268,683 件（全体の 27.13%）**。

| 国・地域 | 照会数 | あり率 | 除外数 |
| --- | ---: | ---: | ---: |
| 日本 | 879,591 | 72.10% | 245,435 |
| 台湾 | 74,277 | 88.23% | 8,744 |
| 香港 | 17,045 | 54.22% | 7,803 |
| シンガポール | 16,208 | 70.02% | 4,859 |
| マカオ | 3,194 | 42.33% | 1,842 |

除外の 91% は日本のノードで、**日本の地図からもマーカーが 4 分の 1 以上消える**。issue の発端は海外ノードだったが、実測すると日本のカバレッジ率も 72% であり、除外は全地域に効く。

## テスト

- 単体 3 件追加: `false` は空 URL / `true` は Google URL / 中国ノードはカバレッジ行があっても Baidu 判定が優先
- DB 統合 4 件追加: collection の除外（false のみ落ち covered・未照会は残る）、中国ノードの保持、feature の空 URL、covered・未照会の URL 維持
- `cargo test` 179 件すべて通過（単体 121 / DB 統合 58）、`clippy --all-targets --all-features -- -D warnings` および `fmt --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
