### PR TITLE
ci: backend/pipeline の Docker イメージビルドと起動確認を PR CI に追加 (#314)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# ルートをビルドコンテキストに取るのは pipeline/Dockerfile のみ
+# (backend/Dockerfile は backend/ がコンテキストで backend/.dockerignore を使う)。
+# pipeline/Dockerfile が COPY するのは backend/ だけなので、それ以外は
+# buildkit に送る必要がない。特に .git は persist-credentials で書き込まれた
+# トークンを含み得るため、コンテキストに入れない。
+
+# VCS
+.git/
+.gitignore
+
+# コンテキストに不要なディレクトリ
+.github/
+.claude/
+.husky/
+doc/
+docs/
+frontend/
+scripts/
+terraform/
+
+# ビルド成果物・依存
+**/node_modules/
+backend/target/
+backend/tests/
+
+# 認証情報・ローカル設定
+**/.env
+**/.env.local
+
+# OS
+.DS_Store
+*.swp
+*.swo
+*~

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,13 +35,17 @@ version-resolver:
   default: patch
 autolabeler:
   # データ追加・更新の自動ラベリング
+  #
+  # title 条件は置かない。autolabeler は branch / files / title を OR で
+  # 評価するため、「追加」「道」のような汎用語を入れると無関係な PR にも
+  # data が付く。data は version-resolver の minor に入っているので、
+  # 誤ラベルはリリースノート誤載と不要な minor bump に直結する。
+  # データ更新は data/* ブランチか doc/data-updates.md の変更で判定する。
   - label: 'data'
     branch:
       - '/^data\/.*/'
     files:
       - 'doc/data-updates.md'
-    title:
-      - '/地域|データ|インポート|追加|道|県|府/'
   
   # 新機能の自動ラベリング
   - label: 'feature'

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,6 +10,11 @@ on:
       - 'pipeline/**'
       - '.github/workflows/backend-ci.yml'
 
+# どのジョブも読み取りしか必要としない。リポジトリ設定の既定も現状 read だが、
+# 設定変更に引きずられないようワークフロー側で固定する。
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Backend - Checks
@@ -158,8 +163,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # persist-credentials の既定 true は checkout トークンを .git/config に
+      # 書き込む。docker ジョブは git 操作をしないうえ、.git がビルド
+      # コンテキストに入り得る（pipeline 側はルートコンテキスト）ので落とす。
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -210,6 +220,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - 'backend/**'
+      # pipeline/Dockerfile はビルドコンテキストにリポジトリルートを取り
+      # backend/ をそのまま焼き込むため、backend 変更でも pipeline 変更でも
+      # イメージビルドを検証する必要がある
+      - 'pipeline/**'
       - '.github/workflows/backend-ci.yml'
 
 jobs:
@@ -140,3 +144,89 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-features
+
+  # Docker イメージのビルド + 起動確認。
+  #
+  # ここが無かったために、MSRV 上げ (#313) と glibc 不一致 (#316) が
+  # 全チェック緑のままマージされ、失敗はマージ後の deploy.yml でしか
+  # 現れなかった。3 つの条件を deploy.yml と揃えておくことが要点:
+  #   - --platform linux/amd64 (本番と同じアーキテクチャ)
+  #   - 本番と同じ Dockerfile / ビルドコンテキスト
+  #   - ビルドだけでなく実際に起動させる (glibc 不一致は実行時にしか出ない)
+  docker-backend:
+    name: Backend - Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build backend image
+        working-directory: backend
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --load \
+            --cache-from type=gha,scope=backend \
+            --cache-to type=gha,scope=backend,mode=max \
+            -t y-junctions-backend:ci \
+            .
+
+      # 接続プールは lazy 生成なので、到達できない DATABASE_URL でも
+      # listen までは進む。DB を用意せずに起動確認できる。
+      - name: Smoke test backend image
+        run: |
+          docker run --rm -d --name backend-smoke \
+            -p 18080:8080 \
+            -e DATABASE_URL='postgresql://root@127.0.0.1:26257/y_junction?sslmode=disable' \
+            -e RUST_LOG=info \
+            y-junctions-backend:ci
+
+          ok=0
+          for _ in $(seq 1 20); do
+            if curl -fsS --max-time 5 http://localhost:18080/health; then
+              ok=1
+              break
+            fi
+            sleep 1
+          done
+
+          echo "--- container logs ---"
+          docker logs backend-smoke || true
+          docker rm -f backend-smoke > /dev/null
+
+          if [ "$ok" -ne 1 ]; then
+            echo "backend image failed to serve /health"
+            exit 1
+          fi
+
+  docker-pipeline:
+    name: Pipeline - Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # ビルドコンテキストはリポジトリルート (deploy.yml と同じ)
+      - name: Build pipeline image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --load \
+            --file pipeline/Dockerfile \
+            --cache-from type=gha,scope=pipeline \
+            --cache-to type=gha,scope=pipeline,mode=max \
+            -t y-junctions-pipeline:ci \
+            .
+
+      # Cloud Run Jobs 用イメージなので listen はしない。バイナリを 1 つ
+      # 実行して、動的リンクが解決すること (= glibc が合っていること) を見る。
+      - name: Smoke test pipeline image
+        run: docker run --rm y-junctions-pipeline:ci pipeline-download-osm --help


### PR DESCRIPTION
Closes #314

## 背景

`backend-ci.yml` に `docker build` が無く、イメージをビルドするのはマージ後の `deploy.yml` だけだった。そのため MSRV 上げ (#313) も builder/runtime の glibc 不一致 (#316) も**全チェック緑でマージでき、失敗はマージ後にしか現れなかった**。

## 変更

`backend-ci.yml` に 2 ジョブ追加:

- **Backend - Docker image**: `backend/Dockerfile` をビルド → コンテナを起動して `/health` に到達するまで確認
- **Pipeline - Docker image**: `pipeline/Dockerfile` をビルド → `pipeline-download-osm --help` を実行

deploy.yml と条件を揃えたポイント:

- `--platform linux/amd64` を明示（本番と同じアーキテクチャ）
- 同じ Dockerfile / ビルドコンテキスト（pipeline はリポジトリルート）
- push はせず `--load` してローカルで起動確認のみ

**ビルド成功だけでは不十分**なので起動まで見る。#316 の GLIBC_2.38 エラーはビルド時には現れず実行時にしか出ないため。接続プールは lazy 生成なので、到達できない `DATABASE_URL` でも listen まで進む（DB 不要）。

`on.pull_request.paths` に `pipeline/**` を追加。pipeline イメージは backend/ を焼き込むので、どちらの変更でも検証が要る。

キャッシュは GitHub Actions cache (`type=gha`) を scope 分けして使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic labeling accuracy for data-related changes by limiting labels to relevant branches and documentation updates.

* **Chores**
  * Expanded continuous integration checks to cover pipeline changes.
  * Added automated validation for backend and pipeline container builds, including startup and health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->