### PR TITLE
fix: backend の builder を bookworm に固定して Cloud Run 起動失敗を直す

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,12 @@
 # Keep in sync with .mise.toml and the CI workflows: sqlx 0.9.0 requires
 # rustc 1.94.0. Dependabot does not watch this pin (no docker ecosystem in
 # .github/dependabot.yml), so it has to move by hand.
-FROM rust:1.94 AS chef
+#
+# The Debian suite must be pinned explicitly, not left to the default `rust:X.Y`
+# tag: that default has moved past bookworm, and a binary linked against its
+# newer glibc dies on the bookworm-slim runtime below with
+# `GLIBC_2.38 not found`. Builder and runtime have to name the same suite.
+FROM rust:1.94-bookworm AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 


### PR DESCRIPTION
## 問題

PR #313 で Docker イメージのビルドは復旧したが、**デプロイされたリビジョンがコンテナ起動に失敗する**。

```
/app/server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/server)
Container called exit(1).
Default STARTUP TCP probe failed ... for container "backend-1" on port 8080.
```

リビジョン `y-junctions-api-00089-5kd` はイメージの取り込みまでは成功する（`ContainerReady: True` / `Container image import completed in 2.39s`）が、プロセスが起動できず 8080 で listen しないため、トラフィックを向けようとすると失敗する。

## 原因

#313 で `rust:1.90` → `rust:1.94` に上げた際、**Debian suite を指定しないタグのまま**にした。

- `rust:1.90` の既定ベースは bookworm だった
- `rust:1.94` の既定ベースは bookworm より新しい Debian に移っている
- ランタイムは `debian:bookworm-slim`（glibc 2.36）のまま

結果、builder が生成したバイナリが GLIBC 2.38 を要求し、ランタイムで解決できない。**#313 が入れたリグレッション。**

`pipeline/Dockerfile` は元から `rust:1.94-slim-bookworm` と suite を明示しているため影響を受けていない（実際 `Pipeline - Build & Push Image` は成功していた）。

## 変更内容

`backend/Dockerfile` の builder を `rust:1.94-bookworm` に固定し、ランタイムと suite を揃える。既定タグに任せると同じ事故が再発するため、その理由をコメントに残した。

## #313 の検証で見逃した理由

ローカル検証で `docker build` の成功しか確認していなかった。**GLIBC の不一致はビルド時ではなく実行時にしか現れない**ため、ビルドが通ることは起動の保証にならない。加えて検証はホストの arm64 で行っており、本番の `linux/amd64` とも条件が違っていた。

今回は `--platform linux/amd64` でビルドし、**コンテナを起動して listen するところまで**確認する（結果は検証完了後にコメントで追記する）。

## 本番の現状

- 配信中は引き続きリビジョン `00087`（2026-05-23）。**ユーザー影響は発生していない**
- `spec.traffic` は `latestRevision: true` に変更済み（#315 の運用対応）。正常なリビジョンがデプロイされれば自動で切り替わる

## 関連

- #313（この PR が直すリグレッションの原因）
- #314（CI にイメージビルドが無い。本件を踏まえ「起動確認まで行う」ことも検討対象）
- #315（トラフィックが最新リビジョンへ向かない / Verify が検知できない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
