### PR TITLE
chore: Dockerfile の Rust を 1.94 に揃えて本番デプロイを復旧する

### DIFF
--- a/.claude/commands/dependabot-backend.md
+++ b/.claude/commands/dependabot-backend.md
@@ -16,6 +16,7 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob, WebFetch
 - バックグラウンド実行禁止（`&`, `nohup`）。
 - **pre-commit hook (`.husky/pre-commit`)** が存在し、commit時に lint-staged が走る。skill の「コミット前最終チェック」を通過していれば pre-commit も通る想定。
 - **前提**: ローカルで `cargo test` を通すには PostgreSQL (with PostGIS) が必要。CI 相当の DB セットアップは CLAUDE.md / README.md 参照。DB 未起動時は test のみスキップし、fmt / clippy だけで判断する（CI で最終判定される）。
+- **CI が全部緑でも、それだけではマージして良い根拠にならない**（MSRV が上がる更新は CI を素通りしてマージ後に落ちる）。Step 2-6 のマージ前チェックを必ず通す。
 
 ## Step 1: 対象PRを列挙
 
@@ -181,6 +182,19 @@ fi
 - `SKIP` → **Step 2-7** へ
 
 ### 2-6. マージ（3段フォールバック）
+
+**マージ前チェック: Rust バージョンの整合**。依存更新が要求 rustc を上げても CI は緑のまま通る。`backend-ci.yml` は `toolchain: '1.94.0'` を明示して新しい側でビルドし、かつ CI には `docker build` が無いため。古いままなのは Dockerfile の `FROM rust:X.Y` だけで、それはマージ後の `Deploy to Production` で初めて落ちる。Rust バージョンは複数ファイルに分散しているので、ずれていないか確認する:
+
+```bash
+grep -rn 'rust:1\|RUST_VERSION:\|^rust = ' .mise.toml .github/workflows/*.yml backend/Dockerfile pipeline/Dockerfile
+```
+
+ずれていたら Dockerfile 2 つを揃える（`FROM rust:X.Y` は `.github/dependabot.yml` に docker ecosystem が無いため自動更新されない）。直したら実ビルドまで確認してからマージする:
+
+```bash
+docker build -t verify-backend ./backend
+docker build -f pipeline/Dockerfile -t verify-pipeline .   # context はリポジトリルート
+```
 
 ```bash
 PR=<PR番号>

--- a/.claude/commands/dependabot-backend.md
+++ b/.claude/commands/dependabot-backend.md
@@ -189,12 +189,7 @@ fi
 grep -rn 'rust:1\|RUST_VERSION:\|^rust = ' .mise.toml .github/workflows/*.yml backend/Dockerfile pipeline/Dockerfile
 ```
 
-ずれていたら Dockerfile 2 つを揃える（`FROM rust:X.Y` は `.github/dependabot.yml` に docker ecosystem が無いため自動更新されない）。直したら実ビルドまで確認してからマージする:
-
-```bash
-docker build -t verify-backend ./backend
-docker build -f pipeline/Dockerfile -t verify-pipeline .   # context はリポジトリルート
-```
+ずれていたら `backend/Dockerfile` と `pipeline/Dockerfile` を揃えてからマージする。`FROM rust:X.Y` は `.github/dependabot.yml` に docker ecosystem が無いため自動更新されない。
 
 ```bash
 PR=<PR番号>

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,8 @@
 # Chef stage - prepare recipe
-FROM rust:1.90 AS chef
+# Keep in sync with .mise.toml and the CI workflows: sqlx 0.9.0 requires
+# rustc 1.94.0. Dependabot does not watch this pin (no docker ecosystem in
+# .github/dependabot.yml), so it has to move by hand.
+FROM rust:1.94 AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -3,7 +3,10 @@
 #
 # Build context is the repository root so that `backend/` is in scope.
 
-FROM rust:1.90-slim-bookworm AS builder
+# Keep in sync with .mise.toml and the CI workflows: sqlx 0.9.0 requires
+# rustc 1.94.0. Dependabot does not watch this pin (no docker ecosystem in
+# .github/dependabot.yml), so it has to move by hand.
+FROM rust:1.94-slim-bookworm AS builder
 
 WORKDIR /app
 RUN apt-get update \


### PR DESCRIPTION
## 問題

`Deploy to Production` の `Backend - Deploy` が失敗し続けている。

```
sqlx-postgres@0.9.0 requires rustc 1.94.0
where `<compatible-ver>` is the latest version supporting rustc 1.90.0
ERROR: process "/bin/sh -c cargo chef cook --release --recipe-path recipe.json" did not complete successfully: exit code: 101
```

`backend/Dockerfile` と `pipeline/Dockerfile` が `rust:1.90` を指しているのに対し、依存の sqlx 0.9.0 は rustc 1.94.0 を要求する。

**2026-06-07 以降、backend をビルドしたデプロイは一度も成功していない。** #312（ストリートビュー除外）を含め、マージ済みの backend 変更が本番に反映されていない状態。

## なぜ気付かれなかったか

CI では検知できない。

- `backend-ci.yml` は 3 ジョブすべてで `dtolnay/rust-toolchain` に `toolchain: '1.94.0'` を明示しており、新しい側でビルドするので通る
- `backend-ci.yml` に `docker build` が無く、イメージをビルドするのはマージ後の `deploy.yml` だけ

つまり MSRV が上がる PR は**全チェック緑でマージでき、失敗はマージ後にしか現れない**。

## なぜ 1.90 のままだったか

据え置きの理由は見当たらなかった。

- Dockerfile にもドキュメントにも固定理由の記述なし
- `.github/dependabot.yml` に **docker ecosystem が無い**ため `FROM rust:X.Y` は自動更新対象外
- `.mise.toml` は既に `rust = "1.94.0"`（`# sqlx 0.9.0 が rustc 1.94.0 以上を要求する。CI とも揃える` というコメント付き）。意図された版は 1.94.0 で、Dockerfile 2 箇所だけが取り残されていた

## 変更内容

1. `backend/Dockerfile` / `pipeline/Dockerfile` を `rust:1.94` に更新。同期先と「Dependabot が追跡しない」旨をコメントで明記
2. `.claude/commands/dependabot-backend.md` の Step 2-6 に**マージ前の Rust バージョン確認**を追加

skill 側の変更を CI 失敗時の修正戦略ではなく**マージ前**に置いたのは、この故障では CI が緑になるため、修正戦略（`has_fail` の分岐）には到達しないから。CI の成否に関わらず必ず通る位置に置く必要がある。

## 検証

両イメージをローカルで実ビルドし、成功を確認:

```
y-junctions-backend-verify:1.94   168MB
y-junctions-pipeline-verify:1.94  282MB
```

## 対象外

この調査で見えた以下は別途の判断とし、本 PR では触っていない。

- `.github/dependabot.yml` に docker ecosystem を追加して `FROM rust:X.Y` を自動追従させる
- `backend-ci.yml` にイメージビルドを追加してマージ前に検知できるようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated backend and pipeline build environments to Rust 1.94.
  - Added build documentation covering toolchain alignment and SQL tooling requirements.
  - Strengthened merge checks to include Rust version consistency and Docker build validation.

- **Documentation**
  - Documented the need for manual maintenance of pinned build versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->